### PR TITLE
[Fixes #153] Update ATSAM{E,V,S}7x SVDs

### DIFF
--- a/data/Atmel/ATSAME70J19.svd
+++ b/data/Atmel/ATSAME70J19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4154,7 +4154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4258,7 +4258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4437,7 +4437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4458,7 +4458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4472,7 +4472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4574,7 +4574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4624,7 +4624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4638,7 +4638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4684,7 +4684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4831,7 +4831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4984,7 +4984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5137,7 +5137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5289,7 +5289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5339,7 +5339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5354,7 +5354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5368,7 +5368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5408,7 +5408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5422,7 +5422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5457,7 +5457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5471,7 +5471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5546,7 +5546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5566,7 +5566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5618,7 +5618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5658,7 +5658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5672,7 +5672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5686,7 +5686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5700,7 +5700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5714,7 +5714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6073,7 +6073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6103,7 +6103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6118,7 +6118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6133,7 +6133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6148,7 +6148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6163,7 +6163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6178,7 +6178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6193,7 +6193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6208,7 +6208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6223,7 +6223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6238,7 +6238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6253,7 +6253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6268,7 +6268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6328,7 +6328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6343,7 +6343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6358,7 +6358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6373,7 +6373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6388,7 +6388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6403,7 +6403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6418,7 +6418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6433,7 +6433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6448,7 +6448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6463,7 +6463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6477,7 +6477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6491,7 +6491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6519,7 +6519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6540,7 +6540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6566,7 +6566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6581,7 +6581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6596,7 +6596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6611,7 +6611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6626,7 +6626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6641,7 +6641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6656,7 +6656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6671,7 +6671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6688,7 +6688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6741,7 +6741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6757,7 +6757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6773,7 +6773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6787,7 +6787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6837,7 +6837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6877,7 +6877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6953,7 +6953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7006,7 +7006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7059,7 +7059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7125,7 +7125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7145,7 +7145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7188,7 +7188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7208,7 +7208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7251,7 +7251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7271,7 +7271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7314,7 +7314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7334,7 +7334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7377,7 +7377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7397,7 +7397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7460,7 +7460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7503,7 +7503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7523,7 +7523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7566,7 +7566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7586,7 +7586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7629,7 +7629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7649,7 +7649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7692,7 +7692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7712,7 +7712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7755,7 +7755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7775,7 +7775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7818,7 +7818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7838,7 +7838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7881,7 +7881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7901,7 +7901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7944,7 +7944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7964,7 +7964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8007,7 +8007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8027,7 +8027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8070,7 +8070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8090,7 +8090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8133,7 +8133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8153,7 +8153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8196,7 +8196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8216,7 +8216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8259,7 +8259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8279,7 +8279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8342,7 +8342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8385,7 +8385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8405,7 +8405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8448,7 +8448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8468,7 +8468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8511,7 +8511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8531,7 +8531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8574,7 +8574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8687,7 +8687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8761,7 +8761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8806,7 +8806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8833,7 +8833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8884,7 +8884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8935,7 +8935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8986,7 +8986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9037,7 +9037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9080,7 +9080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9094,7 +9094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9110,7 +9110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9144,7 +9144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9236,7 +9236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9364,7 +9364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9378,7 +9378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9410,7 +9410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9442,7 +9442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9474,7 +9474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9506,7 +9506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9538,7 +9538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9571,7 +9571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -9652,7 +9652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -9715,7 +9715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9778,7 +9778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9841,7 +9841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9862,7 +9862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -9883,7 +9883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9904,7 +9904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9918,7 +9918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9950,7 +9950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9964,7 +9964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9978,7 +9978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10010,7 +10010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10024,7 +10024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10052,7 +10052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10090,7 +10090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10149,7 +10149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10199,7 +10199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10249,7 +10249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10282,7 +10282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -10446,7 +10446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -10474,7 +10474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -10518,7 +10518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10532,7 +10532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10589,7 +10589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10657,7 +10657,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10677,7 +10677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10890,7 +10890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10922,7 +10922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10960,7 +10960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10974,7 +10974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11036,7 +11036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11050,7 +11050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11083,7 +11083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11212,7 +11212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11400,7 +11400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11588,7 +11588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11776,7 +11776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -11796,7 +11796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -11880,7 +11880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -11900,7 +11900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -11920,7 +11920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -11934,7 +11934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -11990,7 +11990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12190,7 +12190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -12390,7 +12390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -12422,7 +12422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -12461,7 +12461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -12475,7 +12475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -12489,7 +12489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -12521,7 +12521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -12589,7 +12589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -12603,7 +12603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -12758,7 +12758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -12790,7 +12790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -12823,7 +12823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -12880,7 +12880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13081,7 +13081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13281,7 +13281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -13481,7 +13481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -13682,7 +13682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -13883,7 +13883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14083,7 +14083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -14283,7 +14283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -14309,7 +14309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -14348,7 +14348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -14381,7 +14381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -14582,7 +14582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -14783,7 +14783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -14984,7 +14984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -15185,7 +15185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -15386,7 +15386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -15587,7 +15587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -15788,7 +15788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -15989,7 +15989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -16190,7 +16190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -16391,7 +16391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -16592,7 +16592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16792,7 +16792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -16993,7 +16993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -17194,7 +17194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -17395,7 +17395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -17596,7 +17596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -17797,7 +17797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -17998,7 +17998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -18199,7 +18199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -18400,7 +18400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18601,7 +18601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18802,7 +18802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19005,7 +19005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -19205,7 +19205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -19406,7 +19406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -19607,7 +19607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -19808,7 +19808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -19822,7 +19822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -20023,7 +20023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -20224,7 +20224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -20425,7 +20425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -20626,7 +20626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -20827,7 +20827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -21028,7 +21028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -21229,7 +21229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -21430,7 +21430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -21631,7 +21631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -21832,7 +21832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -22033,7 +22033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -22234,7 +22234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -22435,7 +22435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -22636,7 +22636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -22837,7 +22837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -23038,7 +23038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23066,7 +23066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23087,7 +23087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -23287,7 +23287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -23903,7 +23903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -23959,7 +23959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -23992,7 +23992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24025,7 +24025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24058,7 +24058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -24079,7 +24079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -24129,7 +24129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -24186,7 +24186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -24243,7 +24243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -24306,7 +24306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -24465,7 +24465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -24624,7 +24624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -24974,7 +24974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -25095,7 +25095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -25117,7 +25117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25165,7 +25165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -25264,7 +25264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -25363,7 +25363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -25480,7 +25480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -25579,7 +25579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -25737,7 +25737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -25841,7 +25841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -25856,7 +25856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25884,7 +25884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25905,7 +25905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -26064,7 +26064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -26223,7 +26223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -26382,7 +26382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -26454,7 +26454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -26498,7 +26498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -26657,7 +26657,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26816,7 +26816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -26975,7 +26975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -27134,7 +27134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -27148,7 +27148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -27307,7 +27307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -27466,7 +27466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -27625,7 +27625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -27784,7 +27784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -27818,7 +27818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27992,7 +27992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28025,7 +28025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28058,7 +28058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28091,7 +28091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28148,7 +28148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28205,7 +28205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28262,7 +28262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28319,7 +28319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28387,7 +28387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28402,7 +28402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28416,7 +28416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28436,7 +28436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28451,7 +28451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28568,7 +28568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28685,7 +28685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -28802,7 +28802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28919,7 +28919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28975,7 +28975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29031,7 +29031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29088,7 +29088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29145,7 +29145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -29202,7 +29202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -29259,7 +29259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -29285,7 +29285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -29306,7 +29306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -29321,7 +29321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -29377,7 +29377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -29411,7 +29411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -29467,7 +29467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -29487,7 +29487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -29502,7 +29502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -29534,7 +29534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29590,7 +29590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29673,7 +29673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29772,7 +29772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29792,7 +29792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29813,7 +29813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29857,7 +29857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29897,7 +29897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30039,7 +30039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30053,7 +30053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30068,7 +30068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30082,7 +30082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30097,7 +30097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30112,7 +30112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30132,7 +30132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30154,7 +30154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -30175,7 +30175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -30196,7 +30196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -30276,7 +30276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -30314,7 +30314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -30335,7 +30335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -30415,7 +30415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -30453,7 +30453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -30501,7 +30501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30534,7 +30534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30654,7 +30654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30669,7 +30669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30684,7 +30684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30741,7 +30741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30792,7 +30792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30843,7 +30843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30894,7 +30894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30926,7 +30926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30940,7 +30940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30960,7 +30960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31138,7 +31138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31171,7 +31171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31186,7 +31186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31214,7 +31214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31254,7 +31254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31289,7 +31289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31350,7 +31350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31409,7 +31409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31438,7 +31438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31488,7 +31488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31522,7 +31522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31595,7 +31595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31809,7 +31809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31841,7 +31841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31879,7 +31879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31929,7 +31929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31961,7 +31961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32084,7 +32084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32129,7 +32129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32174,7 +32174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32219,7 +32219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -32264,7 +32264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -32316,7 +32316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32360,7 +32360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32374,7 +32374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32389,7 +32389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32429,7 +32429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -32468,7 +32468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -32482,7 +32482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32640,7 +32640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32742,7 +32742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32889,7 +32889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32997,7 +32997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33012,7 +33012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33027,7 +33027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33042,7 +33042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33056,7 +33056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33070,7 +33070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -33084,7 +33084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33153,7 +33153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33210,7 +33210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -33267,7 +33267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -33324,7 +33324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33352,7 +33352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33392,7 +33392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33453,7 +33453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33539,7 +33539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33643,7 +33643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33853,7 +33853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34393,7 +34393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34872,7 +34872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34899,7 +34899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -35142,7 +35142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35162,7 +35162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35177,7 +35177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -35192,7 +35192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -35206,7 +35206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -35220,7 +35220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -35234,7 +35234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -35309,7 +35309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -35366,7 +35366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -35423,7 +35423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -35480,7 +35480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -35533,7 +35533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -35548,7 +35548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -35694,7 +35694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -35721,7 +35721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -35748,7 +35748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -35775,7 +35775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -35808,7 +35808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -35828,7 +35828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35923,7 +35923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35952,7 +35952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35967,7 +35967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35982,7 +35982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35997,7 +35997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -36012,7 +36012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -36046,7 +36046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36187,7 +36187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36236,7 +36236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36304,7 +36304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36318,7 +36318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36350,7 +36350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -36473,7 +36473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -36578,7 +36578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36683,7 +36683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36788,7 +36788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36803,7 +36803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36818,7 +36818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36850,7 +36850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36882,7 +36882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36914,7 +36914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36942,7 +36942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36990,7 +36990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -37047,7 +37047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -37156,7 +37156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -37207,7 +37207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -37258,7 +37258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37309,7 +37309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37360,7 +37360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37375,7 +37375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37390,7 +37390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37404,7 +37404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -37449,7 +37449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -39008,7 +39008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39089,7 +39089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39254,7 +39254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39305,7 +39305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39398,7 +39398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39563,7 +39563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39728,7 +39728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39893,7 +39893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40021,7 +40021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40050,7 +40050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -40222,7 +40222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -40387,7 +40387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -40446,7 +40446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -40511,7 +40511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -40612,7 +40612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -40713,7 +40713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -40806,7 +40806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -40820,7 +40820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -40834,7 +40834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40896,7 +40896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40941,7 +40941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -40986,7 +40986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -41151,7 +41151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -41202,7 +41202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -41295,7 +41295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -41460,7 +41460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -41625,7 +41625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -41790,7 +41790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -41906,7 +41906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -41932,7 +41932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -41964,7 +41964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -41996,7 +41996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -42018,7 +42018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -42178,7 +42178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -42327,7 +42327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -42380,7 +42380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -42445,7 +42445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -42534,7 +42534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -42617,7 +42617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -42700,7 +42700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -42722,7 +42722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -42772,7 +42772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42786,7 +42786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42800,7 +42800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42862,7 +42862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42907,7 +42907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -42958,7 +42958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -43003,7 +43003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -43018,7 +43018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -43054,7 +43054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43085,7 +43085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43131,7 +43131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43160,7 +43160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43210,7 +43210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43250,7 +43250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43277,7 +43277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43315,7 +43315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43347,7 +43347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -43500,7 +43500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43653,7 +43653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -43806,7 +43806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -43959,7 +43959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -44112,7 +44112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -44265,7 +44265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -44418,7 +44418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -44570,7 +44570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -44722,7 +44722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -44875,7 +44875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -45028,7 +45028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -45181,7 +45181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -45334,7 +45334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -45493,7 +45493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45544,7 +45544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45595,7 +45595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45646,7 +45646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45697,7 +45697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -45711,7 +45711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -45725,7 +45725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -45745,7 +45745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -45839,7 +45839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -45853,7 +45853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -45867,7 +45867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -46197,7 +46197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -46217,7 +46217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -46231,7 +46231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -46259,7 +46259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAME70J19B.svd
+++ b/data/Atmel/ATSAME70J19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7457,7 +7457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7502,7 +7502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7529,7 +7529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7580,7 +7580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7631,7 +7631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7682,7 +7682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7733,7 +7733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7776,7 +7776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7806,7 +7806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7840,7 +7840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8046,7 +8046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8066,7 +8066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8080,7 +8080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8112,7 +8112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8144,7 +8144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8176,7 +8176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8208,7 +8208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8240,7 +8240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8273,7 +8273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8354,7 +8354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8417,7 +8417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -8543,7 +8543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -8564,7 +8564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -8585,7 +8585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8606,7 +8606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8620,7 +8620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8666,7 +8666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8680,7 +8680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8712,7 +8712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8754,7 +8754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8792,7 +8792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -8851,7 +8851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8901,7 +8901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -8951,7 +8951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -8990,7 +8990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -9212,7 +9212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -9240,7 +9240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -9284,7 +9284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9329,7 +9329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9358,7 +9358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9409,7 +9409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9471,7 +9471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9491,7 +9491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9700,7 +9700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9732,7 +9732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9770,7 +9770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9784,7 +9784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -9846,7 +9846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -9860,7 +9860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9893,7 +9893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10034,7 +10034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10054,7 +10054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10230,7 +10230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10406,7 +10406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10582,7 +10582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -10602,7 +10602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -10686,7 +10686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -10706,7 +10706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -10726,7 +10726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -10740,7 +10740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -10796,7 +10796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -10996,7 +10996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -11196,7 +11196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -11228,7 +11228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -11267,7 +11267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -11281,7 +11281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -11295,7 +11295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -11327,7 +11327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -11395,7 +11395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -11409,7 +11409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11596,7 +11596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -11629,7 +11629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -11686,7 +11686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -11887,7 +11887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12087,7 +12087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -12287,7 +12287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -12488,7 +12488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -12689,7 +12689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -12889,7 +12889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -13089,7 +13089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -13115,7 +13115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -13154,7 +13154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -13187,7 +13187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -13388,7 +13388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -13589,7 +13589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -13790,7 +13790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -13991,7 +13991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -14192,7 +14192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -14393,7 +14393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -14594,7 +14594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -14795,7 +14795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -14996,7 +14996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -15197,7 +15197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -15398,7 +15398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -15598,7 +15598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -15799,7 +15799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -16000,7 +16000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -16201,7 +16201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -16402,7 +16402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -16603,7 +16603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -16804,7 +16804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -17005,7 +17005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -17206,7 +17206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -17407,7 +17407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -17608,7 +17608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17811,7 +17811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -18011,7 +18011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -18212,7 +18212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -18413,7 +18413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -18614,7 +18614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -18628,7 +18628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -18829,7 +18829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -19030,7 +19030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -19231,7 +19231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -19432,7 +19432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -19633,7 +19633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -19834,7 +19834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -20035,7 +20035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -20236,7 +20236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -20437,7 +20437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -20638,7 +20638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -20839,7 +20839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -21040,7 +21040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -21241,7 +21241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -21442,7 +21442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -21643,7 +21643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -21844,7 +21844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -21872,7 +21872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -21893,7 +21893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22093,7 +22093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -22709,7 +22709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -22765,7 +22765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -22798,7 +22798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -22831,7 +22831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -22864,7 +22864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -22885,7 +22885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -22935,7 +22935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -22998,7 +22998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -23061,7 +23061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -23130,7 +23130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -23253,7 +23253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -23376,7 +23376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -23690,7 +23690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -23811,7 +23811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -23833,7 +23833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -23881,7 +23881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -23986,7 +23986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -24091,7 +24091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -24214,7 +24214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -24319,7 +24319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -24477,7 +24477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -24581,7 +24581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -24596,7 +24596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24624,7 +24624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24645,7 +24645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24780,7 +24780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -24915,7 +24915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -25050,7 +25050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -25122,7 +25122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -25166,7 +25166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -25289,7 +25289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25412,7 +25412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -25535,7 +25535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -25672,7 +25672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -25807,7 +25807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -25942,7 +25942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -26077,7 +26077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -26212,7 +26212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -26246,7 +26246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26420,7 +26420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26453,7 +26453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26486,7 +26486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26519,7 +26519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26576,7 +26576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26633,7 +26633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26690,7 +26690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26747,7 +26747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26815,7 +26815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26830,7 +26830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26844,7 +26844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26864,7 +26864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26879,7 +26879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26996,7 +26996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27113,7 +27113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27230,7 +27230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27347,7 +27347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27403,7 +27403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27459,7 +27459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27516,7 +27516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27573,7 +27573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -27630,7 +27630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -27687,7 +27687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -27713,7 +27713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -27734,7 +27734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -27749,7 +27749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -27805,7 +27805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -27839,7 +27839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27895,7 +27895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27915,7 +27915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27930,7 +27930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27962,7 +27962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -28018,7 +28018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28101,7 +28101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28200,7 +28200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28233,7 +28233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28254,7 +28254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28298,7 +28298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28338,7 +28338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28532,7 +28532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28546,7 +28546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28561,7 +28561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28575,7 +28575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28590,7 +28590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28605,7 +28605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28625,7 +28625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28647,7 +28647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -28668,7 +28668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -28689,7 +28689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -28769,7 +28769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -28807,7 +28807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -28828,7 +28828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -28908,7 +28908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28946,7 +28946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28994,7 +28994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29027,7 +29027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29147,7 +29147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29162,7 +29162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29177,7 +29177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29234,7 +29234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29285,7 +29285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29336,7 +29336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29387,7 +29387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29419,7 +29419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29433,7 +29433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29453,7 +29453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29631,7 +29631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29664,7 +29664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29679,7 +29679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29707,7 +29707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29747,7 +29747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29782,7 +29782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29843,7 +29843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29902,7 +29902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29931,7 +29931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29981,7 +29981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30015,7 +30015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30088,7 +30088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30302,7 +30302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30334,7 +30334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30372,7 +30372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30422,7 +30422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30454,7 +30454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30577,7 +30577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30622,7 +30622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30667,7 +30667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30712,7 +30712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30757,7 +30757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30809,7 +30809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30853,7 +30853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30867,7 +30867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30882,7 +30882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30922,7 +30922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -30961,7 +30961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -30975,7 +30975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31133,7 +31133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31235,7 +31235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31382,7 +31382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31490,7 +31490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31505,7 +31505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31520,7 +31520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31535,7 +31535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31549,7 +31549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31563,7 +31563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31577,7 +31577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31646,7 +31646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31703,7 +31703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31760,7 +31760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31817,7 +31817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31845,7 +31845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31876,7 +31876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -31885,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31946,7 +31946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32032,7 +32032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32136,7 +32136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32346,7 +32346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32886,7 +32886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33331,6 +33331,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -33365,7 +33393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33392,7 +33420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -33635,9 +33663,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -34071,7 +34099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34091,7 +34119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34106,7 +34134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34121,7 +34149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34135,7 +34163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34149,7 +34177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34163,7 +34191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34238,7 +34266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34295,7 +34323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34352,7 +34380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -34409,7 +34437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -34462,7 +34490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -34477,7 +34505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -34635,7 +34663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -34668,7 +34696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -34701,7 +34729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -34734,7 +34762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -34773,7 +34801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -34793,7 +34821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34888,7 +34916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34917,7 +34945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34932,7 +34960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34947,7 +34975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34962,7 +34990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34977,7 +35005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35011,7 +35039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35152,7 +35180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35201,7 +35229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35269,7 +35297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35283,7 +35311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35315,7 +35343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35438,7 +35466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35543,7 +35571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35648,7 +35676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35753,7 +35781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35768,7 +35796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35783,7 +35811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35815,7 +35843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35847,7 +35875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35879,7 +35907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35907,7 +35935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35955,7 +35983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36012,7 +36040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36121,7 +36149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36172,7 +36200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36223,7 +36251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36274,7 +36302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36325,7 +36353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36340,7 +36368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36355,7 +36383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36369,7 +36397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -36414,7 +36442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -37224,6 +37252,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -37274,7 +37320,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -37315,80 +37407,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37486,12 +37504,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -37501,6 +37513,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37536,46 +37560,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -37604,6 +37588,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37657,7 +37659,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -37704,134 +37752,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37923,30 +37843,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -37956,6 +37852,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37991,64 +37899,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -38077,6 +37927,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38130,7 +37998,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -38177,134 +38091,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38396,30 +38182,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -38429,6 +38191,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38464,64 +38238,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -38550,6 +38266,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38627,7 +38361,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -38674,140 +38460,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38905,30 +38557,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -38938,6 +38566,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38968,64 +38608,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -39708,7 +39290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39799,7 +39381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39952,7 +39534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40003,7 +39585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40096,7 +39678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40249,7 +39831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40402,7 +39984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40555,7 +40137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40683,7 +40265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40712,7 +40294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -40884,7 +40466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -41049,9 +40631,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41215,9 +40797,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41381,9 +40963,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41547,7 +41129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -41606,9 +41188,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41666,9 +41248,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41726,9 +41308,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41786,7 +41368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -41851,9 +41433,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41917,9 +41499,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41983,9 +41565,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42049,7 +41631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42150,9 +41732,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42258,9 +41840,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42360,9 +41942,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42462,7 +42044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -42563,9 +42145,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42671,9 +42253,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42773,9 +42355,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42875,7 +42457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -42964,9 +42546,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43054,9 +42636,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43144,9 +42726,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43238,7 +42820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43252,7 +42834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43266,7 +42848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43328,7 +42910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43373,7 +42955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43428,7 +43010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43537,43 +43119,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43581,7 +43163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43632,7 +43214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43681,43 +43263,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43725,7 +43307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -43834,43 +43416,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43878,7 +43460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -43987,43 +43569,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44031,7 +43613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44140,43 +43722,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44184,7 +43766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44300,7 +43882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44326,7 +43908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44358,7 +43940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44390,7 +43972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44412,7 +43994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44572,9 +44154,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -44739,7 +44321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -44888,9 +44470,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45038,9 +44620,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45188,9 +44770,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45338,7 +44920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45391,9 +44973,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45445,9 +45027,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45499,9 +45081,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45553,7 +45135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45618,9 +45200,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45684,9 +45266,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45750,9 +45332,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45816,7 +45398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45905,9 +45487,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45995,9 +45577,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46085,9 +45667,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46175,7 +45757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46258,9 +45840,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46342,9 +45924,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46426,9 +46008,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46510,7 +46092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -46593,9 +46175,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46677,9 +46259,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46761,9 +46343,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46845,7 +46427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -46867,7 +46449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -46917,7 +46499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46931,7 +46513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46945,7 +46527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47007,7 +46589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47052,7 +46634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47109,7 +46691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47154,7 +46736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47169,7 +46751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47205,7 +46787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47236,7 +46818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47282,7 +46864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47311,7 +46893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47361,7 +46943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47401,7 +46983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47428,7 +47010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47466,7 +47048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47498,7 +47080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -47651,7 +47233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47804,7 +47386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -47957,7 +47539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48110,7 +47692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48263,7 +47845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -48416,7 +47998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -48569,7 +48151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -48721,7 +48303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -48873,7 +48455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49026,7 +48608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49179,7 +48761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49332,7 +48914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -49485,7 +49067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -49644,7 +49226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49695,7 +49277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -49746,7 +49328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -49797,7 +49379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -49848,7 +49430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -49862,7 +49444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -49876,7 +49458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -49896,7 +49478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -49990,7 +49572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50004,7 +49586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50018,7 +49600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -50501,7 +50083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -50521,7 +50103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -50535,7 +50117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -50563,7 +50145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -52452,6 +52034,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAME70J20.svd
+++ b/data/Atmel/ATSAME70J20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4154,7 +4154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4258,7 +4258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4437,7 +4437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4458,7 +4458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4472,7 +4472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4574,7 +4574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4624,7 +4624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4638,7 +4638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4684,7 +4684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4831,7 +4831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4984,7 +4984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5137,7 +5137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5289,7 +5289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5339,7 +5339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5354,7 +5354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5368,7 +5368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5408,7 +5408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5422,7 +5422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5457,7 +5457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5471,7 +5471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5546,7 +5546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5566,7 +5566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5618,7 +5618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5658,7 +5658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5672,7 +5672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5686,7 +5686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5700,7 +5700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5714,7 +5714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6073,7 +6073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6103,7 +6103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6118,7 +6118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6133,7 +6133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6148,7 +6148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6163,7 +6163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6178,7 +6178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6193,7 +6193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6208,7 +6208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6223,7 +6223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6238,7 +6238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6253,7 +6253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6268,7 +6268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6328,7 +6328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6343,7 +6343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6358,7 +6358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6373,7 +6373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6388,7 +6388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6403,7 +6403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6418,7 +6418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6433,7 +6433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6448,7 +6448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6463,7 +6463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6477,7 +6477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6491,7 +6491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6519,7 +6519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6540,7 +6540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6566,7 +6566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6581,7 +6581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6596,7 +6596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6611,7 +6611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6626,7 +6626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6641,7 +6641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6656,7 +6656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6671,7 +6671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6688,7 +6688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6741,7 +6741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6757,7 +6757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6773,7 +6773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6787,7 +6787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6837,7 +6837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6877,7 +6877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6953,7 +6953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7006,7 +7006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7059,7 +7059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7125,7 +7125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7145,7 +7145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7188,7 +7188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7208,7 +7208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7251,7 +7251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7271,7 +7271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7314,7 +7314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7334,7 +7334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7377,7 +7377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7397,7 +7397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7460,7 +7460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7503,7 +7503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7523,7 +7523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7566,7 +7566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7586,7 +7586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7629,7 +7629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7649,7 +7649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7692,7 +7692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7712,7 +7712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7755,7 +7755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7775,7 +7775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7818,7 +7818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7838,7 +7838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7881,7 +7881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7901,7 +7901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7944,7 +7944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7964,7 +7964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8007,7 +8007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8027,7 +8027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8070,7 +8070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8090,7 +8090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8133,7 +8133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8153,7 +8153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8196,7 +8196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8216,7 +8216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8259,7 +8259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8279,7 +8279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8342,7 +8342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8385,7 +8385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8405,7 +8405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8448,7 +8448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8468,7 +8468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8511,7 +8511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8531,7 +8531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8574,7 +8574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8687,7 +8687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8761,7 +8761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8806,7 +8806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8833,7 +8833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8884,7 +8884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8935,7 +8935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8986,7 +8986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9037,7 +9037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9080,7 +9080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9094,7 +9094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9110,7 +9110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9144,7 +9144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9242,7 +9242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9350,7 +9350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9370,7 +9370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9384,7 +9384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9416,7 +9416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9448,7 +9448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9480,7 +9480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9512,7 +9512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9544,7 +9544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9577,7 +9577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -9658,7 +9658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -9721,7 +9721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9784,7 +9784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9847,7 +9847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9868,7 +9868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -9889,7 +9889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9910,7 +9910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9924,7 +9924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9956,7 +9956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9970,7 +9970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9984,7 +9984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10016,7 +10016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10030,7 +10030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10058,7 +10058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10096,7 +10096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10155,7 +10155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10205,7 +10205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10255,7 +10255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10288,7 +10288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -10452,7 +10452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -10480,7 +10480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -10524,7 +10524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10538,7 +10538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10595,7 +10595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10663,7 +10663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10683,7 +10683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10896,7 +10896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10928,7 +10928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10966,7 +10966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10980,7 +10980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11042,7 +11042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11056,7 +11056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11089,7 +11089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11218,7 +11218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11406,7 +11406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11594,7 +11594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11782,7 +11782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -11802,7 +11802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -11886,7 +11886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -11906,7 +11906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -11926,7 +11926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -11940,7 +11940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -11996,7 +11996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12196,7 +12196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -12396,7 +12396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -12428,7 +12428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -12467,7 +12467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -12481,7 +12481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -12495,7 +12495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -12527,7 +12527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -12595,7 +12595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -12609,7 +12609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -12764,7 +12764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -12796,7 +12796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -12829,7 +12829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -12886,7 +12886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13087,7 +13087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13287,7 +13287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -13487,7 +13487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -13688,7 +13688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -13889,7 +13889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14089,7 +14089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -14289,7 +14289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -14315,7 +14315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -14354,7 +14354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -14387,7 +14387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -14588,7 +14588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -14789,7 +14789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -14990,7 +14990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -15191,7 +15191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -15392,7 +15392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -15593,7 +15593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -15794,7 +15794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -15995,7 +15995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -16196,7 +16196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -16397,7 +16397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -16598,7 +16598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16798,7 +16798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -16999,7 +16999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -17200,7 +17200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -17401,7 +17401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -17602,7 +17602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -17803,7 +17803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -18004,7 +18004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -18205,7 +18205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -18406,7 +18406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18607,7 +18607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18808,7 +18808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19011,7 +19011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -19211,7 +19211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -19412,7 +19412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -19613,7 +19613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -19814,7 +19814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -19828,7 +19828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -20029,7 +20029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -20230,7 +20230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -20431,7 +20431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -20632,7 +20632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -20833,7 +20833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -21034,7 +21034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -21235,7 +21235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -21436,7 +21436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -21637,7 +21637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -21838,7 +21838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -22039,7 +22039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -22240,7 +22240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -22441,7 +22441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -22642,7 +22642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -22843,7 +22843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -23044,7 +23044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23072,7 +23072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23093,7 +23093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -23293,7 +23293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -23909,7 +23909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -23965,7 +23965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -23998,7 +23998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24031,7 +24031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24064,7 +24064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -24085,7 +24085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -24135,7 +24135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -24192,7 +24192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -24249,7 +24249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -24312,7 +24312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -24471,7 +24471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -24630,7 +24630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -24980,7 +24980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -25101,7 +25101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -25123,7 +25123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25171,7 +25171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -25270,7 +25270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -25369,7 +25369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -25486,7 +25486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -25585,7 +25585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -25743,7 +25743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -25847,7 +25847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -25862,7 +25862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25890,7 +25890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25911,7 +25911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -26070,7 +26070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -26229,7 +26229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -26388,7 +26388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -26460,7 +26460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -26504,7 +26504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -26663,7 +26663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26822,7 +26822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -26981,7 +26981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -27140,7 +27140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -27154,7 +27154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -27313,7 +27313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -27472,7 +27472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -27631,7 +27631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -27790,7 +27790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -27824,7 +27824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27998,7 +27998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28031,7 +28031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28064,7 +28064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28097,7 +28097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28154,7 +28154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28211,7 +28211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28268,7 +28268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28325,7 +28325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28393,7 +28393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28408,7 +28408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28422,7 +28422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28442,7 +28442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28457,7 +28457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28574,7 +28574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28691,7 +28691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -28808,7 +28808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28925,7 +28925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28981,7 +28981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29037,7 +29037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29094,7 +29094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29151,7 +29151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -29208,7 +29208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -29265,7 +29265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -29291,7 +29291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -29312,7 +29312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -29327,7 +29327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -29383,7 +29383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -29417,7 +29417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -29473,7 +29473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -29493,7 +29493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -29508,7 +29508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -29540,7 +29540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29596,7 +29596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29679,7 +29679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29778,7 +29778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29798,7 +29798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29819,7 +29819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29863,7 +29863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29903,7 +29903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30045,7 +30045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30059,7 +30059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30074,7 +30074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30088,7 +30088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30103,7 +30103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30118,7 +30118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30138,7 +30138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30160,7 +30160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -30181,7 +30181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -30202,7 +30202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -30282,7 +30282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -30320,7 +30320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -30341,7 +30341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -30421,7 +30421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -30459,7 +30459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -30507,7 +30507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30540,7 +30540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30660,7 +30660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30675,7 +30675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30690,7 +30690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30747,7 +30747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30798,7 +30798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30849,7 +30849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30900,7 +30900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30932,7 +30932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30946,7 +30946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30966,7 +30966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31144,7 +31144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31177,7 +31177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31192,7 +31192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31220,7 +31220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31260,7 +31260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31295,7 +31295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31356,7 +31356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31415,7 +31415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31444,7 +31444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31494,7 +31494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31528,7 +31528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31601,7 +31601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31815,7 +31815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31847,7 +31847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31885,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31935,7 +31935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31967,7 +31967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32090,7 +32090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32135,7 +32135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32180,7 +32180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32225,7 +32225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -32270,7 +32270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -32322,7 +32322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32366,7 +32366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32380,7 +32380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32395,7 +32395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32435,7 +32435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -32474,7 +32474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -32488,7 +32488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32646,7 +32646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32748,7 +32748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32895,7 +32895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33003,7 +33003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33018,7 +33018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33033,7 +33033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33048,7 +33048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33062,7 +33062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33076,7 +33076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -33090,7 +33090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33159,7 +33159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33216,7 +33216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -33273,7 +33273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -33330,7 +33330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33358,7 +33358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33398,7 +33398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33459,7 +33459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33545,7 +33545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33649,7 +33649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33859,7 +33859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34399,7 +34399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34878,7 +34878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34905,7 +34905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -35148,7 +35148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35168,7 +35168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35183,7 +35183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -35198,7 +35198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -35212,7 +35212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -35226,7 +35226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -35240,7 +35240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -35315,7 +35315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -35372,7 +35372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -35429,7 +35429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -35486,7 +35486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -35539,7 +35539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -35554,7 +35554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -35700,7 +35700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -35727,7 +35727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -35754,7 +35754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -35781,7 +35781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -35814,7 +35814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -35834,7 +35834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35929,7 +35929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35958,7 +35958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35973,7 +35973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35988,7 +35988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36003,7 +36003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -36018,7 +36018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -36052,7 +36052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36193,7 +36193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36242,7 +36242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36310,7 +36310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36324,7 +36324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36356,7 +36356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -36479,7 +36479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -36584,7 +36584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36689,7 +36689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36794,7 +36794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36809,7 +36809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36824,7 +36824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36856,7 +36856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36888,7 +36888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36920,7 +36920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36948,7 +36948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36996,7 +36996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -37053,7 +37053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -37162,7 +37162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -37213,7 +37213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -37264,7 +37264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37315,7 +37315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37366,7 +37366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37381,7 +37381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37396,7 +37396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37410,7 +37410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -37455,7 +37455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -39014,7 +39014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39095,7 +39095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39260,7 +39260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39311,7 +39311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39404,7 +39404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39569,7 +39569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39734,7 +39734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39899,7 +39899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40027,7 +40027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40056,7 +40056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -40228,7 +40228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -40393,7 +40393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -40452,7 +40452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -40517,7 +40517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -40618,7 +40618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -40719,7 +40719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -40812,7 +40812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -40826,7 +40826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -40840,7 +40840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40902,7 +40902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40947,7 +40947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -40992,7 +40992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -41157,7 +41157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -41208,7 +41208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -41301,7 +41301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -41466,7 +41466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -41631,7 +41631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -41796,7 +41796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -41912,7 +41912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -41938,7 +41938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -41970,7 +41970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -42002,7 +42002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -42024,7 +42024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -42184,7 +42184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -42333,7 +42333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -42386,7 +42386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -42451,7 +42451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -42540,7 +42540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -42623,7 +42623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -42706,7 +42706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -42728,7 +42728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -42778,7 +42778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42792,7 +42792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42806,7 +42806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42868,7 +42868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42913,7 +42913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -42964,7 +42964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -43009,7 +43009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -43024,7 +43024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -43060,7 +43060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43091,7 +43091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43137,7 +43137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43166,7 +43166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43216,7 +43216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43256,7 +43256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43283,7 +43283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43321,7 +43321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43353,7 +43353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -43506,7 +43506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43659,7 +43659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -43812,7 +43812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -43965,7 +43965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -44118,7 +44118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -44271,7 +44271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -44424,7 +44424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -44576,7 +44576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -44728,7 +44728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -44881,7 +44881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -45034,7 +45034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -45187,7 +45187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -45340,7 +45340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -45499,7 +45499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45550,7 +45550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45601,7 +45601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45652,7 +45652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45703,7 +45703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -45717,7 +45717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -45731,7 +45731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -45751,7 +45751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -45845,7 +45845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -45859,7 +45859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -45873,7 +45873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -46203,7 +46203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -46223,7 +46223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -46237,7 +46237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -46265,7 +46265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -46465,7 +46465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAME70J20B.svd
+++ b/data/Atmel/ATSAME70J20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7457,7 +7457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7502,7 +7502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7529,7 +7529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7580,7 +7580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7631,7 +7631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7682,7 +7682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7733,7 +7733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7776,7 +7776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7806,7 +7806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7840,7 +7840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8046,7 +8046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8066,7 +8066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8080,7 +8080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8112,7 +8112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8144,7 +8144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8176,7 +8176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8208,7 +8208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8240,7 +8240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8273,7 +8273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8354,7 +8354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8417,7 +8417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -8543,7 +8543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -8564,7 +8564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -8585,7 +8585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8606,7 +8606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8620,7 +8620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8666,7 +8666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8680,7 +8680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8712,7 +8712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8754,7 +8754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8792,7 +8792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -8851,7 +8851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8901,7 +8901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -8951,7 +8951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -8990,7 +8990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -9212,7 +9212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -9240,7 +9240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -9284,7 +9284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9329,7 +9329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9358,7 +9358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9409,7 +9409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9471,7 +9471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9491,7 +9491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9700,7 +9700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9732,7 +9732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9770,7 +9770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9784,7 +9784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -9846,7 +9846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -9860,7 +9860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9893,7 +9893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10034,7 +10034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10054,7 +10054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10230,7 +10230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10406,7 +10406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10582,7 +10582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -10602,7 +10602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -10686,7 +10686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -10706,7 +10706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -10726,7 +10726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -10740,7 +10740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -10796,7 +10796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -10996,7 +10996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -11196,7 +11196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -11228,7 +11228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -11267,7 +11267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -11281,7 +11281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -11295,7 +11295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -11327,7 +11327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -11395,7 +11395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -11409,7 +11409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11596,7 +11596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -11629,7 +11629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -11686,7 +11686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -11887,7 +11887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12087,7 +12087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -12287,7 +12287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -12488,7 +12488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -12689,7 +12689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -12889,7 +12889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -13089,7 +13089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -13115,7 +13115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -13154,7 +13154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -13187,7 +13187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -13388,7 +13388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -13589,7 +13589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -13790,7 +13790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -13991,7 +13991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -14192,7 +14192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -14393,7 +14393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -14594,7 +14594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -14795,7 +14795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -14996,7 +14996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -15197,7 +15197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -15398,7 +15398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -15598,7 +15598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -15799,7 +15799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -16000,7 +16000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -16201,7 +16201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -16402,7 +16402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -16603,7 +16603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -16804,7 +16804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -17005,7 +17005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -17206,7 +17206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -17407,7 +17407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -17608,7 +17608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17811,7 +17811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -18011,7 +18011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -18212,7 +18212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -18413,7 +18413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -18614,7 +18614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -18628,7 +18628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -18829,7 +18829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -19030,7 +19030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -19231,7 +19231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -19432,7 +19432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -19633,7 +19633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -19834,7 +19834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -20035,7 +20035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -20236,7 +20236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -20437,7 +20437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -20638,7 +20638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -20839,7 +20839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -21040,7 +21040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -21241,7 +21241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -21442,7 +21442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -21643,7 +21643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -21844,7 +21844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -21872,7 +21872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -21893,7 +21893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22093,7 +22093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -22709,7 +22709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -22765,7 +22765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -22798,7 +22798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -22831,7 +22831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -22864,7 +22864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -22885,7 +22885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -22935,7 +22935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -22998,7 +22998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -23061,7 +23061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -23130,7 +23130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -23253,7 +23253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -23376,7 +23376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -23690,7 +23690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -23811,7 +23811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -23833,7 +23833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -23881,7 +23881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -23986,7 +23986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -24091,7 +24091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -24214,7 +24214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -24319,7 +24319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -24477,7 +24477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -24581,7 +24581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -24596,7 +24596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24624,7 +24624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24645,7 +24645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24780,7 +24780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -24915,7 +24915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -25050,7 +25050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -25122,7 +25122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -25166,7 +25166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -25289,7 +25289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25412,7 +25412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -25535,7 +25535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -25672,7 +25672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -25807,7 +25807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -25942,7 +25942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -26077,7 +26077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -26212,7 +26212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -26246,7 +26246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26420,7 +26420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26453,7 +26453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26486,7 +26486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26519,7 +26519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26576,7 +26576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26633,7 +26633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26690,7 +26690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26747,7 +26747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26815,7 +26815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26830,7 +26830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26844,7 +26844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26864,7 +26864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26879,7 +26879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26996,7 +26996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27113,7 +27113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27230,7 +27230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27347,7 +27347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27403,7 +27403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27459,7 +27459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27516,7 +27516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27573,7 +27573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -27630,7 +27630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -27687,7 +27687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -27713,7 +27713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -27734,7 +27734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -27749,7 +27749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -27805,7 +27805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -27839,7 +27839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27895,7 +27895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27915,7 +27915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27930,7 +27930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27962,7 +27962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -28018,7 +28018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28101,7 +28101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28200,7 +28200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28233,7 +28233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28254,7 +28254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28298,7 +28298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28338,7 +28338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28532,7 +28532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28546,7 +28546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28561,7 +28561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28575,7 +28575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28590,7 +28590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28605,7 +28605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28625,7 +28625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28647,7 +28647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -28668,7 +28668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -28689,7 +28689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -28769,7 +28769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -28807,7 +28807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -28828,7 +28828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -28908,7 +28908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28946,7 +28946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28994,7 +28994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29027,7 +29027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29147,7 +29147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29162,7 +29162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29177,7 +29177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29234,7 +29234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29285,7 +29285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29336,7 +29336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29387,7 +29387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29419,7 +29419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29433,7 +29433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29453,7 +29453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29631,7 +29631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29664,7 +29664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29679,7 +29679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29707,7 +29707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29747,7 +29747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29782,7 +29782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29843,7 +29843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29902,7 +29902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29931,7 +29931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29981,7 +29981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30015,7 +30015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30088,7 +30088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30302,7 +30302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30334,7 +30334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30372,7 +30372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30422,7 +30422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30454,7 +30454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30577,7 +30577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30622,7 +30622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30667,7 +30667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30712,7 +30712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30757,7 +30757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30809,7 +30809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30853,7 +30853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30867,7 +30867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30882,7 +30882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30922,7 +30922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -30961,7 +30961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -30975,7 +30975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31133,7 +31133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31235,7 +31235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31382,7 +31382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31490,7 +31490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31505,7 +31505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31520,7 +31520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31535,7 +31535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31549,7 +31549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31563,7 +31563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31577,7 +31577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31646,7 +31646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31703,7 +31703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31760,7 +31760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31817,7 +31817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31845,7 +31845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31876,7 +31876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -31885,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31946,7 +31946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32032,7 +32032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32136,7 +32136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32346,7 +32346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32886,7 +32886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33331,6 +33331,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -33365,7 +33393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33392,7 +33420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -33635,9 +33663,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -34071,7 +34099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34091,7 +34119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34106,7 +34134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34121,7 +34149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34135,7 +34163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34149,7 +34177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34163,7 +34191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34238,7 +34266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34295,7 +34323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34352,7 +34380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -34409,7 +34437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -34462,7 +34490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -34477,7 +34505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -34635,7 +34663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -34668,7 +34696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -34701,7 +34729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -34734,7 +34762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -34773,7 +34801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -34793,7 +34821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34888,7 +34916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34917,7 +34945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34932,7 +34960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34947,7 +34975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34962,7 +34990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34977,7 +35005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35011,7 +35039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35152,7 +35180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35201,7 +35229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35269,7 +35297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35283,7 +35311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35315,7 +35343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35438,7 +35466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35543,7 +35571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35648,7 +35676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35753,7 +35781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35768,7 +35796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35783,7 +35811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35815,7 +35843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35847,7 +35875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35879,7 +35907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35907,7 +35935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35955,7 +35983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36012,7 +36040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36121,7 +36149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36172,7 +36200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36223,7 +36251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36274,7 +36302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36325,7 +36353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36340,7 +36368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36355,7 +36383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36369,7 +36397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -36414,7 +36442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -37224,6 +37252,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -37274,7 +37320,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -37315,80 +37407,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37486,12 +37504,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -37501,6 +37513,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37536,46 +37560,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -37604,6 +37588,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37657,7 +37659,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -37704,134 +37752,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37923,30 +37843,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -37956,6 +37852,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37991,64 +37899,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -38077,6 +37927,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38130,7 +37998,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -38177,134 +38091,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38396,30 +38182,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -38429,6 +38191,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38464,64 +38238,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -38550,6 +38266,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38627,7 +38361,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -38674,140 +38460,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38905,30 +38557,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -38938,6 +38566,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38968,64 +38608,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -39708,7 +39290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39799,7 +39381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39952,7 +39534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40003,7 +39585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40096,7 +39678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40249,7 +39831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40402,7 +39984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40555,7 +40137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40683,7 +40265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40712,7 +40294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -40884,7 +40466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -41049,9 +40631,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41215,9 +40797,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41381,9 +40963,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41547,7 +41129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -41606,9 +41188,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41666,9 +41248,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41726,9 +41308,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41786,7 +41368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -41851,9 +41433,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41917,9 +41499,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41983,9 +41565,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42049,7 +41631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42150,9 +41732,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42258,9 +41840,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42360,9 +41942,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42462,7 +42044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -42563,9 +42145,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42671,9 +42253,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42773,9 +42355,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42875,7 +42457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -42964,9 +42546,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43054,9 +42636,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43144,9 +42726,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43238,7 +42820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43252,7 +42834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43266,7 +42848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43328,7 +42910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43373,7 +42955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43428,7 +43010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43537,43 +43119,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43581,7 +43163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43632,7 +43214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43681,43 +43263,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43725,7 +43307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -43834,43 +43416,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43878,7 +43460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -43987,43 +43569,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44031,7 +43613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44140,43 +43722,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44184,7 +43766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44300,7 +43882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44326,7 +43908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44358,7 +43940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44390,7 +43972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44412,7 +43994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44572,9 +44154,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -44739,7 +44321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -44888,9 +44470,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45038,9 +44620,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45188,9 +44770,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45338,7 +44920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45391,9 +44973,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45445,9 +45027,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45499,9 +45081,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45553,7 +45135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45618,9 +45200,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45684,9 +45266,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45750,9 +45332,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45816,7 +45398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45905,9 +45487,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45995,9 +45577,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46085,9 +45667,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46175,7 +45757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46258,9 +45840,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46342,9 +45924,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46426,9 +46008,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46510,7 +46092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -46593,9 +46175,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46677,9 +46259,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46761,9 +46343,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46845,7 +46427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -46867,7 +46449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -46917,7 +46499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46931,7 +46513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46945,7 +46527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47007,7 +46589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47052,7 +46634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47109,7 +46691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47154,7 +46736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47169,7 +46751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47205,7 +46787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47236,7 +46818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47282,7 +46864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47311,7 +46893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47361,7 +46943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47401,7 +46983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47428,7 +47010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47466,7 +47048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47498,7 +47080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -47651,7 +47233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47804,7 +47386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -47957,7 +47539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48110,7 +47692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48263,7 +47845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -48416,7 +47998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -48569,7 +48151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -48721,7 +48303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -48873,7 +48455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49026,7 +48608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49179,7 +48761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49332,7 +48914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -49485,7 +49067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -49644,7 +49226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49695,7 +49277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -49746,7 +49328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -49797,7 +49379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -49848,7 +49430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -49862,7 +49444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -49876,7 +49458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -49896,7 +49478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -49990,7 +49572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50004,7 +49586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50018,7 +49600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -50501,7 +50083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -50521,7 +50103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -50535,7 +50117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -50563,7 +50145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -50763,7 +50345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -52652,6 +52234,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAME70J21.svd
+++ b/data/Atmel/ATSAME70J21.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4154,7 +4154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4258,7 +4258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4437,7 +4437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4458,7 +4458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4472,7 +4472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4574,7 +4574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4624,7 +4624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4638,7 +4638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4684,7 +4684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4831,7 +4831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4984,7 +4984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5137,7 +5137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5289,7 +5289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5339,7 +5339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5354,7 +5354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5368,7 +5368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5408,7 +5408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5422,7 +5422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5457,7 +5457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5471,7 +5471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5546,7 +5546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5566,7 +5566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5618,7 +5618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5658,7 +5658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5672,7 +5672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5686,7 +5686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5700,7 +5700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5714,7 +5714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6073,7 +6073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6103,7 +6103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6118,7 +6118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6133,7 +6133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6148,7 +6148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6163,7 +6163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6178,7 +6178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6193,7 +6193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6208,7 +6208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6223,7 +6223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6238,7 +6238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6253,7 +6253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6268,7 +6268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6328,7 +6328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6343,7 +6343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6358,7 +6358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6373,7 +6373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6388,7 +6388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6403,7 +6403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6418,7 +6418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6433,7 +6433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6448,7 +6448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6463,7 +6463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6477,7 +6477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6491,7 +6491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6519,7 +6519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6540,7 +6540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6566,7 +6566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6581,7 +6581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6596,7 +6596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6611,7 +6611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6626,7 +6626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6641,7 +6641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6656,7 +6656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6671,7 +6671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6688,7 +6688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6741,7 +6741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6757,7 +6757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6773,7 +6773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6787,7 +6787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6837,7 +6837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6877,7 +6877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6953,7 +6953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7006,7 +7006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7059,7 +7059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7125,7 +7125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7145,7 +7145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7188,7 +7188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7208,7 +7208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7251,7 +7251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7271,7 +7271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7314,7 +7314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7334,7 +7334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7377,7 +7377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7397,7 +7397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7460,7 +7460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7503,7 +7503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7523,7 +7523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7566,7 +7566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7586,7 +7586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7629,7 +7629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7649,7 +7649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7692,7 +7692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7712,7 +7712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7755,7 +7755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7775,7 +7775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7818,7 +7818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7838,7 +7838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7881,7 +7881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7901,7 +7901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7944,7 +7944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7964,7 +7964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8007,7 +8007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8027,7 +8027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8070,7 +8070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8090,7 +8090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8133,7 +8133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8153,7 +8153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8196,7 +8196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8216,7 +8216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8259,7 +8259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8279,7 +8279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8342,7 +8342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8385,7 +8385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8405,7 +8405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8448,7 +8448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8468,7 +8468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8511,7 +8511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8531,7 +8531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8574,7 +8574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8687,7 +8687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8761,7 +8761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8806,7 +8806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8833,7 +8833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8884,7 +8884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8935,7 +8935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8986,7 +8986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9037,7 +9037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9080,7 +9080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9094,7 +9094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9110,7 +9110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9144,7 +9144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9242,7 +9242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9350,7 +9350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9370,7 +9370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9384,7 +9384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9416,7 +9416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9448,7 +9448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9480,7 +9480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9512,7 +9512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9544,7 +9544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9577,7 +9577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -9658,7 +9658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -9721,7 +9721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9784,7 +9784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9847,7 +9847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9868,7 +9868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -9889,7 +9889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9910,7 +9910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9924,7 +9924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9956,7 +9956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9970,7 +9970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9984,7 +9984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10016,7 +10016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10030,7 +10030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10058,7 +10058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10096,7 +10096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10155,7 +10155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10205,7 +10205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10255,7 +10255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10288,7 +10288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -10452,7 +10452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -10480,7 +10480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -10524,7 +10524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10538,7 +10538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10595,7 +10595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10663,7 +10663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10683,7 +10683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10896,7 +10896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10928,7 +10928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10966,7 +10966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10980,7 +10980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11042,7 +11042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11056,7 +11056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11089,7 +11089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11218,7 +11218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11406,7 +11406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11594,7 +11594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11782,7 +11782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -11802,7 +11802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -11886,7 +11886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -11906,7 +11906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -11926,7 +11926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -11940,7 +11940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -11996,7 +11996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12196,7 +12196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -12396,7 +12396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -12428,7 +12428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -12467,7 +12467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -12481,7 +12481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -12495,7 +12495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -12527,7 +12527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -12595,7 +12595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -12609,7 +12609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -12764,7 +12764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -12796,7 +12796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -12829,7 +12829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -12886,7 +12886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13087,7 +13087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13287,7 +13287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -13487,7 +13487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -13688,7 +13688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -13889,7 +13889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14089,7 +14089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -14289,7 +14289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -14315,7 +14315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -14354,7 +14354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -14387,7 +14387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -14588,7 +14588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -14789,7 +14789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -14990,7 +14990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -15191,7 +15191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -15392,7 +15392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -15593,7 +15593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -15794,7 +15794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -15995,7 +15995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -16196,7 +16196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -16397,7 +16397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -16598,7 +16598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16798,7 +16798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -16999,7 +16999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -17200,7 +17200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -17401,7 +17401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -17602,7 +17602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -17803,7 +17803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -18004,7 +18004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -18205,7 +18205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -18406,7 +18406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18607,7 +18607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18808,7 +18808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19011,7 +19011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -19211,7 +19211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -19412,7 +19412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -19613,7 +19613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -19814,7 +19814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -19828,7 +19828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -20029,7 +20029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -20230,7 +20230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -20431,7 +20431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -20632,7 +20632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -20833,7 +20833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -21034,7 +21034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -21235,7 +21235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -21436,7 +21436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -21637,7 +21637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -21838,7 +21838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -22039,7 +22039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -22240,7 +22240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -22441,7 +22441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -22642,7 +22642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -22843,7 +22843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -23044,7 +23044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23072,7 +23072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23093,7 +23093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -23293,7 +23293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -23909,7 +23909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -23965,7 +23965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -23998,7 +23998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24031,7 +24031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24064,7 +24064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -24085,7 +24085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -24135,7 +24135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -24192,7 +24192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -24249,7 +24249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -24312,7 +24312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -24471,7 +24471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -24630,7 +24630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -24980,7 +24980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -25101,7 +25101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -25123,7 +25123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25171,7 +25171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -25270,7 +25270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -25369,7 +25369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -25486,7 +25486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -25585,7 +25585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -25743,7 +25743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -25847,7 +25847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -25862,7 +25862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25890,7 +25890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25911,7 +25911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -26070,7 +26070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -26229,7 +26229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -26388,7 +26388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -26460,7 +26460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -26504,7 +26504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -26663,7 +26663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26822,7 +26822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -26981,7 +26981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -27140,7 +27140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -27154,7 +27154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -27313,7 +27313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -27472,7 +27472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -27631,7 +27631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -27790,7 +27790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -27824,7 +27824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27998,7 +27998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28031,7 +28031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28064,7 +28064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28097,7 +28097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28154,7 +28154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28211,7 +28211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28268,7 +28268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28325,7 +28325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28393,7 +28393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28408,7 +28408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28422,7 +28422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28442,7 +28442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28457,7 +28457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28574,7 +28574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28691,7 +28691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -28808,7 +28808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28925,7 +28925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28981,7 +28981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29037,7 +29037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29094,7 +29094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29151,7 +29151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -29208,7 +29208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -29265,7 +29265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -29291,7 +29291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -29312,7 +29312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -29327,7 +29327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -29383,7 +29383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -29417,7 +29417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -29473,7 +29473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -29493,7 +29493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -29508,7 +29508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -29540,7 +29540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29596,7 +29596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29679,7 +29679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29778,7 +29778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29798,7 +29798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29819,7 +29819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29863,7 +29863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29903,7 +29903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30045,7 +30045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30059,7 +30059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30074,7 +30074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30088,7 +30088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30103,7 +30103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30118,7 +30118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30138,7 +30138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30160,7 +30160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -30181,7 +30181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -30202,7 +30202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -30282,7 +30282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -30320,7 +30320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -30341,7 +30341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -30421,7 +30421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -30459,7 +30459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -30507,7 +30507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30540,7 +30540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30660,7 +30660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30675,7 +30675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30690,7 +30690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30747,7 +30747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30798,7 +30798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30849,7 +30849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30900,7 +30900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30932,7 +30932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30946,7 +30946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30966,7 +30966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31144,7 +31144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31177,7 +31177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31192,7 +31192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31220,7 +31220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31260,7 +31260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31295,7 +31295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31356,7 +31356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31415,7 +31415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31444,7 +31444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31494,7 +31494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31528,7 +31528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31601,7 +31601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31815,7 +31815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31847,7 +31847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31885,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31935,7 +31935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31967,7 +31967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32090,7 +32090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32135,7 +32135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32180,7 +32180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32225,7 +32225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -32270,7 +32270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -32322,7 +32322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32366,7 +32366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32380,7 +32380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32395,7 +32395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32435,7 +32435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -32474,7 +32474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -32488,7 +32488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32646,7 +32646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32748,7 +32748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32895,7 +32895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33003,7 +33003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33018,7 +33018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33033,7 +33033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33048,7 +33048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33062,7 +33062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33076,7 +33076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -33090,7 +33090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33159,7 +33159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33216,7 +33216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -33273,7 +33273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -33330,7 +33330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33358,7 +33358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33398,7 +33398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33459,7 +33459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33545,7 +33545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33649,7 +33649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33859,7 +33859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34399,7 +34399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34878,7 +34878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34905,7 +34905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -35148,7 +35148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35168,7 +35168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35183,7 +35183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -35198,7 +35198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -35212,7 +35212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -35226,7 +35226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -35240,7 +35240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -35315,7 +35315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -35372,7 +35372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -35429,7 +35429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -35486,7 +35486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -35539,7 +35539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -35554,7 +35554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -35700,7 +35700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -35727,7 +35727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -35754,7 +35754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -35781,7 +35781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -35814,7 +35814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -35834,7 +35834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35929,7 +35929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35958,7 +35958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35973,7 +35973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35988,7 +35988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36003,7 +36003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -36018,7 +36018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -36052,7 +36052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36193,7 +36193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36242,7 +36242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36310,7 +36310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36324,7 +36324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36356,7 +36356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -36479,7 +36479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -36584,7 +36584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36689,7 +36689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36794,7 +36794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36809,7 +36809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36824,7 +36824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36856,7 +36856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36888,7 +36888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36920,7 +36920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36948,7 +36948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36996,7 +36996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -37053,7 +37053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -37162,7 +37162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -37213,7 +37213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -37264,7 +37264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37315,7 +37315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37366,7 +37366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37381,7 +37381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37396,7 +37396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37410,7 +37410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -37455,7 +37455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -39014,7 +39014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39095,7 +39095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39260,7 +39260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39311,7 +39311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39404,7 +39404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39569,7 +39569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39734,7 +39734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39899,7 +39899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40027,7 +40027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40056,7 +40056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -40228,7 +40228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -40393,7 +40393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -40452,7 +40452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -40517,7 +40517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -40618,7 +40618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -40719,7 +40719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -40812,7 +40812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -40826,7 +40826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -40840,7 +40840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40902,7 +40902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40947,7 +40947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -40992,7 +40992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -41157,7 +41157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -41208,7 +41208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -41301,7 +41301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -41466,7 +41466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -41631,7 +41631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -41796,7 +41796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -41912,7 +41912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -41938,7 +41938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -41970,7 +41970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -42002,7 +42002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -42024,7 +42024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -42184,7 +42184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -42333,7 +42333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -42386,7 +42386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -42451,7 +42451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -42540,7 +42540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -42623,7 +42623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -42706,7 +42706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -42728,7 +42728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -42778,7 +42778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42792,7 +42792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42806,7 +42806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42868,7 +42868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42913,7 +42913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -42964,7 +42964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -43009,7 +43009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -43024,7 +43024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -43060,7 +43060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43091,7 +43091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43137,7 +43137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43166,7 +43166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43216,7 +43216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43256,7 +43256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43283,7 +43283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43321,7 +43321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43353,7 +43353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -43506,7 +43506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43659,7 +43659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -43812,7 +43812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -43965,7 +43965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -44118,7 +44118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -44271,7 +44271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -44424,7 +44424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -44576,7 +44576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -44728,7 +44728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -44881,7 +44881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -45034,7 +45034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -45187,7 +45187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -45340,7 +45340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -45499,7 +45499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45550,7 +45550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45601,7 +45601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45652,7 +45652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45703,7 +45703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -45717,7 +45717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -45731,7 +45731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -45751,7 +45751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -45845,7 +45845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -45859,7 +45859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -45873,7 +45873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -46203,7 +46203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -46223,7 +46223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -46237,7 +46237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -46265,7 +46265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -46465,7 +46465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -46665,7 +46665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -46865,7 +46865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAME70J21B.svd
+++ b/data/Atmel/ATSAME70J21B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7457,7 +7457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7502,7 +7502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7529,7 +7529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7580,7 +7580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7631,7 +7631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7682,7 +7682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7733,7 +7733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7776,7 +7776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7806,7 +7806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7840,7 +7840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8046,7 +8046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8066,7 +8066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8080,7 +8080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8112,7 +8112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8144,7 +8144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8176,7 +8176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8208,7 +8208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8240,7 +8240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8273,7 +8273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8354,7 +8354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8417,7 +8417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -8543,7 +8543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -8564,7 +8564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -8585,7 +8585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8606,7 +8606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8620,7 +8620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8666,7 +8666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8680,7 +8680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8712,7 +8712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8754,7 +8754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8792,7 +8792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -8851,7 +8851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8901,7 +8901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -8951,7 +8951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -8990,7 +8990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -9212,7 +9212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -9240,7 +9240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -9284,7 +9284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9329,7 +9329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9358,7 +9358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9409,7 +9409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9471,7 +9471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9491,7 +9491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9700,7 +9700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9732,7 +9732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9770,7 +9770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9784,7 +9784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -9846,7 +9846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -9860,7 +9860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9893,7 +9893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10034,7 +10034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10054,7 +10054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10230,7 +10230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10406,7 +10406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10582,7 +10582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -10602,7 +10602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -10686,7 +10686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -10706,7 +10706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -10726,7 +10726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -10740,7 +10740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -10796,7 +10796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -10996,7 +10996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -11196,7 +11196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -11228,7 +11228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -11267,7 +11267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -11281,7 +11281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -11295,7 +11295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -11327,7 +11327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -11395,7 +11395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -11409,7 +11409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11596,7 +11596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -11629,7 +11629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -11686,7 +11686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -11887,7 +11887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12087,7 +12087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -12287,7 +12287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -12488,7 +12488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -12689,7 +12689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -12889,7 +12889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -13089,7 +13089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -13115,7 +13115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -13154,7 +13154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -13187,7 +13187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -13388,7 +13388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -13589,7 +13589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -13790,7 +13790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -13991,7 +13991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -14192,7 +14192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -14393,7 +14393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -14594,7 +14594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -14795,7 +14795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -14996,7 +14996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -15197,7 +15197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -15398,7 +15398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -15598,7 +15598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -15799,7 +15799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -16000,7 +16000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -16201,7 +16201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -16402,7 +16402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -16603,7 +16603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -16804,7 +16804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -17005,7 +17005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -17206,7 +17206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -17407,7 +17407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -17608,7 +17608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17811,7 +17811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -18011,7 +18011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -18212,7 +18212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -18413,7 +18413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -18614,7 +18614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -18628,7 +18628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -18829,7 +18829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -19030,7 +19030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -19231,7 +19231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -19432,7 +19432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -19633,7 +19633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -19834,7 +19834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -20035,7 +20035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -20236,7 +20236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -20437,7 +20437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -20638,7 +20638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -20839,7 +20839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -21040,7 +21040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -21241,7 +21241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -21442,7 +21442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -21643,7 +21643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -21844,7 +21844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -21872,7 +21872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -21893,7 +21893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22093,7 +22093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -22709,7 +22709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -22765,7 +22765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -22798,7 +22798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -22831,7 +22831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -22864,7 +22864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -22885,7 +22885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -22935,7 +22935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -22998,7 +22998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -23061,7 +23061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -23130,7 +23130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -23253,7 +23253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -23376,7 +23376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -23690,7 +23690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -23811,7 +23811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -23833,7 +23833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -23881,7 +23881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -23986,7 +23986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -24091,7 +24091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -24214,7 +24214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -24319,7 +24319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -24477,7 +24477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -24581,7 +24581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -24596,7 +24596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24624,7 +24624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24645,7 +24645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24780,7 +24780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -24915,7 +24915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -25050,7 +25050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -25122,7 +25122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -25166,7 +25166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -25289,7 +25289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25412,7 +25412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -25535,7 +25535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -25672,7 +25672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -25807,7 +25807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -25942,7 +25942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -26077,7 +26077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -26212,7 +26212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -26246,7 +26246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26420,7 +26420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26453,7 +26453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26486,7 +26486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26519,7 +26519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26576,7 +26576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26633,7 +26633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26690,7 +26690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26747,7 +26747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26815,7 +26815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26830,7 +26830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26844,7 +26844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26864,7 +26864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26879,7 +26879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26996,7 +26996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27113,7 +27113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27230,7 +27230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27347,7 +27347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27403,7 +27403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27459,7 +27459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27516,7 +27516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27573,7 +27573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -27630,7 +27630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -27687,7 +27687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -27713,7 +27713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -27734,7 +27734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -27749,7 +27749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -27805,7 +27805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -27839,7 +27839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27895,7 +27895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27915,7 +27915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27930,7 +27930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27962,7 +27962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -28018,7 +28018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28101,7 +28101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28200,7 +28200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28233,7 +28233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28254,7 +28254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28298,7 +28298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28338,7 +28338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28532,7 +28532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28546,7 +28546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28561,7 +28561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28575,7 +28575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28590,7 +28590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28605,7 +28605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28625,7 +28625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28647,7 +28647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -28668,7 +28668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -28689,7 +28689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -28769,7 +28769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -28807,7 +28807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -28828,7 +28828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -28908,7 +28908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28946,7 +28946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28994,7 +28994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29027,7 +29027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29147,7 +29147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29162,7 +29162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29177,7 +29177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29234,7 +29234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29285,7 +29285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29336,7 +29336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29387,7 +29387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29419,7 +29419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29433,7 +29433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29453,7 +29453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29631,7 +29631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29664,7 +29664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29679,7 +29679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29707,7 +29707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29747,7 +29747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29782,7 +29782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29843,7 +29843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29902,7 +29902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29931,7 +29931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29981,7 +29981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30015,7 +30015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30088,7 +30088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30302,7 +30302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30334,7 +30334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30372,7 +30372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30422,7 +30422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30454,7 +30454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30577,7 +30577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30622,7 +30622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30667,7 +30667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30712,7 +30712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30757,7 +30757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30809,7 +30809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30853,7 +30853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30867,7 +30867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30882,7 +30882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30922,7 +30922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -30961,7 +30961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -30975,7 +30975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31133,7 +31133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31235,7 +31235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31382,7 +31382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31490,7 +31490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31505,7 +31505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31520,7 +31520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31535,7 +31535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31549,7 +31549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31563,7 +31563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31577,7 +31577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31646,7 +31646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31703,7 +31703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31760,7 +31760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31817,7 +31817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31845,7 +31845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31876,7 +31876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -31885,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31946,7 +31946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32032,7 +32032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32136,7 +32136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32346,7 +32346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32886,7 +32886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33331,6 +33331,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -33365,7 +33393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33392,7 +33420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -33635,9 +33663,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -34071,7 +34099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34091,7 +34119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34106,7 +34134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34121,7 +34149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34135,7 +34163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34149,7 +34177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34163,7 +34191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34238,7 +34266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34295,7 +34323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34352,7 +34380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -34409,7 +34437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -34462,7 +34490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -34477,7 +34505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -34635,7 +34663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -34668,7 +34696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -34701,7 +34729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -34734,7 +34762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -34773,7 +34801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -34793,7 +34821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34888,7 +34916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34917,7 +34945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34932,7 +34960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34947,7 +34975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34962,7 +34990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34977,7 +35005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35011,7 +35039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35152,7 +35180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35201,7 +35229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35269,7 +35297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35283,7 +35311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35315,7 +35343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35438,7 +35466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35543,7 +35571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35648,7 +35676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35753,7 +35781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35768,7 +35796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35783,7 +35811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35815,7 +35843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35847,7 +35875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35879,7 +35907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35907,7 +35935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35955,7 +35983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36012,7 +36040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36121,7 +36149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36172,7 +36200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36223,7 +36251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36274,7 +36302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36325,7 +36353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36340,7 +36368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36355,7 +36383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36369,7 +36397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -36414,7 +36442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -37224,6 +37252,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -37274,7 +37320,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -37315,80 +37407,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37486,12 +37504,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -37501,6 +37513,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37536,46 +37560,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -37604,6 +37588,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37657,7 +37659,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -37704,134 +37752,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37923,30 +37843,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -37956,6 +37852,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37991,64 +37899,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -38077,6 +37927,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38130,7 +37998,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -38177,134 +38091,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38396,30 +38182,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -38429,6 +38191,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38464,64 +38238,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -38550,6 +38266,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38627,7 +38361,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -38674,140 +38460,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38905,30 +38557,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -38938,6 +38566,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38968,64 +38608,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -39708,7 +39290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39799,7 +39381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39952,7 +39534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40003,7 +39585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40096,7 +39678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40249,7 +39831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40402,7 +39984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40555,7 +40137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40683,7 +40265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40712,7 +40294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -40884,7 +40466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -41049,9 +40631,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41215,9 +40797,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41381,9 +40963,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41547,7 +41129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -41606,9 +41188,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41666,9 +41248,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41726,9 +41308,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41786,7 +41368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -41851,9 +41433,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41917,9 +41499,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41983,9 +41565,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42049,7 +41631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42150,9 +41732,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42258,9 +41840,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42360,9 +41942,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42462,7 +42044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -42563,9 +42145,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42671,9 +42253,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42773,9 +42355,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42875,7 +42457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -42964,9 +42546,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43054,9 +42636,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43144,9 +42726,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43238,7 +42820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43252,7 +42834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43266,7 +42848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43328,7 +42910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43373,7 +42955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43428,7 +43010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43537,43 +43119,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43581,7 +43163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43632,7 +43214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43681,43 +43263,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43725,7 +43307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -43834,43 +43416,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43878,7 +43460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -43987,43 +43569,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44031,7 +43613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44140,43 +43722,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44184,7 +43766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44300,7 +43882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44326,7 +43908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44358,7 +43940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44390,7 +43972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44412,7 +43994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44572,9 +44154,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -44739,7 +44321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -44888,9 +44470,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45038,9 +44620,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45188,9 +44770,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45338,7 +44920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45391,9 +44973,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45445,9 +45027,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45499,9 +45081,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45553,7 +45135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45618,9 +45200,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45684,9 +45266,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45750,9 +45332,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45816,7 +45398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45905,9 +45487,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45995,9 +45577,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46085,9 +45667,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46175,7 +45757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46258,9 +45840,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46342,9 +45924,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46426,9 +46008,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46510,7 +46092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -46593,9 +46175,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46677,9 +46259,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46761,9 +46343,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46845,7 +46427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -46867,7 +46449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -46917,7 +46499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46931,7 +46513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46945,7 +46527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47007,7 +46589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47052,7 +46634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47109,7 +46691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47154,7 +46736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47169,7 +46751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47205,7 +46787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47236,7 +46818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47282,7 +46864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47311,7 +46893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47361,7 +46943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47401,7 +46983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47428,7 +47010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47466,7 +47048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47498,7 +47080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -47651,7 +47233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47804,7 +47386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -47957,7 +47539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48110,7 +47692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48263,7 +47845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -48416,7 +47998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -48569,7 +48151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -48721,7 +48303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -48873,7 +48455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49026,7 +48608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49179,7 +48761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49332,7 +48914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -49485,7 +49067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -49644,7 +49226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49695,7 +49277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -49746,7 +49328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -49797,7 +49379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -49848,7 +49430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -49862,7 +49444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -49876,7 +49458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -49896,7 +49478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -49990,7 +49572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50004,7 +49586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50018,7 +49600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -50501,7 +50083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -50521,7 +50103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -50535,7 +50117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -50563,7 +50145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -50763,7 +50345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -50963,7 +50545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -51163,7 +50745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>
@@ -53052,6 +52634,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAME70N19.svd
+++ b/data/Atmel/ATSAME70N19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4154,7 +4154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4258,7 +4258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4437,7 +4437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4458,7 +4458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4472,7 +4472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4574,7 +4574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4624,7 +4624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4638,7 +4638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4684,7 +4684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4831,7 +4831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4984,7 +4984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5137,7 +5137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5289,7 +5289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5339,7 +5339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5354,7 +5354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5368,7 +5368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5408,7 +5408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5422,7 +5422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5457,7 +5457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5471,7 +5471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5546,7 +5546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5566,7 +5566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5618,7 +5618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5658,7 +5658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5672,7 +5672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5686,7 +5686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5700,7 +5700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5714,7 +5714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6073,7 +6073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6103,7 +6103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6118,7 +6118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6133,7 +6133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6148,7 +6148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6163,7 +6163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6178,7 +6178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6193,7 +6193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6208,7 +6208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6223,7 +6223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6238,7 +6238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6253,7 +6253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6268,7 +6268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6328,7 +6328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6343,7 +6343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6358,7 +6358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6373,7 +6373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6388,7 +6388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6403,7 +6403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6418,7 +6418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6433,7 +6433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6448,7 +6448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6463,7 +6463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6477,7 +6477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6491,7 +6491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6519,7 +6519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6540,7 +6540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6566,7 +6566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6581,7 +6581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6596,7 +6596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6611,7 +6611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6626,7 +6626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6641,7 +6641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6656,7 +6656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6671,7 +6671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6688,7 +6688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6741,7 +6741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6757,7 +6757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6773,7 +6773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6787,7 +6787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6837,7 +6837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6877,7 +6877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6953,7 +6953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7006,7 +7006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7059,7 +7059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7125,7 +7125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7145,7 +7145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7188,7 +7188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7208,7 +7208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7251,7 +7251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7271,7 +7271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7314,7 +7314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7334,7 +7334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7377,7 +7377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7397,7 +7397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7460,7 +7460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7503,7 +7503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7523,7 +7523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7566,7 +7566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7586,7 +7586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7629,7 +7629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7649,7 +7649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7692,7 +7692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7712,7 +7712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7755,7 +7755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7775,7 +7775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7818,7 +7818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7838,7 +7838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7881,7 +7881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7901,7 +7901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7944,7 +7944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7964,7 +7964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8007,7 +8007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8027,7 +8027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8070,7 +8070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8090,7 +8090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8133,7 +8133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8153,7 +8153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8196,7 +8196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8216,7 +8216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8259,7 +8259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8279,7 +8279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8342,7 +8342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8385,7 +8385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8405,7 +8405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8448,7 +8448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8468,7 +8468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8511,7 +8511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8531,7 +8531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8574,7 +8574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8687,7 +8687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8776,7 +8776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8839,7 +8839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8885,7 +8885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8899,7 +8899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9156,7 +9156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9176,7 +9176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9241,7 +9241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9256,7 +9256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9271,7 +9271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9286,7 +9286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9439,7 +9439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9592,7 +9592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9898,7 +9898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9946,7 +9946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9978,7 +9978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10006,7 +10006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10029,7 +10029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10062,7 +10062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10181,7 +10181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10208,7 +10208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10259,7 +10259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10310,7 +10310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10361,7 +10361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10412,7 +10412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10455,7 +10455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10469,7 +10469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10485,7 +10485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10519,7 +10519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10617,7 +10617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10725,7 +10725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10745,7 +10745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10759,7 +10759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10791,7 +10791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10823,7 +10823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10855,7 +10855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10887,7 +10887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10919,7 +10919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11033,7 +11033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11096,7 +11096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11159,7 +11159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11222,7 +11222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11243,7 +11243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11264,7 +11264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11285,7 +11285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11299,7 +11299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11331,7 +11331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11345,7 +11345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11359,7 +11359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11391,7 +11391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11405,7 +11405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11433,7 +11433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11471,7 +11471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11530,7 +11530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11580,7 +11580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11630,7 +11630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11663,7 +11663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11833,7 +11833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11861,7 +11861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11905,7 +11905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11919,7 +11919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11976,7 +11976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12044,7 +12044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12064,7 +12064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12277,7 +12277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12309,7 +12309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12347,7 +12347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12361,7 +12361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12423,7 +12423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12437,7 +12437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12470,7 +12470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -12599,7 +12599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12787,7 +12787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12975,7 +12975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13163,7 +13163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13183,7 +13183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13267,7 +13267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13287,7 +13287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13307,7 +13307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13321,7 +13321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13377,7 +13377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13577,7 +13577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13777,7 +13777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13809,7 +13809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13848,7 +13848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13862,7 +13862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13876,7 +13876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13908,7 +13908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13976,7 +13976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13990,7 +13990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14145,7 +14145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14177,7 +14177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14210,7 +14210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14267,7 +14267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14468,7 +14468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14668,7 +14668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14868,7 +14868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15069,7 +15069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15270,7 +15270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15470,7 +15470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15670,7 +15670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15696,7 +15696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15735,7 +15735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15780,7 +15780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15981,7 +15981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16182,7 +16182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16383,7 +16383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16584,7 +16584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16785,7 +16785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16986,7 +16986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17187,7 +17187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17388,7 +17388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17589,7 +17589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17790,7 +17790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17991,7 +17991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18191,7 +18191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18392,7 +18392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18593,7 +18593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18794,7 +18794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18995,7 +18995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19196,7 +19196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19397,7 +19397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19598,7 +19598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19799,7 +19799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -20000,7 +20000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20201,7 +20201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20404,7 +20404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20604,7 +20604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20805,7 +20805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -21006,7 +21006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21207,7 +21207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21221,7 +21221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21422,7 +21422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21623,7 +21623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21824,7 +21824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -22025,7 +22025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22226,7 +22226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22427,7 +22427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22628,7 +22628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22829,7 +22829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -23030,7 +23030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23231,7 +23231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23432,7 +23432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23633,7 +23633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23834,7 +23834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -24035,7 +24035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24236,7 +24236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24437,7 +24437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24465,7 +24465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24486,7 +24486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24686,7 +24686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25302,7 +25302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25358,7 +25358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25391,7 +25391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25424,7 +25424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25457,7 +25457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25478,7 +25478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25528,7 +25528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25585,7 +25585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25642,7 +25642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25705,7 +25705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25864,7 +25864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -26023,7 +26023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26373,7 +26373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26494,7 +26494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26516,7 +26516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26564,7 +26564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26663,7 +26663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26762,7 +26762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26879,7 +26879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26978,7 +26978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27136,7 +27136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27240,7 +27240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27255,7 +27255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27283,7 +27283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27304,7 +27304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27463,7 +27463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27622,7 +27622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27781,7 +27781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27853,7 +27853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27897,7 +27897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28056,7 +28056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28215,7 +28215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28374,7 +28374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28533,7 +28533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28547,7 +28547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28706,7 +28706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28865,7 +28865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29024,7 +29024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29183,7 +29183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29217,7 +29217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29391,7 +29391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29424,7 +29424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29457,7 +29457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29490,7 +29490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29547,7 +29547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29604,7 +29604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29661,7 +29661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29718,7 +29718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29786,7 +29786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29801,7 +29801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29815,7 +29815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29835,7 +29835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29850,7 +29850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29967,7 +29967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30084,7 +30084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30201,7 +30201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30318,7 +30318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30374,7 +30374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30430,7 +30430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30487,7 +30487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30544,7 +30544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30601,7 +30601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30658,7 +30658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30684,7 +30684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30705,7 +30705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30720,7 +30720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30776,7 +30776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30810,7 +30810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30866,7 +30866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30886,7 +30886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30901,7 +30901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30933,7 +30933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30989,7 +30989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31072,7 +31072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31171,7 +31171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31191,7 +31191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31212,7 +31212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31256,7 +31256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31296,7 +31296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31438,7 +31438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31452,7 +31452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31467,7 +31467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31481,7 +31481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31496,7 +31496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31511,7 +31511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31531,7 +31531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31553,7 +31553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31574,7 +31574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31595,7 +31595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31675,7 +31675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31713,7 +31713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31734,7 +31734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31814,7 +31814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31852,7 +31852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31900,7 +31900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31933,7 +31933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32053,7 +32053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32068,7 +32068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32083,7 +32083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32140,7 +32140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32191,7 +32191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32242,7 +32242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32293,7 +32293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32325,7 +32325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32339,7 +32339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32359,7 +32359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32537,7 +32537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32570,7 +32570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32585,7 +32585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32613,7 +32613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32653,7 +32653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32688,7 +32688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32749,7 +32749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32808,7 +32808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32837,7 +32837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32887,7 +32887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32921,7 +32921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32994,7 +32994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33208,7 +33208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33240,7 +33240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33278,7 +33278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33328,7 +33328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33360,7 +33360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33483,7 +33483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33528,7 +33528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33573,7 +33573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33618,7 +33618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33663,7 +33663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33715,7 +33715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33759,7 +33759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33773,7 +33773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33788,7 +33788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33828,7 +33828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33891,7 +33891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33947,7 +33947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33968,7 +33968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33995,7 +33995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34052,7 +34052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34103,7 +34103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34154,7 +34154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34207,7 +34207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34311,7 +34311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34339,7 +34339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34379,7 +34379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34418,7 +34418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34432,7 +34432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34590,7 +34590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34692,7 +34692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34839,7 +34839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34947,7 +34947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34962,7 +34962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34977,7 +34977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34992,7 +34992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35006,7 +35006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35020,7 +35020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35034,7 +35034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35103,7 +35103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35160,7 +35160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35217,7 +35217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35274,7 +35274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35302,7 +35302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35342,7 +35342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35403,7 +35403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35489,7 +35489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35593,7 +35593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35803,7 +35803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36343,7 +36343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36822,7 +36822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36849,7 +36849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37092,7 +37092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37112,7 +37112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37127,7 +37127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37142,7 +37142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37156,7 +37156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37170,7 +37170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37184,7 +37184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37259,7 +37259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37316,7 +37316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37373,7 +37373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37430,7 +37430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37483,7 +37483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37498,7 +37498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -37644,7 +37644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -37671,7 +37671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -37698,7 +37698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -37725,7 +37725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -37758,7 +37758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -37778,7 +37778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37873,7 +37873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37902,7 +37902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37917,7 +37917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37932,7 +37932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37947,7 +37947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37962,7 +37962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -37996,7 +37996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38137,7 +38137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38186,7 +38186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38254,7 +38254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38268,7 +38268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38300,7 +38300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38423,7 +38423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38528,7 +38528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38633,7 +38633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38738,7 +38738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38753,7 +38753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38768,7 +38768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38800,7 +38800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -38832,7 +38832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -38864,7 +38864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38892,7 +38892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -38948,7 +38948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39005,7 +39005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39114,7 +39114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39165,7 +39165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39216,7 +39216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39267,7 +39267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39318,7 +39318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39333,7 +39333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39348,7 +39348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39362,7 +39362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39407,7 +39407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40990,7 +40990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41071,7 +41071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41236,7 +41236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -41287,7 +41287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -41380,7 +41380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -41545,7 +41545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41710,7 +41710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41875,7 +41875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42003,7 +42003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42032,7 +42032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42204,7 +42204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -42369,7 +42369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -42428,7 +42428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -42493,7 +42493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42594,7 +42594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -42695,7 +42695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -42788,7 +42788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42802,7 +42802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42816,7 +42816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42878,7 +42878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42923,7 +42923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -42968,7 +42968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43133,7 +43133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43184,7 +43184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43277,7 +43277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -43442,7 +43442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -43607,7 +43607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -43772,7 +43772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -43888,7 +43888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -43914,7 +43914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -43946,7 +43946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -43978,7 +43978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44000,7 +44000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44160,7 +44160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -44309,7 +44309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -44362,7 +44362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -44427,7 +44427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -44516,7 +44516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -44599,7 +44599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -44682,7 +44682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -44704,7 +44704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -44754,7 +44754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44768,7 +44768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44782,7 +44782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44844,7 +44844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44889,7 +44889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -44940,7 +44940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -44985,7 +44985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45000,7 +45000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45036,7 +45036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45067,7 +45067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45113,7 +45113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45142,7 +45142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -45192,7 +45192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -45232,7 +45232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45259,7 +45259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -45297,7 +45297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -45329,7 +45329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -45482,7 +45482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45635,7 +45635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -45788,7 +45788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -45941,7 +45941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -46094,7 +46094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -46247,7 +46247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -46400,7 +46400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -46552,7 +46552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -46704,7 +46704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -46857,7 +46857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47010,7 +47010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -47163,7 +47163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -47316,7 +47316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -47475,7 +47475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47526,7 +47526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47577,7 +47577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47628,7 +47628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47679,7 +47679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -47693,7 +47693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -47707,7 +47707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -47727,7 +47727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -47821,7 +47821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -47835,7 +47835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -47849,7 +47849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -48179,7 +48179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -48199,7 +48199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -48213,7 +48213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -48241,7 +48241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAME70N19B.svd
+++ b/data/Atmel/ATSAME70N19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9279,7 +9279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9353,7 +9353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9398,7 +9398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9425,7 +9425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9476,7 +9476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9527,7 +9527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9578,7 +9578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9629,7 +9629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9672,7 +9672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9686,7 +9686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9702,7 +9702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9736,7 +9736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9834,7 +9834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9942,7 +9942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9962,7 +9962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9976,7 +9976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10008,7 +10008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10040,7 +10040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10072,7 +10072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10104,7 +10104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10169,7 +10169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10250,7 +10250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10313,7 +10313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10376,7 +10376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10439,7 +10439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10460,7 +10460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10502,7 +10502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10516,7 +10516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10548,7 +10548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10562,7 +10562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10576,7 +10576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10608,7 +10608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10622,7 +10622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10650,7 +10650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10688,7 +10688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10747,7 +10747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10797,7 +10797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10847,7 +10847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10886,7 +10886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11114,7 +11114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11142,7 +11142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11186,7 +11186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11231,7 +11231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11246,7 +11246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11260,7 +11260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11311,7 +11311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11373,7 +11373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11393,7 +11393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11602,7 +11602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11634,7 +11634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11672,7 +11672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11686,7 +11686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11748,7 +11748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11762,7 +11762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11795,7 +11795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11936,7 +11936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11956,7 +11956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12132,7 +12132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12308,7 +12308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12484,7 +12484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12504,7 +12504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12588,7 +12588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12608,7 +12608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12628,7 +12628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12642,7 +12642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12698,7 +12698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12898,7 +12898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13098,7 +13098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13130,7 +13130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13169,7 +13169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13183,7 +13183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13197,7 +13197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13229,7 +13229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13297,7 +13297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13311,7 +13311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13466,7 +13466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13498,7 +13498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13531,7 +13531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13588,7 +13588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13789,7 +13789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13989,7 +13989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14189,7 +14189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14390,7 +14390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14591,7 +14591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14791,7 +14791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -14991,7 +14991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15017,7 +15017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15056,7 +15056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15101,7 +15101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15302,7 +15302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15503,7 +15503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15704,7 +15704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -15905,7 +15905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16106,7 +16106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16307,7 +16307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -16508,7 +16508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -16709,7 +16709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -16910,7 +16910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17111,7 +17111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17312,7 +17312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -17512,7 +17512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -17713,7 +17713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -17914,7 +17914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18115,7 +18115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18316,7 +18316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -18517,7 +18517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -18718,7 +18718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -18919,7 +18919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19120,7 +19120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19321,7 +19321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -19522,7 +19522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19725,7 +19725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -19925,7 +19925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20126,7 +20126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20327,7 +20327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -20528,7 +20528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -20542,7 +20542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -20743,7 +20743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -20944,7 +20944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21145,7 +21145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21346,7 +21346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -21547,7 +21547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -21748,7 +21748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -21949,7 +21949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22150,7 +22150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22351,7 +22351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -22552,7 +22552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -22753,7 +22753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -22954,7 +22954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23155,7 +23155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23356,7 +23356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -23557,7 +23557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -23758,7 +23758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23786,7 +23786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23807,7 +23807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24007,7 +24007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24623,7 +24623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -24679,7 +24679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -24712,7 +24712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24745,7 +24745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24778,7 +24778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -24799,7 +24799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -24849,7 +24849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -24912,7 +24912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -24975,7 +24975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25044,7 +25044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25185,7 +25185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25326,7 +25326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -25779,7 +25779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -25801,7 +25801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25849,7 +25849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -25954,7 +25954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26059,7 +26059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26182,7 +26182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26287,7 +26287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -26445,7 +26445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -26549,7 +26549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -26564,7 +26564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -26592,7 +26592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -26613,7 +26613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -26760,7 +26760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -26907,7 +26907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27054,7 +27054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27126,7 +27126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27170,7 +27170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -27311,7 +27311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -27452,7 +27452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -27593,7 +27593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -27734,7 +27734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -27748,7 +27748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -27895,7 +27895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28042,7 +28042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -28189,7 +28189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -28336,7 +28336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -28370,7 +28370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28544,7 +28544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28577,7 +28577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28610,7 +28610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28643,7 +28643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28700,7 +28700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28757,7 +28757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28814,7 +28814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28871,7 +28871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28939,7 +28939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28954,7 +28954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28968,7 +28968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28988,7 +28988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29003,7 +29003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29120,7 +29120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29237,7 +29237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -29354,7 +29354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29471,7 +29471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29527,7 +29527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29583,7 +29583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29640,7 +29640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29697,7 +29697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -29754,7 +29754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -29811,7 +29811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -29837,7 +29837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -29858,7 +29858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -29873,7 +29873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -29929,7 +29929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -29963,7 +29963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30019,7 +30019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30039,7 +30039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30054,7 +30054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30086,7 +30086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30142,7 +30142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30225,7 +30225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30324,7 +30324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30357,7 +30357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30378,7 +30378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30422,7 +30422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30462,7 +30462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30656,7 +30656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30670,7 +30670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30685,7 +30685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30699,7 +30699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30714,7 +30714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30729,7 +30729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30749,7 +30749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30771,7 +30771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -30792,7 +30792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -30813,7 +30813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -30893,7 +30893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -30931,7 +30931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -30952,7 +30952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31032,7 +31032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31070,7 +31070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31118,7 +31118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31151,7 +31151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31271,7 +31271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31286,7 +31286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31301,7 +31301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31358,7 +31358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31409,7 +31409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31460,7 +31460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31511,7 +31511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31543,7 +31543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31557,7 +31557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31577,7 +31577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31755,7 +31755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31788,7 +31788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31803,7 +31803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31831,7 +31831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31871,7 +31871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31906,7 +31906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31967,7 +31967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32026,7 +32026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32055,7 +32055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32105,7 +32105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32139,7 +32139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32212,7 +32212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32426,7 +32426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32458,7 +32458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32496,7 +32496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32546,7 +32546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32578,7 +32578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32701,7 +32701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32746,7 +32746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32791,7 +32791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32836,7 +32836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -32881,7 +32881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -32933,7 +32933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32977,7 +32977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32991,7 +32991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33006,7 +33006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33046,7 +33046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33085,7 +33085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33177,7 +33177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33198,7 +33198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33248,7 +33248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33305,7 +33305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33356,7 +33356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33407,7 +33407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33460,7 +33460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33493,12 +33493,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -33590,7 +33590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33618,7 +33618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33658,7 +33658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -33697,7 +33697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -33711,7 +33711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33869,7 +33869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33971,7 +33971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34118,7 +34118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34226,7 +34226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34241,7 +34241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34256,7 +34256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34271,7 +34271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34285,7 +34285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34299,7 +34299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -34313,7 +34313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -34382,7 +34382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -34439,7 +34439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -34496,7 +34496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -34553,7 +34553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34581,7 +34581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34612,7 +34612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -34621,7 +34621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34682,7 +34682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34768,7 +34768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34872,7 +34872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35082,7 +35082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35622,7 +35622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36067,6 +36067,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -36101,7 +36129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36128,7 +36156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -36371,9 +36399,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -36807,7 +36835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -36827,7 +36855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -36842,7 +36870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -36857,7 +36885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -36871,7 +36899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -36885,7 +36913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -36899,7 +36927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -36974,7 +37002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37031,7 +37059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37088,7 +37116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37145,7 +37173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37198,7 +37226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37213,7 +37241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -37371,7 +37399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -37404,7 +37432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -37437,7 +37465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -37470,7 +37498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -37509,7 +37537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -37529,7 +37557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37624,7 +37652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37653,7 +37681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37668,7 +37696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37683,7 +37711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37698,7 +37726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37713,7 +37741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -37747,7 +37775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37888,7 +37916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37937,7 +37965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38005,7 +38033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38019,7 +38047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38051,7 +38079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38174,7 +38202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38279,7 +38307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38384,7 +38412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38489,7 +38517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38504,7 +38532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38519,7 +38547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38551,7 +38579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -38583,7 +38611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -38615,7 +38643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38643,7 +38671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -38699,7 +38727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -38756,7 +38784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -38865,7 +38893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -38916,7 +38944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -38967,7 +38995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39018,7 +39046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39069,7 +39097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39084,7 +39112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39099,7 +39127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39113,7 +39141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39158,7 +39186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -39984,6 +40012,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -40034,7 +40080,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -40075,80 +40167,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40246,12 +40264,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -40261,6 +40273,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40296,46 +40320,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -40364,6 +40348,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40417,7 +40419,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -40464,134 +40512,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40683,30 +40603,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -40716,6 +40612,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40751,64 +40659,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -40837,6 +40687,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40890,7 +40758,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -40937,134 +40851,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41156,30 +40942,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -41189,6 +40951,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41224,64 +40998,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -41310,6 +41026,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41387,7 +41121,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -41434,140 +41220,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41665,30 +41317,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -41698,6 +41326,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41728,64 +41368,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -42476,7 +42058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -42567,7 +42149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -42720,7 +42302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42771,7 +42353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42864,7 +42446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -43017,7 +42599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -43170,7 +42752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -43323,7 +42905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -43451,7 +43033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -43480,7 +43062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -43652,7 +43234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43817,9 +43399,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43983,9 +43565,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44149,9 +43731,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44315,7 +43897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -44374,9 +43956,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44434,9 +44016,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44494,9 +44076,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44554,7 +44136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -44619,9 +44201,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44685,9 +44267,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44751,9 +44333,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44817,7 +44399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -44918,9 +44500,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45026,9 +44608,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45128,9 +44710,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45230,7 +44812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -45331,9 +44913,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45439,9 +45021,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45541,9 +45123,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45643,7 +45225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -45732,9 +45314,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45822,9 +45404,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45912,9 +45494,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46006,7 +45588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46020,7 +45602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46034,7 +45616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46096,7 +45678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46141,7 +45723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -46196,7 +45778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -46305,43 +45887,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46349,7 +45931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -46400,7 +45982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -46449,43 +46031,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46493,7 +46075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -46602,43 +46184,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46646,7 +46228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -46755,43 +46337,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46799,7 +46381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -46908,43 +46490,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46952,7 +46534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -47068,7 +46650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -47094,7 +46676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -47126,7 +46708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -47158,7 +46740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -47180,7 +46762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -47340,9 +46922,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -47507,7 +47089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -47656,9 +47238,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47806,9 +47388,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47956,9 +47538,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48106,7 +47688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -48159,9 +47741,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48213,9 +47795,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48267,9 +47849,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48321,7 +47903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -48386,9 +47968,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48452,9 +48034,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48518,9 +48100,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48584,7 +48166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -48673,9 +48255,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48763,9 +48345,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48853,9 +48435,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48943,7 +48525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -49026,9 +48608,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49110,9 +48692,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49194,9 +48776,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49278,7 +48860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -49361,9 +48943,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49445,9 +49027,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49529,9 +49111,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49613,7 +49195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -49635,7 +49217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -49685,7 +49267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49699,7 +49281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -49713,7 +49295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -49775,7 +49357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -49820,7 +49402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -49877,7 +49459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -49922,7 +49504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -49937,7 +49519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -49973,7 +49555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -50004,7 +49586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -50050,7 +49632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50079,7 +49661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50129,7 +49711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50169,7 +49751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50196,7 +49778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50234,7 +49816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50266,7 +49848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -50419,7 +50001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -50572,7 +50154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -50725,7 +50307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -50878,7 +50460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -51031,7 +50613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -51184,7 +50766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -51337,7 +50919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -51489,7 +51071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -51641,7 +51223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -51794,7 +51376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -51947,7 +51529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -52100,7 +51682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -52253,7 +51835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -52412,7 +51994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -52463,7 +52045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -52514,7 +52096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -52565,7 +52147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -52616,7 +52198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -52630,7 +52212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -52644,7 +52226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -52664,7 +52246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -52758,7 +52340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -52772,7 +52354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -52786,7 +52368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -53349,7 +52931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -53369,7 +52951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -53383,7 +52965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -53411,7 +52993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -55300,6 +54882,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAME70N20.svd
+++ b/data/Atmel/ATSAME70N20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4154,7 +4154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4258,7 +4258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4437,7 +4437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4458,7 +4458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4472,7 +4472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4574,7 +4574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4624,7 +4624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4638,7 +4638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4684,7 +4684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4831,7 +4831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4984,7 +4984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5137,7 +5137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5289,7 +5289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5339,7 +5339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5354,7 +5354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5368,7 +5368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5408,7 +5408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5422,7 +5422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5457,7 +5457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5471,7 +5471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5546,7 +5546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5566,7 +5566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5618,7 +5618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5658,7 +5658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5672,7 +5672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5686,7 +5686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5700,7 +5700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5714,7 +5714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6073,7 +6073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6103,7 +6103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6118,7 +6118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6133,7 +6133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6148,7 +6148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6163,7 +6163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6178,7 +6178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6193,7 +6193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6208,7 +6208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6223,7 +6223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6238,7 +6238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6253,7 +6253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6268,7 +6268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6328,7 +6328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6343,7 +6343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6358,7 +6358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6373,7 +6373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6388,7 +6388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6403,7 +6403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6418,7 +6418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6433,7 +6433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6448,7 +6448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6463,7 +6463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6477,7 +6477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6491,7 +6491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6519,7 +6519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6540,7 +6540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6566,7 +6566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6581,7 +6581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6596,7 +6596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6611,7 +6611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6626,7 +6626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6641,7 +6641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6656,7 +6656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6671,7 +6671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6688,7 +6688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6741,7 +6741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6757,7 +6757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6773,7 +6773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6787,7 +6787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6837,7 +6837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6877,7 +6877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6953,7 +6953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7006,7 +7006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7059,7 +7059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7125,7 +7125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7145,7 +7145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7188,7 +7188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7208,7 +7208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7251,7 +7251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7271,7 +7271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7314,7 +7314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7334,7 +7334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7377,7 +7377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7397,7 +7397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7460,7 +7460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7503,7 +7503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7523,7 +7523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7566,7 +7566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7586,7 +7586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7629,7 +7629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7649,7 +7649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7692,7 +7692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7712,7 +7712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7755,7 +7755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7775,7 +7775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7818,7 +7818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7838,7 +7838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7881,7 +7881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7901,7 +7901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7944,7 +7944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7964,7 +7964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8007,7 +8007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8027,7 +8027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8070,7 +8070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8090,7 +8090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8133,7 +8133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8153,7 +8153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8196,7 +8196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8216,7 +8216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8259,7 +8259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8279,7 +8279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8342,7 +8342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8385,7 +8385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8405,7 +8405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8448,7 +8448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8468,7 +8468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8511,7 +8511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8531,7 +8531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8574,7 +8574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8687,7 +8687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8776,7 +8776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8839,7 +8839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8885,7 +8885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8899,7 +8899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9156,7 +9156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9176,7 +9176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9241,7 +9241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9256,7 +9256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9271,7 +9271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9286,7 +9286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9439,7 +9439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9592,7 +9592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9898,7 +9898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9946,7 +9946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9978,7 +9978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10006,7 +10006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10029,7 +10029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10062,7 +10062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10181,7 +10181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10208,7 +10208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10259,7 +10259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10310,7 +10310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10361,7 +10361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10412,7 +10412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10455,7 +10455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10469,7 +10469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10485,7 +10485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10519,7 +10519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10617,7 +10617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10725,7 +10725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10745,7 +10745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10759,7 +10759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10791,7 +10791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10823,7 +10823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10855,7 +10855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10887,7 +10887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10919,7 +10919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11033,7 +11033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11096,7 +11096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11159,7 +11159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11222,7 +11222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11243,7 +11243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11264,7 +11264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11285,7 +11285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11299,7 +11299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11331,7 +11331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11345,7 +11345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11359,7 +11359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11391,7 +11391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11405,7 +11405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11433,7 +11433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11471,7 +11471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11530,7 +11530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11580,7 +11580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11630,7 +11630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11663,7 +11663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11833,7 +11833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11861,7 +11861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11905,7 +11905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11919,7 +11919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11976,7 +11976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12044,7 +12044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12064,7 +12064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12277,7 +12277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12309,7 +12309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12347,7 +12347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12361,7 +12361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12423,7 +12423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12437,7 +12437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12470,7 +12470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -12599,7 +12599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12787,7 +12787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12975,7 +12975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13163,7 +13163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13183,7 +13183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13267,7 +13267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13287,7 +13287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13307,7 +13307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13321,7 +13321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13377,7 +13377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13577,7 +13577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13777,7 +13777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13809,7 +13809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13848,7 +13848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13862,7 +13862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13876,7 +13876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13908,7 +13908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13976,7 +13976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13990,7 +13990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14145,7 +14145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14177,7 +14177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14210,7 +14210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14267,7 +14267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14468,7 +14468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14668,7 +14668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14868,7 +14868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15069,7 +15069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15270,7 +15270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15470,7 +15470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15670,7 +15670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15696,7 +15696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15735,7 +15735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15780,7 +15780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15981,7 +15981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16182,7 +16182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16383,7 +16383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16584,7 +16584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16785,7 +16785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16986,7 +16986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17187,7 +17187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17388,7 +17388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17589,7 +17589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17790,7 +17790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17991,7 +17991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18191,7 +18191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18392,7 +18392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18593,7 +18593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18794,7 +18794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18995,7 +18995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19196,7 +19196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19397,7 +19397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19598,7 +19598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19799,7 +19799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -20000,7 +20000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20201,7 +20201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20404,7 +20404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20604,7 +20604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20805,7 +20805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -21006,7 +21006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21207,7 +21207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21221,7 +21221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21422,7 +21422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21623,7 +21623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21824,7 +21824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -22025,7 +22025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22226,7 +22226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22427,7 +22427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22628,7 +22628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22829,7 +22829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -23030,7 +23030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23231,7 +23231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23432,7 +23432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23633,7 +23633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23834,7 +23834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -24035,7 +24035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24236,7 +24236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24437,7 +24437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24465,7 +24465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24486,7 +24486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24686,7 +24686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25302,7 +25302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25358,7 +25358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25391,7 +25391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25424,7 +25424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25457,7 +25457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25478,7 +25478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25528,7 +25528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25585,7 +25585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25642,7 +25642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25705,7 +25705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25864,7 +25864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -26023,7 +26023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26373,7 +26373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26494,7 +26494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26516,7 +26516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26564,7 +26564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26663,7 +26663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26762,7 +26762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26879,7 +26879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26978,7 +26978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27136,7 +27136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27240,7 +27240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27255,7 +27255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27283,7 +27283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27304,7 +27304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27463,7 +27463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27622,7 +27622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27781,7 +27781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27853,7 +27853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27897,7 +27897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28056,7 +28056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28215,7 +28215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28374,7 +28374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28533,7 +28533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28547,7 +28547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28706,7 +28706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28865,7 +28865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29024,7 +29024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29183,7 +29183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29217,7 +29217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29391,7 +29391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29424,7 +29424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29457,7 +29457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29490,7 +29490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29547,7 +29547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29604,7 +29604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29661,7 +29661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29718,7 +29718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29786,7 +29786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29801,7 +29801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29815,7 +29815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29835,7 +29835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29850,7 +29850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29967,7 +29967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30084,7 +30084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30201,7 +30201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30318,7 +30318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30374,7 +30374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30430,7 +30430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30487,7 +30487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30544,7 +30544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30601,7 +30601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30658,7 +30658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30684,7 +30684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30705,7 +30705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30720,7 +30720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30776,7 +30776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30810,7 +30810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30866,7 +30866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30886,7 +30886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30901,7 +30901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30933,7 +30933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30989,7 +30989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31072,7 +31072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31171,7 +31171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31191,7 +31191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31212,7 +31212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31256,7 +31256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31296,7 +31296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31438,7 +31438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31452,7 +31452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31467,7 +31467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31481,7 +31481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31496,7 +31496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31511,7 +31511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31531,7 +31531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31553,7 +31553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31574,7 +31574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31595,7 +31595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31675,7 +31675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31713,7 +31713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31734,7 +31734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31814,7 +31814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31852,7 +31852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31900,7 +31900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31933,7 +31933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32053,7 +32053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32068,7 +32068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32083,7 +32083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32140,7 +32140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32191,7 +32191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32242,7 +32242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32293,7 +32293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32325,7 +32325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32339,7 +32339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32359,7 +32359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32537,7 +32537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32570,7 +32570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32585,7 +32585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32613,7 +32613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32653,7 +32653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32688,7 +32688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32749,7 +32749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32808,7 +32808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32837,7 +32837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32887,7 +32887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32921,7 +32921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32994,7 +32994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33208,7 +33208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33240,7 +33240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33278,7 +33278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33328,7 +33328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33360,7 +33360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33483,7 +33483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33528,7 +33528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33573,7 +33573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33618,7 +33618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33663,7 +33663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33715,7 +33715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33759,7 +33759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33773,7 +33773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33788,7 +33788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33828,7 +33828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33867,7 +33867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33923,7 +33923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33944,7 +33944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33971,7 +33971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34028,7 +34028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34079,7 +34079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34130,7 +34130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34183,7 +34183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34287,7 +34287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34315,7 +34315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34355,7 +34355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34394,7 +34394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34408,7 +34408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34566,7 +34566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34668,7 +34668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34815,7 +34815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34923,7 +34923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34938,7 +34938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34953,7 +34953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34968,7 +34968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34982,7 +34982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34996,7 +34996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35010,7 +35010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35079,7 +35079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35136,7 +35136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35193,7 +35193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35250,7 +35250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35278,7 +35278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35318,7 +35318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35379,7 +35379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35465,7 +35465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35569,7 +35569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35779,7 +35779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36319,7 +36319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36798,7 +36798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36825,7 +36825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37068,7 +37068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37088,7 +37088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37103,7 +37103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37118,7 +37118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37132,7 +37132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37146,7 +37146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37160,7 +37160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37235,7 +37235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37292,7 +37292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37349,7 +37349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37406,7 +37406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37459,7 +37459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37474,7 +37474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -37620,7 +37620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -37647,7 +37647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -37674,7 +37674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -37701,7 +37701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -37734,7 +37734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -37754,7 +37754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37849,7 +37849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37878,7 +37878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37893,7 +37893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37908,7 +37908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37923,7 +37923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37938,7 +37938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -37972,7 +37972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38113,7 +38113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38162,7 +38162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38230,7 +38230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38244,7 +38244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38276,7 +38276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38399,7 +38399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38504,7 +38504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38609,7 +38609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38714,7 +38714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38729,7 +38729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38744,7 +38744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38776,7 +38776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -38808,7 +38808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -38840,7 +38840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38868,7 +38868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -38924,7 +38924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -38981,7 +38981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39090,7 +39090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39141,7 +39141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39192,7 +39192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39243,7 +39243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39294,7 +39294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39309,7 +39309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39324,7 +39324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39338,7 +39338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39383,7 +39383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40966,7 +40966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41047,7 +41047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41212,7 +41212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -41263,7 +41263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -41356,7 +41356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -41521,7 +41521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41686,7 +41686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41851,7 +41851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -41979,7 +41979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42008,7 +42008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42180,7 +42180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -42345,7 +42345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -42404,7 +42404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -42469,7 +42469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42570,7 +42570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -42671,7 +42671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -42764,7 +42764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42778,7 +42778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42792,7 +42792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42854,7 +42854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42899,7 +42899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -42944,7 +42944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43109,7 +43109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43160,7 +43160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43253,7 +43253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -43418,7 +43418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -43583,7 +43583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -43748,7 +43748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -43864,7 +43864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -43890,7 +43890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -43922,7 +43922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -43954,7 +43954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -43976,7 +43976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44136,7 +44136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -44285,7 +44285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -44338,7 +44338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -44403,7 +44403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -44492,7 +44492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -44575,7 +44575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -44658,7 +44658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -44680,7 +44680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -44730,7 +44730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44744,7 +44744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44758,7 +44758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44820,7 +44820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44865,7 +44865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -44916,7 +44916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -44961,7 +44961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -44976,7 +44976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45012,7 +45012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45043,7 +45043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45089,7 +45089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45118,7 +45118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -45168,7 +45168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -45208,7 +45208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45235,7 +45235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -45273,7 +45273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -45305,7 +45305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -45458,7 +45458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45611,7 +45611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -45764,7 +45764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -45917,7 +45917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -46070,7 +46070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -46223,7 +46223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -46376,7 +46376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -46528,7 +46528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -46680,7 +46680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -46833,7 +46833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -46986,7 +46986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -47139,7 +47139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -47292,7 +47292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -47451,7 +47451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47502,7 +47502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47553,7 +47553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47604,7 +47604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47655,7 +47655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -47669,7 +47669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -47683,7 +47683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -47703,7 +47703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -47797,7 +47797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -47811,7 +47811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -47825,7 +47825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -48155,7 +48155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -48175,7 +48175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -48189,7 +48189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -48217,7 +48217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -48417,7 +48417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAME70N20B.svd
+++ b/data/Atmel/ATSAME70N20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9279,7 +9279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9353,7 +9353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9398,7 +9398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9425,7 +9425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9476,7 +9476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9527,7 +9527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9578,7 +9578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9629,7 +9629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9672,7 +9672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9686,7 +9686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9702,7 +9702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9736,7 +9736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9834,7 +9834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9942,7 +9942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9962,7 +9962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9976,7 +9976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10008,7 +10008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10040,7 +10040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10072,7 +10072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10104,7 +10104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10169,7 +10169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10250,7 +10250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10313,7 +10313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10376,7 +10376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10439,7 +10439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10460,7 +10460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10502,7 +10502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10516,7 +10516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10548,7 +10548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10562,7 +10562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10576,7 +10576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10608,7 +10608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10622,7 +10622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10650,7 +10650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10688,7 +10688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10747,7 +10747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10797,7 +10797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10847,7 +10847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10886,7 +10886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11114,7 +11114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11142,7 +11142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11186,7 +11186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11231,7 +11231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11246,7 +11246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11260,7 +11260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11311,7 +11311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11373,7 +11373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11393,7 +11393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11602,7 +11602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11634,7 +11634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11672,7 +11672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11686,7 +11686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11748,7 +11748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11762,7 +11762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11795,7 +11795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11936,7 +11936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11956,7 +11956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12132,7 +12132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12308,7 +12308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12484,7 +12484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12504,7 +12504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12588,7 +12588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12608,7 +12608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12628,7 +12628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12642,7 +12642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12698,7 +12698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12898,7 +12898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13098,7 +13098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13130,7 +13130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13169,7 +13169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13183,7 +13183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13197,7 +13197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13229,7 +13229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13297,7 +13297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13311,7 +13311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13466,7 +13466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13498,7 +13498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13531,7 +13531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13588,7 +13588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13789,7 +13789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13989,7 +13989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14189,7 +14189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14390,7 +14390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14591,7 +14591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14791,7 +14791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -14991,7 +14991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15017,7 +15017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15056,7 +15056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15101,7 +15101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15302,7 +15302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15503,7 +15503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15704,7 +15704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -15905,7 +15905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16106,7 +16106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16307,7 +16307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -16508,7 +16508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -16709,7 +16709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -16910,7 +16910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17111,7 +17111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17312,7 +17312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -17512,7 +17512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -17713,7 +17713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -17914,7 +17914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18115,7 +18115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18316,7 +18316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -18517,7 +18517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -18718,7 +18718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -18919,7 +18919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19120,7 +19120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19321,7 +19321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -19522,7 +19522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19725,7 +19725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -19925,7 +19925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20126,7 +20126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20327,7 +20327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -20528,7 +20528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -20542,7 +20542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -20743,7 +20743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -20944,7 +20944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21145,7 +21145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21346,7 +21346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -21547,7 +21547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -21748,7 +21748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -21949,7 +21949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22150,7 +22150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22351,7 +22351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -22552,7 +22552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -22753,7 +22753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -22954,7 +22954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23155,7 +23155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23356,7 +23356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -23557,7 +23557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -23758,7 +23758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23786,7 +23786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23807,7 +23807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24007,7 +24007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24623,7 +24623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -24679,7 +24679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -24712,7 +24712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24745,7 +24745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24778,7 +24778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -24799,7 +24799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -24849,7 +24849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -24912,7 +24912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -24975,7 +24975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25044,7 +25044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25185,7 +25185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25326,7 +25326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -25779,7 +25779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -25801,7 +25801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25849,7 +25849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -25954,7 +25954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26059,7 +26059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26182,7 +26182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26287,7 +26287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -26445,7 +26445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -26549,7 +26549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -26564,7 +26564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -26592,7 +26592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -26613,7 +26613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -26760,7 +26760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -26907,7 +26907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27054,7 +27054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27126,7 +27126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27170,7 +27170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -27311,7 +27311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -27452,7 +27452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -27593,7 +27593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -27734,7 +27734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -27748,7 +27748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -27895,7 +27895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28042,7 +28042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -28189,7 +28189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -28336,7 +28336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -28370,7 +28370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28544,7 +28544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28577,7 +28577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28610,7 +28610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28643,7 +28643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28700,7 +28700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28757,7 +28757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28814,7 +28814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28871,7 +28871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28939,7 +28939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28954,7 +28954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28968,7 +28968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28988,7 +28988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29003,7 +29003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29120,7 +29120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29237,7 +29237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -29354,7 +29354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29471,7 +29471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29527,7 +29527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29583,7 +29583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29640,7 +29640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29697,7 +29697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -29754,7 +29754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -29811,7 +29811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -29837,7 +29837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -29858,7 +29858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -29873,7 +29873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -29929,7 +29929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -29963,7 +29963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30019,7 +30019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30039,7 +30039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30054,7 +30054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30086,7 +30086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30142,7 +30142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30225,7 +30225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30324,7 +30324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30357,7 +30357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30378,7 +30378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30422,7 +30422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30462,7 +30462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30656,7 +30656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30670,7 +30670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30685,7 +30685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30699,7 +30699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30714,7 +30714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30729,7 +30729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30749,7 +30749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30771,7 +30771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -30792,7 +30792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -30813,7 +30813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -30893,7 +30893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -30931,7 +30931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -30952,7 +30952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31032,7 +31032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31070,7 +31070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31118,7 +31118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31151,7 +31151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31271,7 +31271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31286,7 +31286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31301,7 +31301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31358,7 +31358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31409,7 +31409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31460,7 +31460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31511,7 +31511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31543,7 +31543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31557,7 +31557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31577,7 +31577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31755,7 +31755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31788,7 +31788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31803,7 +31803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31831,7 +31831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31871,7 +31871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31906,7 +31906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31967,7 +31967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32026,7 +32026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32055,7 +32055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32105,7 +32105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32139,7 +32139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32212,7 +32212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32426,7 +32426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32458,7 +32458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32496,7 +32496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32546,7 +32546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32578,7 +32578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32701,7 +32701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32746,7 +32746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32791,7 +32791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32836,7 +32836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -32881,7 +32881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -32933,7 +32933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32977,7 +32977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32991,7 +32991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33006,7 +33006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33046,7 +33046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33085,7 +33085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33177,7 +33177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33198,7 +33198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33248,7 +33248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33305,7 +33305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33356,7 +33356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33407,7 +33407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33460,7 +33460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33493,12 +33493,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -33590,7 +33590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33618,7 +33618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33658,7 +33658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -33697,7 +33697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -33711,7 +33711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33869,7 +33869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33971,7 +33971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34118,7 +34118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34226,7 +34226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34241,7 +34241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34256,7 +34256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34271,7 +34271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34285,7 +34285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34299,7 +34299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -34313,7 +34313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -34382,7 +34382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -34439,7 +34439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -34496,7 +34496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -34553,7 +34553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34581,7 +34581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34612,7 +34612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -34621,7 +34621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34682,7 +34682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34768,7 +34768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34872,7 +34872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35082,7 +35082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35622,7 +35622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36067,6 +36067,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -36101,7 +36129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36128,7 +36156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -36371,9 +36399,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -36807,7 +36835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -36827,7 +36855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -36842,7 +36870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -36857,7 +36885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -36871,7 +36899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -36885,7 +36913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -36899,7 +36927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -36974,7 +37002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37031,7 +37059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37088,7 +37116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37145,7 +37173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37198,7 +37226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37213,7 +37241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -37371,7 +37399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -37404,7 +37432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -37437,7 +37465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -37470,7 +37498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -37509,7 +37537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -37529,7 +37557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37624,7 +37652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37653,7 +37681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37668,7 +37696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37683,7 +37711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37698,7 +37726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37713,7 +37741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -37747,7 +37775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37888,7 +37916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37937,7 +37965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38005,7 +38033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38019,7 +38047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38051,7 +38079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38174,7 +38202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38279,7 +38307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38384,7 +38412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38489,7 +38517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38504,7 +38532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38519,7 +38547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38551,7 +38579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -38583,7 +38611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -38615,7 +38643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38643,7 +38671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -38699,7 +38727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -38756,7 +38784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -38865,7 +38893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -38916,7 +38944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -38967,7 +38995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39018,7 +39046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39069,7 +39097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39084,7 +39112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39099,7 +39127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39113,7 +39141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39158,7 +39186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -39984,6 +40012,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -40034,7 +40080,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -40075,80 +40167,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40246,12 +40264,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -40261,6 +40273,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40296,46 +40320,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -40364,6 +40348,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40417,7 +40419,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -40464,134 +40512,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40683,30 +40603,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -40716,6 +40612,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40751,64 +40659,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -40837,6 +40687,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40890,7 +40758,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -40937,134 +40851,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41156,30 +40942,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -41189,6 +40951,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41224,64 +40998,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -41310,6 +41026,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41387,7 +41121,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -41434,140 +41220,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41665,30 +41317,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -41698,6 +41326,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41728,64 +41368,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -42476,7 +42058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -42567,7 +42149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -42720,7 +42302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42771,7 +42353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42864,7 +42446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -43017,7 +42599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -43170,7 +42752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -43323,7 +42905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -43451,7 +43033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -43480,7 +43062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -43652,7 +43234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43817,9 +43399,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43983,9 +43565,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44149,9 +43731,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44315,7 +43897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -44374,9 +43956,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44434,9 +44016,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44494,9 +44076,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44554,7 +44136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -44619,9 +44201,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44685,9 +44267,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44751,9 +44333,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44817,7 +44399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -44918,9 +44500,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45026,9 +44608,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45128,9 +44710,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45230,7 +44812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -45331,9 +44913,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45439,9 +45021,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45541,9 +45123,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45643,7 +45225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -45732,9 +45314,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45822,9 +45404,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45912,9 +45494,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46006,7 +45588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46020,7 +45602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46034,7 +45616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46096,7 +45678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46141,7 +45723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -46196,7 +45778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -46305,43 +45887,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46349,7 +45931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -46400,7 +45982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -46449,43 +46031,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46493,7 +46075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -46602,43 +46184,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46646,7 +46228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -46755,43 +46337,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46799,7 +46381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -46908,43 +46490,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46952,7 +46534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -47068,7 +46650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -47094,7 +46676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -47126,7 +46708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -47158,7 +46740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -47180,7 +46762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -47340,9 +46922,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -47507,7 +47089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -47656,9 +47238,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47806,9 +47388,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47956,9 +47538,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48106,7 +47688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -48159,9 +47741,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48213,9 +47795,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48267,9 +47849,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48321,7 +47903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -48386,9 +47968,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48452,9 +48034,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48518,9 +48100,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48584,7 +48166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -48673,9 +48255,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48763,9 +48345,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48853,9 +48435,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48943,7 +48525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -49026,9 +48608,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49110,9 +48692,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49194,9 +48776,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49278,7 +48860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -49361,9 +48943,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49445,9 +49027,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49529,9 +49111,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49613,7 +49195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -49635,7 +49217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -49685,7 +49267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49699,7 +49281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -49713,7 +49295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -49775,7 +49357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -49820,7 +49402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -49877,7 +49459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -49922,7 +49504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -49937,7 +49519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -49973,7 +49555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -50004,7 +49586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -50050,7 +49632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50079,7 +49661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50129,7 +49711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50169,7 +49751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50196,7 +49778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50234,7 +49816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50266,7 +49848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -50419,7 +50001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -50572,7 +50154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -50725,7 +50307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -50878,7 +50460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -51031,7 +50613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -51184,7 +50766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -51337,7 +50919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -51489,7 +51071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -51641,7 +51223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -51794,7 +51376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -51947,7 +51529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -52100,7 +51682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -52253,7 +51835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -52412,7 +51994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -52463,7 +52045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -52514,7 +52096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -52565,7 +52147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -52616,7 +52198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -52630,7 +52212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -52644,7 +52226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -52664,7 +52246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -52758,7 +52340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -52772,7 +52354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -52786,7 +52368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -53349,7 +52931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -53369,7 +52951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -53383,7 +52965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -53411,7 +52993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -53611,7 +53193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -55500,6 +55082,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAME70N21.svd
+++ b/data/Atmel/ATSAME70N21.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4154,7 +4154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4258,7 +4258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4437,7 +4437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4458,7 +4458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4472,7 +4472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4574,7 +4574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4624,7 +4624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4638,7 +4638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4684,7 +4684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4831,7 +4831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4984,7 +4984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5137,7 +5137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5289,7 +5289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5339,7 +5339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5354,7 +5354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5368,7 +5368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5408,7 +5408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5422,7 +5422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5457,7 +5457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5471,7 +5471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5546,7 +5546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5566,7 +5566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5618,7 +5618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5658,7 +5658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5672,7 +5672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5686,7 +5686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5700,7 +5700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5714,7 +5714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6073,7 +6073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6103,7 +6103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6118,7 +6118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6133,7 +6133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6148,7 +6148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6163,7 +6163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6178,7 +6178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6193,7 +6193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6208,7 +6208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6223,7 +6223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6238,7 +6238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6253,7 +6253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6268,7 +6268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6328,7 +6328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6343,7 +6343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6358,7 +6358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6373,7 +6373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6388,7 +6388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6403,7 +6403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6418,7 +6418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6433,7 +6433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6448,7 +6448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6463,7 +6463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6477,7 +6477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6491,7 +6491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6519,7 +6519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6540,7 +6540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6566,7 +6566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6581,7 +6581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6596,7 +6596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6611,7 +6611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6626,7 +6626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6641,7 +6641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6656,7 +6656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6671,7 +6671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6688,7 +6688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6741,7 +6741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6757,7 +6757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6773,7 +6773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6787,7 +6787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6837,7 +6837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6877,7 +6877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6953,7 +6953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7006,7 +7006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7059,7 +7059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7125,7 +7125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7145,7 +7145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7188,7 +7188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7208,7 +7208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7251,7 +7251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7271,7 +7271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7314,7 +7314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7334,7 +7334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7377,7 +7377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7397,7 +7397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7460,7 +7460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7503,7 +7503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7523,7 +7523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7566,7 +7566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7586,7 +7586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7629,7 +7629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7649,7 +7649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7692,7 +7692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7712,7 +7712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7755,7 +7755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7775,7 +7775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7818,7 +7818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7838,7 +7838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7881,7 +7881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7901,7 +7901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7944,7 +7944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7964,7 +7964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8007,7 +8007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8027,7 +8027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8070,7 +8070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8090,7 +8090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8133,7 +8133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8153,7 +8153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8196,7 +8196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8216,7 +8216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8259,7 +8259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8279,7 +8279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8342,7 +8342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8385,7 +8385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8405,7 +8405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8448,7 +8448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8468,7 +8468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8511,7 +8511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8531,7 +8531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8574,7 +8574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8687,7 +8687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8776,7 +8776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8839,7 +8839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8885,7 +8885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8899,7 +8899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9156,7 +9156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9176,7 +9176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9241,7 +9241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9256,7 +9256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9271,7 +9271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9286,7 +9286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9439,7 +9439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9592,7 +9592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9898,7 +9898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9946,7 +9946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9978,7 +9978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10006,7 +10006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10029,7 +10029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10062,7 +10062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10181,7 +10181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10208,7 +10208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10259,7 +10259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10310,7 +10310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10361,7 +10361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10412,7 +10412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10455,7 +10455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10469,7 +10469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10485,7 +10485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10519,7 +10519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10617,7 +10617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10725,7 +10725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10745,7 +10745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10759,7 +10759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10791,7 +10791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10823,7 +10823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10855,7 +10855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10887,7 +10887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10919,7 +10919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11033,7 +11033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11096,7 +11096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11159,7 +11159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11222,7 +11222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11243,7 +11243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11264,7 +11264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11285,7 +11285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11299,7 +11299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11331,7 +11331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11345,7 +11345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11359,7 +11359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11391,7 +11391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11405,7 +11405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11433,7 +11433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11471,7 +11471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11530,7 +11530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11580,7 +11580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11630,7 +11630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11663,7 +11663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11833,7 +11833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11861,7 +11861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11905,7 +11905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11919,7 +11919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11976,7 +11976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12044,7 +12044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12064,7 +12064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12277,7 +12277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12309,7 +12309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12347,7 +12347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12361,7 +12361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12423,7 +12423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12437,7 +12437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12470,7 +12470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -12599,7 +12599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12787,7 +12787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12975,7 +12975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13163,7 +13163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13183,7 +13183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13267,7 +13267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13287,7 +13287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13307,7 +13307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13321,7 +13321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13377,7 +13377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13577,7 +13577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13777,7 +13777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13809,7 +13809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13848,7 +13848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13862,7 +13862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13876,7 +13876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13908,7 +13908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13976,7 +13976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13990,7 +13990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14145,7 +14145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14177,7 +14177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14210,7 +14210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14267,7 +14267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14468,7 +14468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14668,7 +14668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14868,7 +14868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15069,7 +15069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15270,7 +15270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15470,7 +15470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15670,7 +15670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15696,7 +15696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15735,7 +15735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15780,7 +15780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15981,7 +15981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16182,7 +16182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16383,7 +16383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16584,7 +16584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16785,7 +16785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16986,7 +16986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17187,7 +17187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17388,7 +17388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17589,7 +17589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17790,7 +17790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17991,7 +17991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18191,7 +18191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18392,7 +18392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18593,7 +18593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18794,7 +18794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18995,7 +18995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19196,7 +19196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19397,7 +19397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19598,7 +19598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19799,7 +19799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -20000,7 +20000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20201,7 +20201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20404,7 +20404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20604,7 +20604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20805,7 +20805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -21006,7 +21006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21207,7 +21207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21221,7 +21221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21422,7 +21422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21623,7 +21623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21824,7 +21824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -22025,7 +22025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22226,7 +22226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22427,7 +22427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22628,7 +22628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22829,7 +22829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -23030,7 +23030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23231,7 +23231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23432,7 +23432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23633,7 +23633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23834,7 +23834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -24035,7 +24035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24236,7 +24236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24437,7 +24437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24465,7 +24465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24486,7 +24486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24686,7 +24686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25302,7 +25302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25358,7 +25358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25391,7 +25391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25424,7 +25424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25457,7 +25457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25478,7 +25478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25528,7 +25528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25585,7 +25585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25642,7 +25642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25705,7 +25705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25864,7 +25864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -26023,7 +26023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26373,7 +26373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26494,7 +26494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26516,7 +26516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26564,7 +26564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26663,7 +26663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26762,7 +26762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26879,7 +26879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26978,7 +26978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27136,7 +27136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27240,7 +27240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27255,7 +27255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27283,7 +27283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27304,7 +27304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27463,7 +27463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27622,7 +27622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27781,7 +27781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27853,7 +27853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27897,7 +27897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28056,7 +28056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28215,7 +28215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28374,7 +28374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28533,7 +28533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28547,7 +28547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28706,7 +28706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28865,7 +28865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29024,7 +29024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29183,7 +29183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29217,7 +29217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29391,7 +29391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29424,7 +29424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29457,7 +29457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29490,7 +29490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29547,7 +29547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29604,7 +29604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29661,7 +29661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29718,7 +29718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29786,7 +29786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29801,7 +29801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29815,7 +29815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29835,7 +29835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29850,7 +29850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29967,7 +29967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30084,7 +30084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30201,7 +30201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30318,7 +30318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30374,7 +30374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30430,7 +30430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30487,7 +30487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30544,7 +30544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30601,7 +30601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30658,7 +30658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30684,7 +30684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30705,7 +30705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30720,7 +30720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30776,7 +30776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30810,7 +30810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30866,7 +30866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30886,7 +30886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30901,7 +30901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30933,7 +30933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30989,7 +30989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31072,7 +31072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31171,7 +31171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31191,7 +31191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31212,7 +31212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31256,7 +31256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31296,7 +31296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31438,7 +31438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31452,7 +31452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31467,7 +31467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31481,7 +31481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31496,7 +31496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31511,7 +31511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31531,7 +31531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31553,7 +31553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31574,7 +31574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31595,7 +31595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31675,7 +31675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31713,7 +31713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31734,7 +31734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31814,7 +31814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31852,7 +31852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31900,7 +31900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31933,7 +31933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32053,7 +32053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32068,7 +32068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32083,7 +32083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32140,7 +32140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32191,7 +32191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32242,7 +32242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32293,7 +32293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32325,7 +32325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32339,7 +32339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32359,7 +32359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32537,7 +32537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32570,7 +32570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32585,7 +32585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32613,7 +32613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32653,7 +32653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32688,7 +32688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32749,7 +32749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32808,7 +32808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32837,7 +32837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32887,7 +32887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32921,7 +32921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32994,7 +32994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33208,7 +33208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33240,7 +33240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33278,7 +33278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33328,7 +33328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33360,7 +33360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33483,7 +33483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33528,7 +33528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33573,7 +33573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33618,7 +33618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33663,7 +33663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33715,7 +33715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33759,7 +33759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33773,7 +33773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33788,7 +33788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33828,7 +33828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33891,7 +33891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33947,7 +33947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33968,7 +33968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33995,7 +33995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34052,7 +34052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34103,7 +34103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34154,7 +34154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34207,7 +34207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34311,7 +34311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34339,7 +34339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34379,7 +34379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34418,7 +34418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34432,7 +34432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34590,7 +34590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34692,7 +34692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34839,7 +34839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34947,7 +34947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34962,7 +34962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34977,7 +34977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34992,7 +34992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35006,7 +35006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35020,7 +35020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35034,7 +35034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35103,7 +35103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35160,7 +35160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35217,7 +35217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35274,7 +35274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35302,7 +35302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35342,7 +35342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35403,7 +35403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35489,7 +35489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35593,7 +35593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35803,7 +35803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36343,7 +36343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36822,7 +36822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36849,7 +36849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37092,7 +37092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37112,7 +37112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37127,7 +37127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37142,7 +37142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37156,7 +37156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37170,7 +37170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37184,7 +37184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37259,7 +37259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37316,7 +37316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37373,7 +37373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37430,7 +37430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37483,7 +37483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37498,7 +37498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -37644,7 +37644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -37671,7 +37671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -37698,7 +37698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -37725,7 +37725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -37758,7 +37758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -37778,7 +37778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37873,7 +37873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37902,7 +37902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37917,7 +37917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37932,7 +37932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37947,7 +37947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37962,7 +37962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -37996,7 +37996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38137,7 +38137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38186,7 +38186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38254,7 +38254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38268,7 +38268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38300,7 +38300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38423,7 +38423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38528,7 +38528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38633,7 +38633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38738,7 +38738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38753,7 +38753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38768,7 +38768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38800,7 +38800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -38832,7 +38832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -38864,7 +38864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38892,7 +38892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -38948,7 +38948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39005,7 +39005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39114,7 +39114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39165,7 +39165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39216,7 +39216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39267,7 +39267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39318,7 +39318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39333,7 +39333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39348,7 +39348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39362,7 +39362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39407,7 +39407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40990,7 +40990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41071,7 +41071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41236,7 +41236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -41287,7 +41287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -41380,7 +41380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -41545,7 +41545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41710,7 +41710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41875,7 +41875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42003,7 +42003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42032,7 +42032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42204,7 +42204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -42369,7 +42369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -42428,7 +42428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -42493,7 +42493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42594,7 +42594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -42695,7 +42695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -42788,7 +42788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42802,7 +42802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42816,7 +42816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42878,7 +42878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42923,7 +42923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -42968,7 +42968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43133,7 +43133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43184,7 +43184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43277,7 +43277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -43442,7 +43442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -43607,7 +43607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -43772,7 +43772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -43888,7 +43888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -43914,7 +43914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -43946,7 +43946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -43978,7 +43978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44000,7 +44000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44160,7 +44160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -44309,7 +44309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -44362,7 +44362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -44427,7 +44427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -44516,7 +44516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -44599,7 +44599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -44682,7 +44682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -44704,7 +44704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -44754,7 +44754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44768,7 +44768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44782,7 +44782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44844,7 +44844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44889,7 +44889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -44940,7 +44940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -44985,7 +44985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45000,7 +45000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45036,7 +45036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45067,7 +45067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45113,7 +45113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45142,7 +45142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -45192,7 +45192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -45232,7 +45232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45259,7 +45259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -45297,7 +45297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -45329,7 +45329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -45482,7 +45482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45635,7 +45635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -45788,7 +45788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -45941,7 +45941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -46094,7 +46094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -46247,7 +46247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -46400,7 +46400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -46552,7 +46552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -46704,7 +46704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -46857,7 +46857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47010,7 +47010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -47163,7 +47163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -47316,7 +47316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -47475,7 +47475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47526,7 +47526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47577,7 +47577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47628,7 +47628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47679,7 +47679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -47693,7 +47693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -47707,7 +47707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -47727,7 +47727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -47821,7 +47821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -47835,7 +47835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -47849,7 +47849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -48179,7 +48179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -48199,7 +48199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -48213,7 +48213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -48241,7 +48241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -48441,7 +48441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -48641,7 +48641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -48841,7 +48841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAME70N21B.svd
+++ b/data/Atmel/ATSAME70N21B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9279,7 +9279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9353,7 +9353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9398,7 +9398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9425,7 +9425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9476,7 +9476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9527,7 +9527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9578,7 +9578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9629,7 +9629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9672,7 +9672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9686,7 +9686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9702,7 +9702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9736,7 +9736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9834,7 +9834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9942,7 +9942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9962,7 +9962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9976,7 +9976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10008,7 +10008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10040,7 +10040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10072,7 +10072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10104,7 +10104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10169,7 +10169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10250,7 +10250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10313,7 +10313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10376,7 +10376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10439,7 +10439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10460,7 +10460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10502,7 +10502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10516,7 +10516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10548,7 +10548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10562,7 +10562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10576,7 +10576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10608,7 +10608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10622,7 +10622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10650,7 +10650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10688,7 +10688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10747,7 +10747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10797,7 +10797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10847,7 +10847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10886,7 +10886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11114,7 +11114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11142,7 +11142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11186,7 +11186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11231,7 +11231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11246,7 +11246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11260,7 +11260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11311,7 +11311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11373,7 +11373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11393,7 +11393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11602,7 +11602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11634,7 +11634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11672,7 +11672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11686,7 +11686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11748,7 +11748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11762,7 +11762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11795,7 +11795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11936,7 +11936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11956,7 +11956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12132,7 +12132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12308,7 +12308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12484,7 +12484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12504,7 +12504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12588,7 +12588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12608,7 +12608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12628,7 +12628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12642,7 +12642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12698,7 +12698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12898,7 +12898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13098,7 +13098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13130,7 +13130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13169,7 +13169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13183,7 +13183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13197,7 +13197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13229,7 +13229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13297,7 +13297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13311,7 +13311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13466,7 +13466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13498,7 +13498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13531,7 +13531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13588,7 +13588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13789,7 +13789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13989,7 +13989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14189,7 +14189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14390,7 +14390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14591,7 +14591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14791,7 +14791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -14991,7 +14991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15017,7 +15017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15056,7 +15056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15101,7 +15101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15302,7 +15302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15503,7 +15503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15704,7 +15704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -15905,7 +15905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16106,7 +16106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16307,7 +16307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -16508,7 +16508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -16709,7 +16709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -16910,7 +16910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17111,7 +17111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17312,7 +17312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -17512,7 +17512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -17713,7 +17713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -17914,7 +17914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18115,7 +18115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18316,7 +18316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -18517,7 +18517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -18718,7 +18718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -18919,7 +18919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19120,7 +19120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19321,7 +19321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -19522,7 +19522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19725,7 +19725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -19925,7 +19925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20126,7 +20126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20327,7 +20327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -20528,7 +20528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -20542,7 +20542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -20743,7 +20743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -20944,7 +20944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21145,7 +21145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21346,7 +21346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -21547,7 +21547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -21748,7 +21748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -21949,7 +21949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22150,7 +22150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22351,7 +22351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -22552,7 +22552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -22753,7 +22753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -22954,7 +22954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23155,7 +23155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23356,7 +23356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -23557,7 +23557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -23758,7 +23758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23786,7 +23786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23807,7 +23807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24007,7 +24007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24623,7 +24623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -24679,7 +24679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -24712,7 +24712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24745,7 +24745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24778,7 +24778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -24799,7 +24799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -24849,7 +24849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -24912,7 +24912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -24975,7 +24975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25044,7 +25044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25185,7 +25185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25326,7 +25326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -25779,7 +25779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -25801,7 +25801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25849,7 +25849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -25954,7 +25954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26059,7 +26059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26182,7 +26182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26287,7 +26287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -26445,7 +26445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -26549,7 +26549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -26564,7 +26564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -26592,7 +26592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -26613,7 +26613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -26760,7 +26760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -26907,7 +26907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27054,7 +27054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27126,7 +27126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27170,7 +27170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -27311,7 +27311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -27452,7 +27452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -27593,7 +27593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -27734,7 +27734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -27748,7 +27748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -27895,7 +27895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28042,7 +28042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -28189,7 +28189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -28336,7 +28336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -28370,7 +28370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28544,7 +28544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28577,7 +28577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28610,7 +28610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28643,7 +28643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28700,7 +28700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28757,7 +28757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28814,7 +28814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28871,7 +28871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28939,7 +28939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28954,7 +28954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28968,7 +28968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28988,7 +28988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29003,7 +29003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29120,7 +29120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29237,7 +29237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -29354,7 +29354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29471,7 +29471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29527,7 +29527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29583,7 +29583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29640,7 +29640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29697,7 +29697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -29754,7 +29754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -29811,7 +29811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -29837,7 +29837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -29858,7 +29858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -29873,7 +29873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -29929,7 +29929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -29963,7 +29963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30019,7 +30019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30039,7 +30039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30054,7 +30054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30086,7 +30086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30142,7 +30142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30225,7 +30225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30324,7 +30324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30357,7 +30357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30378,7 +30378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30422,7 +30422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30462,7 +30462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30656,7 +30656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30670,7 +30670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30685,7 +30685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30699,7 +30699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30714,7 +30714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30729,7 +30729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30749,7 +30749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30771,7 +30771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -30792,7 +30792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -30813,7 +30813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -30893,7 +30893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -30931,7 +30931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -30952,7 +30952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31032,7 +31032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31070,7 +31070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31118,7 +31118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31151,7 +31151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31271,7 +31271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31286,7 +31286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31301,7 +31301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31358,7 +31358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31409,7 +31409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31460,7 +31460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31511,7 +31511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31543,7 +31543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31557,7 +31557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31577,7 +31577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31755,7 +31755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31788,7 +31788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31803,7 +31803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31831,7 +31831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31871,7 +31871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31906,7 +31906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31967,7 +31967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32026,7 +32026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32055,7 +32055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32105,7 +32105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32139,7 +32139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32212,7 +32212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32426,7 +32426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32458,7 +32458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32496,7 +32496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32546,7 +32546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32578,7 +32578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32701,7 +32701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32746,7 +32746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32791,7 +32791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32836,7 +32836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -32881,7 +32881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -32933,7 +32933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32977,7 +32977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32991,7 +32991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33006,7 +33006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33046,7 +33046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33085,7 +33085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33177,7 +33177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33198,7 +33198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33248,7 +33248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33305,7 +33305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33356,7 +33356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33407,7 +33407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33460,7 +33460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33493,12 +33493,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -33590,7 +33590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33618,7 +33618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33658,7 +33658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -33697,7 +33697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -33711,7 +33711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33869,7 +33869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33971,7 +33971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34118,7 +34118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34226,7 +34226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34241,7 +34241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34256,7 +34256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34271,7 +34271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34285,7 +34285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34299,7 +34299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -34313,7 +34313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -34382,7 +34382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -34439,7 +34439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -34496,7 +34496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -34553,7 +34553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34581,7 +34581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34612,7 +34612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -34621,7 +34621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34682,7 +34682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34768,7 +34768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34872,7 +34872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35082,7 +35082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35622,7 +35622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36067,6 +36067,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -36101,7 +36129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36128,7 +36156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -36371,9 +36399,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -36807,7 +36835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -36827,7 +36855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -36842,7 +36870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -36857,7 +36885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -36871,7 +36899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -36885,7 +36913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -36899,7 +36927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -36974,7 +37002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37031,7 +37059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37088,7 +37116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37145,7 +37173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37198,7 +37226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37213,7 +37241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -37371,7 +37399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -37404,7 +37432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -37437,7 +37465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -37470,7 +37498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -37509,7 +37537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -37529,7 +37557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37624,7 +37652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37653,7 +37681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37668,7 +37696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37683,7 +37711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37698,7 +37726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37713,7 +37741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -37747,7 +37775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37888,7 +37916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37937,7 +37965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38005,7 +38033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38019,7 +38047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38051,7 +38079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38174,7 +38202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38279,7 +38307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38384,7 +38412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38489,7 +38517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38504,7 +38532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38519,7 +38547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38551,7 +38579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -38583,7 +38611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -38615,7 +38643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38643,7 +38671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -38699,7 +38727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -38756,7 +38784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -38865,7 +38893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -38916,7 +38944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -38967,7 +38995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39018,7 +39046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39069,7 +39097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39084,7 +39112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39099,7 +39127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39113,7 +39141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39158,7 +39186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -39984,6 +40012,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -40034,7 +40080,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -40075,80 +40167,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40246,12 +40264,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -40261,6 +40273,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40296,46 +40320,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -40364,6 +40348,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40417,7 +40419,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -40464,134 +40512,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40683,30 +40603,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -40716,6 +40612,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40751,64 +40659,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -40837,6 +40687,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40890,7 +40758,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -40937,134 +40851,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41156,30 +40942,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -41189,6 +40951,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41224,64 +40998,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -41310,6 +41026,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41387,7 +41121,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -41434,140 +41220,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41665,30 +41317,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -41698,6 +41326,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41728,64 +41368,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -42476,7 +42058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -42567,7 +42149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -42720,7 +42302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42771,7 +42353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42864,7 +42446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -43017,7 +42599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -43170,7 +42752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -43323,7 +42905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -43451,7 +43033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -43480,7 +43062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -43652,7 +43234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43817,9 +43399,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43983,9 +43565,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44149,9 +43731,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44315,7 +43897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -44374,9 +43956,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44434,9 +44016,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44494,9 +44076,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44554,7 +44136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -44619,9 +44201,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44685,9 +44267,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44751,9 +44333,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44817,7 +44399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -44918,9 +44500,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45026,9 +44608,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45128,9 +44710,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45230,7 +44812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -45331,9 +44913,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45439,9 +45021,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45541,9 +45123,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45643,7 +45225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -45732,9 +45314,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45822,9 +45404,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45912,9 +45494,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46006,7 +45588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46020,7 +45602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46034,7 +45616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46096,7 +45678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46141,7 +45723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -46196,7 +45778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -46305,43 +45887,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46349,7 +45931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -46400,7 +45982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -46449,43 +46031,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46493,7 +46075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -46602,43 +46184,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46646,7 +46228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -46755,43 +46337,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46799,7 +46381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -46908,43 +46490,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46952,7 +46534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -47068,7 +46650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -47094,7 +46676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -47126,7 +46708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -47158,7 +46740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -47180,7 +46762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -47340,9 +46922,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -47507,7 +47089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -47656,9 +47238,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47806,9 +47388,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47956,9 +47538,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48106,7 +47688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -48159,9 +47741,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48213,9 +47795,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48267,9 +47849,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48321,7 +47903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -48386,9 +47968,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48452,9 +48034,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48518,9 +48100,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48584,7 +48166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -48673,9 +48255,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48763,9 +48345,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48853,9 +48435,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48943,7 +48525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -49026,9 +48608,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49110,9 +48692,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49194,9 +48776,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49278,7 +48860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -49361,9 +48943,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49445,9 +49027,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49529,9 +49111,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49613,7 +49195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -49635,7 +49217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -49685,7 +49267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49699,7 +49281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -49713,7 +49295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -49775,7 +49357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -49820,7 +49402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -49877,7 +49459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -49922,7 +49504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -49937,7 +49519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -49973,7 +49555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -50004,7 +49586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -50050,7 +49632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50079,7 +49661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50129,7 +49711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50169,7 +49751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50196,7 +49778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50234,7 +49816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50266,7 +49848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -50419,7 +50001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -50572,7 +50154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -50725,7 +50307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -50878,7 +50460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -51031,7 +50613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -51184,7 +50766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -51337,7 +50919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -51489,7 +51071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -51641,7 +51223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -51794,7 +51376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -51947,7 +51529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -52100,7 +51682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -52253,7 +51835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -52412,7 +51994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -52463,7 +52045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -52514,7 +52096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -52565,7 +52147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -52616,7 +52198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -52630,7 +52212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -52644,7 +52226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -52664,7 +52246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -52758,7 +52340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -52772,7 +52354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -52786,7 +52368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -53349,7 +52931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -53369,7 +52951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -53383,7 +52965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -53411,7 +52993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -53611,7 +53193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -53811,7 +53393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -54011,7 +53593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>
@@ -55900,6 +55482,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAME70Q19.svd
+++ b/data/Atmel/ATSAME70Q19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4154,7 +4154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4258,7 +4258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4437,7 +4437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4458,7 +4458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4472,7 +4472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4574,7 +4574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4624,7 +4624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4638,7 +4638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4684,7 +4684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4831,7 +4831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4984,7 +4984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5137,7 +5137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5289,7 +5289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5339,7 +5339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5354,7 +5354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5368,7 +5368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5408,7 +5408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5422,7 +5422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5457,7 +5457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5471,7 +5471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5546,7 +5546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5566,7 +5566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5618,7 +5618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5658,7 +5658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5672,7 +5672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5686,7 +5686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5700,7 +5700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5714,7 +5714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6073,7 +6073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6103,7 +6103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6118,7 +6118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6133,7 +6133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6148,7 +6148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6163,7 +6163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6178,7 +6178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6193,7 +6193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6208,7 +6208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6223,7 +6223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6238,7 +6238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6253,7 +6253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6268,7 +6268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6328,7 +6328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6343,7 +6343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6358,7 +6358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6373,7 +6373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6388,7 +6388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6403,7 +6403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6418,7 +6418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6433,7 +6433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6448,7 +6448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6463,7 +6463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6477,7 +6477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6491,7 +6491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6519,7 +6519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6540,7 +6540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6566,7 +6566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6581,7 +6581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6596,7 +6596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6611,7 +6611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6626,7 +6626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6641,7 +6641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6656,7 +6656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6671,7 +6671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6688,7 +6688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6741,7 +6741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6757,7 +6757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6773,7 +6773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6787,7 +6787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6837,7 +6837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6877,7 +6877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6953,7 +6953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7006,7 +7006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7059,7 +7059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7125,7 +7125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7145,7 +7145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7188,7 +7188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7208,7 +7208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7251,7 +7251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7271,7 +7271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7314,7 +7314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7334,7 +7334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7377,7 +7377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7397,7 +7397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7460,7 +7460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7503,7 +7503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7523,7 +7523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7566,7 +7566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7586,7 +7586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7629,7 +7629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7649,7 +7649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7692,7 +7692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7712,7 +7712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7755,7 +7755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7775,7 +7775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7818,7 +7818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7838,7 +7838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7881,7 +7881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7901,7 +7901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7944,7 +7944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7964,7 +7964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8007,7 +8007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8027,7 +8027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8070,7 +8070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8090,7 +8090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8133,7 +8133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8153,7 +8153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8196,7 +8196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8216,7 +8216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8259,7 +8259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8279,7 +8279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8342,7 +8342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8385,7 +8385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8405,7 +8405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8448,7 +8448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8468,7 +8468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8511,7 +8511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8531,7 +8531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8574,7 +8574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8687,7 +8687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8776,7 +8776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8839,7 +8839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8885,7 +8885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8899,7 +8899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9156,7 +9156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9176,7 +9176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9241,7 +9241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9256,7 +9256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9271,7 +9271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9286,7 +9286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9439,7 +9439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9592,7 +9592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9898,7 +9898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9946,7 +9946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9978,7 +9978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10006,7 +10006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10029,7 +10029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10062,7 +10062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10181,7 +10181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10208,7 +10208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10259,7 +10259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10310,7 +10310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10361,7 +10361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10412,7 +10412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10455,7 +10455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10469,7 +10469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10485,7 +10485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10519,7 +10519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10617,7 +10617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10725,7 +10725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10745,7 +10745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10759,7 +10759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10791,7 +10791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10823,7 +10823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10855,7 +10855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10887,7 +10887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10919,7 +10919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11033,7 +11033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11096,7 +11096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11159,7 +11159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11222,7 +11222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11243,7 +11243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11264,7 +11264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11285,7 +11285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11299,7 +11299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11331,7 +11331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11345,7 +11345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11359,7 +11359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11391,7 +11391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11405,7 +11405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11433,7 +11433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11471,7 +11471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11530,7 +11530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11580,7 +11580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11630,7 +11630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11663,7 +11663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11833,7 +11833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11861,7 +11861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11905,7 +11905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11919,7 +11919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11976,7 +11976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12044,7 +12044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12064,7 +12064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12277,7 +12277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12309,7 +12309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12347,7 +12347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12361,7 +12361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12423,7 +12423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12437,7 +12437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12470,7 +12470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -12599,7 +12599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12787,7 +12787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12975,7 +12975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13163,7 +13163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13183,7 +13183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13267,7 +13267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13287,7 +13287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13307,7 +13307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13321,7 +13321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13377,7 +13377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13577,7 +13577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13777,7 +13777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13809,7 +13809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13848,7 +13848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13862,7 +13862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13876,7 +13876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13908,7 +13908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13976,7 +13976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13990,7 +13990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14145,7 +14145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14177,7 +14177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14210,7 +14210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14267,7 +14267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14468,7 +14468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14668,7 +14668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14868,7 +14868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15069,7 +15069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15270,7 +15270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15470,7 +15470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15670,7 +15670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15696,7 +15696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15735,7 +15735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15780,7 +15780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15981,7 +15981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16182,7 +16182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16383,7 +16383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16584,7 +16584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16785,7 +16785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16986,7 +16986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17187,7 +17187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17388,7 +17388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17589,7 +17589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17790,7 +17790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17991,7 +17991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18191,7 +18191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18392,7 +18392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18593,7 +18593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18794,7 +18794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18995,7 +18995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19196,7 +19196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19397,7 +19397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19598,7 +19598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19799,7 +19799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -20000,7 +20000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20201,7 +20201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20404,7 +20404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20604,7 +20604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20805,7 +20805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -21006,7 +21006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21207,7 +21207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21221,7 +21221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21422,7 +21422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21623,7 +21623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21824,7 +21824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -22025,7 +22025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22226,7 +22226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22427,7 +22427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22628,7 +22628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22829,7 +22829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -23030,7 +23030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23231,7 +23231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23432,7 +23432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23633,7 +23633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23834,7 +23834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -24035,7 +24035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24236,7 +24236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24437,7 +24437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24465,7 +24465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24486,7 +24486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24686,7 +24686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25302,7 +25302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25358,7 +25358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25391,7 +25391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25424,7 +25424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25457,7 +25457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25478,7 +25478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25544,7 +25544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25601,7 +25601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25721,7 +25721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25880,7 +25880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -26039,7 +26039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26389,7 +26389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26510,7 +26510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26532,7 +26532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26580,7 +26580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26679,7 +26679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26778,7 +26778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26895,7 +26895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26994,7 +26994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27152,7 +27152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27256,7 +27256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27271,7 +27271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27299,7 +27299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27320,7 +27320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27479,7 +27479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27638,7 +27638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27797,7 +27797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27869,7 +27869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27913,7 +27913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28072,7 +28072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28231,7 +28231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28390,7 +28390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28549,7 +28549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28563,7 +28563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28722,7 +28722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28881,7 +28881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29040,7 +29040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29199,7 +29199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29233,7 +29233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29407,7 +29407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29440,7 +29440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29473,7 +29473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29506,7 +29506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29563,7 +29563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29620,7 +29620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29677,7 +29677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29734,7 +29734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29802,7 +29802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29817,7 +29817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29831,7 +29831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29851,7 +29851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29866,7 +29866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29983,7 +29983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30100,7 +30100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30217,7 +30217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30334,7 +30334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30390,7 +30390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30446,7 +30446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30503,7 +30503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30560,7 +30560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30617,7 +30617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30674,7 +30674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30700,7 +30700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30721,7 +30721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30736,7 +30736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30792,7 +30792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30826,7 +30826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30882,7 +30882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30902,7 +30902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30917,7 +30917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30949,7 +30949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -31005,7 +31005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31088,7 +31088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31187,7 +31187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31207,7 +31207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31228,7 +31228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31272,7 +31272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31312,7 +31312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31454,7 +31454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31468,7 +31468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31483,7 +31483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31497,7 +31497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31512,7 +31512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31527,7 +31527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31547,7 +31547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31569,7 +31569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31590,7 +31590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31611,7 +31611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31691,7 +31691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31729,7 +31729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31750,7 +31750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31830,7 +31830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31868,7 +31868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31916,7 +31916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31949,7 +31949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32069,7 +32069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32084,7 +32084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32099,7 +32099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32156,7 +32156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32207,7 +32207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32258,7 +32258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32309,7 +32309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32341,7 +32341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32355,7 +32355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32375,7 +32375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32553,7 +32553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32586,7 +32586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32601,7 +32601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32629,7 +32629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32669,7 +32669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32704,7 +32704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32765,7 +32765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32824,7 +32824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32853,7 +32853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32903,7 +32903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32937,7 +32937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33010,7 +33010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33224,7 +33224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33256,7 +33256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33294,7 +33294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33344,7 +33344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33376,7 +33376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33499,7 +33499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33544,7 +33544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33589,7 +33589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33634,7 +33634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33679,7 +33679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33731,7 +33731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33775,7 +33775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33789,7 +33789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33804,7 +33804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33844,7 +33844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33896,7 +33896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33910,7 +33910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34056,7 +34056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34135,7 +34135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34150,7 +34150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34165,7 +34165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34180,7 +34180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34195,7 +34195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34222,7 +34222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34255,7 +34255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34269,7 +34269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34284,7 +34284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34320,7 +34320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34352,7 +34352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34384,7 +34384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34404,7 +34404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC MODE Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34534,7 +34534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC OCMS MODE Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -34572,7 +34572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC OCMS KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -34587,7 +34587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC OCMS KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -34602,7 +34602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34630,7 +34630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34670,7 +34670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34733,7 +34733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34789,7 +34789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34810,7 +34810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34837,7 +34837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34894,7 +34894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34945,7 +34945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34996,7 +34996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35049,7 +35049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35153,7 +35153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35181,7 +35181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35229,7 +35229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -35268,7 +35268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -35282,7 +35282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35440,7 +35440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35542,7 +35542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35689,7 +35689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35797,7 +35797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35812,7 +35812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35827,7 +35827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35842,7 +35842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35856,7 +35856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35870,7 +35870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35884,7 +35884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35953,7 +35953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36010,7 +36010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -36067,7 +36067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36124,7 +36124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36152,7 +36152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36192,7 +36192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36253,7 +36253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36339,7 +36339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36443,7 +36443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36653,7 +36653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37193,7 +37193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37672,7 +37672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37699,7 +37699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37942,7 +37942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37962,7 +37962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37977,7 +37977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37992,7 +37992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -38006,7 +38006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -38020,7 +38020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -38034,7 +38034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38109,7 +38109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38166,7 +38166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38223,7 +38223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38280,7 +38280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38333,7 +38333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38348,7 +38348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38494,7 +38494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38521,7 +38521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38548,7 +38548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38575,7 +38575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38608,7 +38608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38628,7 +38628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38723,7 +38723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38752,7 +38752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38767,7 +38767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38782,7 +38782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38797,7 +38797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38812,7 +38812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38846,7 +38846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38987,7 +38987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -39036,7 +39036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39104,7 +39104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39118,7 +39118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39150,7 +39150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39273,7 +39273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39378,7 +39378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39483,7 +39483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39588,7 +39588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39603,7 +39603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39618,7 +39618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39650,7 +39650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39682,7 +39682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39714,7 +39714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39742,7 +39742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39798,7 +39798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39855,7 +39855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39964,7 +39964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40015,7 +40015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40066,7 +40066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40117,7 +40117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40168,7 +40168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40183,7 +40183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40198,7 +40198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40212,7 +40212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40257,7 +40257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41840,7 +41840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41921,7 +41921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -42086,7 +42086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42137,7 +42137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42230,7 +42230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -42395,7 +42395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -42560,7 +42560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -42725,7 +42725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42853,7 +42853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42882,7 +42882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -43054,7 +43054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43219,7 +43219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -43278,7 +43278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43343,7 +43343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43444,7 +43444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43545,7 +43545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43638,7 +43638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43652,7 +43652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43666,7 +43666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43728,7 +43728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43773,7 +43773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43818,7 +43818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43983,7 +43983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -44034,7 +44034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44127,7 +44127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44292,7 +44292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44457,7 +44457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44622,7 +44622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44738,7 +44738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44764,7 +44764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44796,7 +44796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44828,7 +44828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44850,7 +44850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -45010,7 +45010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45159,7 +45159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45212,7 +45212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45277,7 +45277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45366,7 +45366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -45449,7 +45449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -45532,7 +45532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -45554,7 +45554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -45604,7 +45604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45618,7 +45618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45632,7 +45632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45694,7 +45694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45739,7 +45739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -45790,7 +45790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -45835,7 +45835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45850,7 +45850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45886,7 +45886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45917,7 +45917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45963,7 +45963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45992,7 +45992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46042,7 +46042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46082,7 +46082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46108,7 +46108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46147,7 +46147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46179,7 +46179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -46332,7 +46332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46485,7 +46485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -46638,7 +46638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -46791,7 +46791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -46944,7 +46944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -47097,7 +47097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -47250,7 +47250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -47402,7 +47402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -47554,7 +47554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47707,7 +47707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47860,7 +47860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -48013,7 +48013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -48166,7 +48166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -48325,7 +48325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -48376,7 +48376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -48427,7 +48427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -48478,7 +48478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -48529,7 +48529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -48543,7 +48543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -48557,7 +48557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -48577,7 +48577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -48671,7 +48671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -48685,7 +48685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -48699,7 +48699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -49029,7 +49029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -49049,7 +49049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -49063,7 +49063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -49091,7 +49091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAME70Q19B.svd
+++ b/data/Atmel/ATSAME70Q19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9287,7 +9287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9361,7 +9361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9406,7 +9406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9433,7 +9433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9484,7 +9484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9535,7 +9535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9586,7 +9586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9637,7 +9637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9694,7 +9694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9710,7 +9710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9744,7 +9744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9842,7 +9842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9950,7 +9950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9970,7 +9970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9984,7 +9984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10016,7 +10016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10048,7 +10048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10080,7 +10080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10112,7 +10112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10144,7 +10144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10177,7 +10177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10258,7 +10258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10321,7 +10321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10384,7 +10384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10447,7 +10447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10468,7 +10468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10489,7 +10489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10510,7 +10510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10524,7 +10524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10556,7 +10556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10570,7 +10570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10584,7 +10584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10616,7 +10616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10630,7 +10630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10658,7 +10658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10696,7 +10696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10855,7 +10855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10894,7 +10894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11122,7 +11122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11150,7 +11150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11194,7 +11194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11239,7 +11239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11254,7 +11254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11268,7 +11268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11319,7 +11319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11381,7 +11381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11401,7 +11401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11610,7 +11610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11642,7 +11642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11680,7 +11680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11694,7 +11694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11756,7 +11756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11770,7 +11770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11803,7 +11803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11944,7 +11944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11964,7 +11964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12140,7 +12140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12316,7 +12316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12492,7 +12492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12512,7 +12512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12596,7 +12596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12616,7 +12616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12636,7 +12636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12650,7 +12650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12706,7 +12706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12906,7 +12906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13106,7 +13106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13138,7 +13138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13177,7 +13177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13191,7 +13191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13205,7 +13205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13237,7 +13237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13305,7 +13305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13319,7 +13319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13474,7 +13474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13506,7 +13506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13539,7 +13539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13596,7 +13596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13797,7 +13797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13997,7 +13997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14197,7 +14197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14398,7 +14398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14599,7 +14599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14799,7 +14799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -14999,7 +14999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15025,7 +15025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15064,7 +15064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15109,7 +15109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15310,7 +15310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15511,7 +15511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15712,7 +15712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -15913,7 +15913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16114,7 +16114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16315,7 +16315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -16516,7 +16516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -16717,7 +16717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -16918,7 +16918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17119,7 +17119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17320,7 +17320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -17520,7 +17520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -17721,7 +17721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -17922,7 +17922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18123,7 +18123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18324,7 +18324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -18525,7 +18525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -18726,7 +18726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -18927,7 +18927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19128,7 +19128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19329,7 +19329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -19530,7 +19530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19733,7 +19733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -19933,7 +19933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20134,7 +20134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20335,7 +20335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -20536,7 +20536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -20550,7 +20550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -20751,7 +20751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -20952,7 +20952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21153,7 +21153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21354,7 +21354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -21555,7 +21555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -21756,7 +21756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -21957,7 +21957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22158,7 +22158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22359,7 +22359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -22560,7 +22560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -22761,7 +22761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -22962,7 +22962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23163,7 +23163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23364,7 +23364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -23565,7 +23565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -23766,7 +23766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23794,7 +23794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23815,7 +23815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24015,7 +24015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24631,7 +24631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -24687,7 +24687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -24720,7 +24720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24753,7 +24753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24786,7 +24786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -24807,7 +24807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -24873,7 +24873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -24936,7 +24936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -24999,7 +24999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25068,7 +25068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25227,7 +25227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25386,7 +25386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -25736,7 +25736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -25857,7 +25857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -25879,7 +25879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25927,7 +25927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26032,7 +26032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26137,7 +26137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26260,7 +26260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -26523,7 +26523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -26627,7 +26627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -26642,7 +26642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -26670,7 +26670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -26691,7 +26691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -26844,7 +26844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -26997,7 +26997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27150,7 +27150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27222,7 +27222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27266,7 +27266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -27425,7 +27425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -27584,7 +27584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -27743,7 +27743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -27902,7 +27902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -27916,7 +27916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28069,7 +28069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28222,7 +28222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -28375,7 +28375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -28528,7 +28528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -28562,7 +28562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28736,7 +28736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28769,7 +28769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28802,7 +28802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28835,7 +28835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28892,7 +28892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28949,7 +28949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29006,7 +29006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29063,7 +29063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29131,7 +29131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29146,7 +29146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29160,7 +29160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29180,7 +29180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29195,7 +29195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29312,7 +29312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29429,7 +29429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -29546,7 +29546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29663,7 +29663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29719,7 +29719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29775,7 +29775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29832,7 +29832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29889,7 +29889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -29946,7 +29946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30003,7 +30003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30029,7 +30029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30050,7 +30050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30065,7 +30065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30121,7 +30121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30155,7 +30155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30211,7 +30211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30231,7 +30231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30246,7 +30246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30278,7 +30278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30334,7 +30334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30417,7 +30417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30516,7 +30516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30549,7 +30549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30570,7 +30570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30614,7 +30614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30654,7 +30654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30848,7 +30848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30862,7 +30862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30877,7 +30877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30891,7 +30891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30906,7 +30906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30921,7 +30921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30941,7 +30941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30963,7 +30963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -30984,7 +30984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31005,7 +31005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31085,7 +31085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31123,7 +31123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31144,7 +31144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31224,7 +31224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31262,7 +31262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31310,7 +31310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31343,7 +31343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31463,7 +31463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31478,7 +31478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31493,7 +31493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31550,7 +31550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31601,7 +31601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31652,7 +31652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31703,7 +31703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31735,7 +31735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31749,7 +31749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31769,7 +31769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31947,7 +31947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31980,7 +31980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31995,7 +31995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32023,7 +32023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32063,7 +32063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32098,7 +32098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32159,7 +32159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32218,7 +32218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32247,7 +32247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32297,7 +32297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32331,7 +32331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32404,7 +32404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32618,7 +32618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32650,7 +32650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32688,7 +32688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32738,7 +32738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32770,7 +32770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32893,7 +32893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32938,7 +32938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32983,7 +32983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33028,7 +33028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33073,7 +33073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33125,7 +33125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33169,7 +33169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33183,7 +33183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33198,7 +33198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33238,7 +33238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33290,7 +33290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33304,7 +33304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33450,7 +33450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33529,7 +33529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33544,7 +33544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33559,7 +33559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33574,7 +33574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33589,7 +33589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33616,7 +33616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33649,7 +33649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33663,7 +33663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33678,7 +33678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33714,7 +33714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33746,7 +33746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -33778,7 +33778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -33798,7 +33798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -33928,7 +33928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -33966,7 +33966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -33981,7 +33981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -33996,7 +33996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34024,7 +34024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34064,7 +34064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34103,7 +34103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34195,7 +34195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34216,7 +34216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34266,7 +34266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34323,7 +34323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34374,7 +34374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34425,7 +34425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34478,7 +34478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34511,12 +34511,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -34608,7 +34608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34636,7 +34636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34684,7 +34684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34723,7 +34723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34737,7 +34737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34895,7 +34895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34997,7 +34997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35144,7 +35144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35252,7 +35252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35267,7 +35267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35282,7 +35282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35297,7 +35297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35311,7 +35311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35325,7 +35325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35339,7 +35339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35408,7 +35408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35465,7 +35465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35522,7 +35522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35579,7 +35579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35607,7 +35607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35638,7 +35638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -35647,7 +35647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35708,7 +35708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35794,7 +35794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35898,7 +35898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36108,7 +36108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36648,7 +36648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37093,6 +37093,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -37127,7 +37155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37154,7 +37182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37397,9 +37425,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -37833,7 +37861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37853,7 +37881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37868,7 +37896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37883,7 +37911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37897,7 +37925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37911,7 +37939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37925,7 +37953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38000,7 +38028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38057,7 +38085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38114,7 +38142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38171,7 +38199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38224,7 +38252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38239,7 +38267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38397,7 +38425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38430,7 +38458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38463,7 +38491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38496,7 +38524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38535,7 +38563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38555,7 +38583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38650,7 +38678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38679,7 +38707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38694,7 +38722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38709,7 +38737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38724,7 +38752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38739,7 +38767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38773,7 +38801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38914,7 +38942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38963,7 +38991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39031,7 +39059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39045,7 +39073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39077,7 +39105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39200,7 +39228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39305,7 +39333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39410,7 +39438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39515,7 +39543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39530,7 +39558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39545,7 +39573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39577,7 +39605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39609,7 +39637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39641,7 +39669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39669,7 +39697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39725,7 +39753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39782,7 +39810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39891,7 +39919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39942,7 +39970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39993,7 +40021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40044,7 +40072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40095,7 +40123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40110,7 +40138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40125,7 +40153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40139,7 +40167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40184,7 +40212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41010,6 +41038,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -41060,7 +41106,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -41101,80 +41193,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41272,12 +41290,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -41287,6 +41299,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41322,46 +41346,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -41390,6 +41374,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41443,7 +41445,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -41490,134 +41538,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41709,30 +41629,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -41742,6 +41638,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41777,64 +41685,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -41863,6 +41713,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41916,7 +41784,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -41963,134 +41877,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42182,30 +41968,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -42215,6 +41977,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42250,64 +42024,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -42336,6 +42052,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42413,7 +42147,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -42460,140 +42246,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42691,30 +42343,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -42724,6 +42352,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42754,64 +42394,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -43502,7 +43084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -43593,7 +43175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -43746,7 +43328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -43797,7 +43379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -43890,7 +43472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -44043,7 +43625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -44196,7 +43778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -44349,7 +43931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -44477,7 +44059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -44506,7 +44088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -44678,7 +44260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -44843,9 +44425,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45009,9 +44591,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45175,9 +44757,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45341,7 +44923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -45400,9 +44982,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45460,9 +45042,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45520,9 +45102,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45580,7 +45162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -45645,9 +45227,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45711,9 +45293,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45777,9 +45359,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45843,7 +45425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -45944,9 +45526,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46052,9 +45634,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46154,9 +45736,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46256,7 +45838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -46357,9 +45939,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46465,9 +46047,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46567,9 +46149,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46669,7 +46251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -46758,9 +46340,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46848,9 +46430,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46938,9 +46520,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47032,7 +46614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47046,7 +46628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47060,7 +46642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47122,7 +46704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47167,7 +46749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -47222,7 +46804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -47331,43 +46913,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47375,7 +46957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -47426,7 +47008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -47475,43 +47057,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47519,7 +47101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -47628,43 +47210,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47672,7 +47254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -47781,43 +47363,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47825,7 +47407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -47934,43 +47516,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47978,7 +47560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -48094,7 +47676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -48120,7 +47702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -48152,7 +47734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -48184,7 +47766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -48206,7 +47788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -48366,9 +47948,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -48533,7 +48115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -48682,9 +48264,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48832,9 +48414,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48982,9 +48564,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49132,7 +48714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -49185,9 +48767,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49239,9 +48821,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49293,9 +48875,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49347,7 +48929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -49412,9 +48994,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49478,9 +49060,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49544,9 +49126,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49610,7 +49192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -49699,9 +49281,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49789,9 +49371,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49879,9 +49461,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49969,7 +49551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -50052,9 +49634,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50136,9 +49718,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50220,9 +49802,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50304,7 +49886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -50387,9 +49969,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50471,9 +50053,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50555,9 +50137,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50639,7 +50221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -50661,7 +50243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -50711,7 +50293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50725,7 +50307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50739,7 +50321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50801,7 +50383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50846,7 +50428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -50903,7 +50485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -50948,7 +50530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -50963,7 +50545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -50999,7 +50581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51030,7 +50612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -51076,7 +50658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51105,7 +50687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51155,7 +50737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51195,7 +50777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51222,7 +50804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51260,7 +50842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51292,7 +50874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -51445,7 +51027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51598,7 +51180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -51751,7 +51333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -51904,7 +51486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -52057,7 +51639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -52210,7 +51792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -52363,7 +51945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -52515,7 +52097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -52667,7 +52249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -52820,7 +52402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -52973,7 +52555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -53126,7 +52708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -53279,7 +52861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -53438,7 +53020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -53489,7 +53071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -53540,7 +53122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -53591,7 +53173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -53642,7 +53224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -53656,7 +53238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -53670,7 +53252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -53690,7 +53272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -53784,7 +53366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -53798,7 +53380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -53812,7 +53394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -54405,7 +53987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -54425,7 +54007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -54439,7 +54021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -54467,7 +54049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -56356,6 +55938,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAME70Q20.svd
+++ b/data/Atmel/ATSAME70Q20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4154,7 +4154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4258,7 +4258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4437,7 +4437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4458,7 +4458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4472,7 +4472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4574,7 +4574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4624,7 +4624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4638,7 +4638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4684,7 +4684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4831,7 +4831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4984,7 +4984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5137,7 +5137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5289,7 +5289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5339,7 +5339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5354,7 +5354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5368,7 +5368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5408,7 +5408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5422,7 +5422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5457,7 +5457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5471,7 +5471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5546,7 +5546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5566,7 +5566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5618,7 +5618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5658,7 +5658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5672,7 +5672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5686,7 +5686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5700,7 +5700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5714,7 +5714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6073,7 +6073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6103,7 +6103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6118,7 +6118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6133,7 +6133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6148,7 +6148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6163,7 +6163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6178,7 +6178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6193,7 +6193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6208,7 +6208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6223,7 +6223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6238,7 +6238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6253,7 +6253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6268,7 +6268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6328,7 +6328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6343,7 +6343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6358,7 +6358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6373,7 +6373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6388,7 +6388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6403,7 +6403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6418,7 +6418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6433,7 +6433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6448,7 +6448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6463,7 +6463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6477,7 +6477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6491,7 +6491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6519,7 +6519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6540,7 +6540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6566,7 +6566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6581,7 +6581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6596,7 +6596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6611,7 +6611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6626,7 +6626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6641,7 +6641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6656,7 +6656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6671,7 +6671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6688,7 +6688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6741,7 +6741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6757,7 +6757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6773,7 +6773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6787,7 +6787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6837,7 +6837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6877,7 +6877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6953,7 +6953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7006,7 +7006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7059,7 +7059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7125,7 +7125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7145,7 +7145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7188,7 +7188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7208,7 +7208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7251,7 +7251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7271,7 +7271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7314,7 +7314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7334,7 +7334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7377,7 +7377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7397,7 +7397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7460,7 +7460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7503,7 +7503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7523,7 +7523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7566,7 +7566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7586,7 +7586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7629,7 +7629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7649,7 +7649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7692,7 +7692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7712,7 +7712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7755,7 +7755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7775,7 +7775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7818,7 +7818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7838,7 +7838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7881,7 +7881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7901,7 +7901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7944,7 +7944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7964,7 +7964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8007,7 +8007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8027,7 +8027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8070,7 +8070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8090,7 +8090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8133,7 +8133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8153,7 +8153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8196,7 +8196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8216,7 +8216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8259,7 +8259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8279,7 +8279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8342,7 +8342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8385,7 +8385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8405,7 +8405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8448,7 +8448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8468,7 +8468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8511,7 +8511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8531,7 +8531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8574,7 +8574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8687,7 +8687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8776,7 +8776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8839,7 +8839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8885,7 +8885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8899,7 +8899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9156,7 +9156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9176,7 +9176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9241,7 +9241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9256,7 +9256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9271,7 +9271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9286,7 +9286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9439,7 +9439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9592,7 +9592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9898,7 +9898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9946,7 +9946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9978,7 +9978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10006,7 +10006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10029,7 +10029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10062,7 +10062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10181,7 +10181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10208,7 +10208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10259,7 +10259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10310,7 +10310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10361,7 +10361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10412,7 +10412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10455,7 +10455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10469,7 +10469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10485,7 +10485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10519,7 +10519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10617,7 +10617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10725,7 +10725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10745,7 +10745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10759,7 +10759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10791,7 +10791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10823,7 +10823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10855,7 +10855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10887,7 +10887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10919,7 +10919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11033,7 +11033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11096,7 +11096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11159,7 +11159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11222,7 +11222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11243,7 +11243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11264,7 +11264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11285,7 +11285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11299,7 +11299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11331,7 +11331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11345,7 +11345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11359,7 +11359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11391,7 +11391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11405,7 +11405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11433,7 +11433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11471,7 +11471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11530,7 +11530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11580,7 +11580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11630,7 +11630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11663,7 +11663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11833,7 +11833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11861,7 +11861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11905,7 +11905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11919,7 +11919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11976,7 +11976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12044,7 +12044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12064,7 +12064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12277,7 +12277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12309,7 +12309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12347,7 +12347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12361,7 +12361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12423,7 +12423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12437,7 +12437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12470,7 +12470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -12599,7 +12599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12787,7 +12787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12975,7 +12975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13163,7 +13163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13183,7 +13183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13267,7 +13267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13287,7 +13287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13307,7 +13307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13321,7 +13321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13377,7 +13377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13577,7 +13577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13777,7 +13777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13809,7 +13809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13848,7 +13848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13862,7 +13862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13876,7 +13876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13908,7 +13908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13976,7 +13976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13990,7 +13990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14145,7 +14145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14177,7 +14177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14210,7 +14210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14267,7 +14267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14468,7 +14468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14668,7 +14668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14868,7 +14868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15069,7 +15069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15270,7 +15270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15470,7 +15470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15670,7 +15670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15696,7 +15696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15735,7 +15735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15780,7 +15780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15981,7 +15981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16182,7 +16182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16383,7 +16383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16584,7 +16584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16785,7 +16785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16986,7 +16986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17187,7 +17187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17388,7 +17388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17589,7 +17589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17790,7 +17790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17991,7 +17991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18191,7 +18191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18392,7 +18392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18593,7 +18593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18794,7 +18794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18995,7 +18995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19196,7 +19196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19397,7 +19397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19598,7 +19598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19799,7 +19799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -20000,7 +20000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20201,7 +20201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20404,7 +20404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20604,7 +20604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20805,7 +20805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -21006,7 +21006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21207,7 +21207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21221,7 +21221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21422,7 +21422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21623,7 +21623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21824,7 +21824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -22025,7 +22025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22226,7 +22226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22427,7 +22427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22628,7 +22628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22829,7 +22829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -23030,7 +23030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23231,7 +23231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23432,7 +23432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23633,7 +23633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23834,7 +23834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -24035,7 +24035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24236,7 +24236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24437,7 +24437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24465,7 +24465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24486,7 +24486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24686,7 +24686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25302,7 +25302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25358,7 +25358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25391,7 +25391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25424,7 +25424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25457,7 +25457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25478,7 +25478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25544,7 +25544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25601,7 +25601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25721,7 +25721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25880,7 +25880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -26039,7 +26039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26389,7 +26389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26510,7 +26510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26532,7 +26532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26580,7 +26580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26679,7 +26679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26778,7 +26778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26895,7 +26895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26994,7 +26994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27152,7 +27152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27256,7 +27256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27271,7 +27271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27299,7 +27299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27320,7 +27320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27479,7 +27479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27638,7 +27638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27797,7 +27797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27869,7 +27869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27913,7 +27913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28072,7 +28072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28231,7 +28231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28390,7 +28390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28549,7 +28549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28563,7 +28563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28722,7 +28722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28881,7 +28881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29040,7 +29040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29199,7 +29199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29233,7 +29233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29407,7 +29407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29440,7 +29440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29473,7 +29473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29506,7 +29506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29563,7 +29563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29620,7 +29620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29677,7 +29677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29734,7 +29734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29802,7 +29802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29817,7 +29817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29831,7 +29831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29851,7 +29851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29866,7 +29866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29983,7 +29983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30100,7 +30100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30217,7 +30217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30334,7 +30334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30390,7 +30390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30446,7 +30446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30503,7 +30503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30560,7 +30560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30617,7 +30617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30674,7 +30674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30700,7 +30700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30721,7 +30721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30736,7 +30736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30792,7 +30792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30826,7 +30826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30882,7 +30882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30902,7 +30902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30917,7 +30917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30949,7 +30949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -31005,7 +31005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31088,7 +31088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31187,7 +31187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31207,7 +31207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31228,7 +31228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31272,7 +31272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31312,7 +31312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31454,7 +31454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31468,7 +31468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31483,7 +31483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31497,7 +31497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31512,7 +31512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31527,7 +31527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31547,7 +31547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31569,7 +31569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31590,7 +31590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31611,7 +31611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31691,7 +31691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31729,7 +31729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31750,7 +31750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31830,7 +31830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31868,7 +31868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31916,7 +31916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31949,7 +31949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32069,7 +32069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32084,7 +32084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32099,7 +32099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32156,7 +32156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32207,7 +32207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32258,7 +32258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32309,7 +32309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32341,7 +32341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32355,7 +32355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32375,7 +32375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32553,7 +32553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32586,7 +32586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32601,7 +32601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32629,7 +32629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32669,7 +32669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32704,7 +32704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32765,7 +32765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32824,7 +32824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32853,7 +32853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32903,7 +32903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32937,7 +32937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33010,7 +33010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33224,7 +33224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33256,7 +33256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33294,7 +33294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33344,7 +33344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33376,7 +33376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33499,7 +33499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33544,7 +33544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33589,7 +33589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33634,7 +33634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33679,7 +33679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33731,7 +33731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33775,7 +33775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33789,7 +33789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33804,7 +33804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33844,7 +33844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33896,7 +33896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33910,7 +33910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34056,7 +34056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34135,7 +34135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34150,7 +34150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34165,7 +34165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34180,7 +34180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34195,7 +34195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34222,7 +34222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34255,7 +34255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34269,7 +34269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34284,7 +34284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34320,7 +34320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34352,7 +34352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34384,7 +34384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34404,7 +34404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC MODE Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34534,7 +34534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC OCMS MODE Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -34572,7 +34572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC OCMS KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -34587,7 +34587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC OCMS KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -34602,7 +34602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34630,7 +34630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34670,7 +34670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34733,7 +34733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34789,7 +34789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34810,7 +34810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34837,7 +34837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34894,7 +34894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34945,7 +34945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34996,7 +34996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35049,7 +35049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35153,7 +35153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35181,7 +35181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35229,7 +35229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -35268,7 +35268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -35282,7 +35282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35440,7 +35440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35542,7 +35542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35689,7 +35689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35797,7 +35797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35812,7 +35812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35827,7 +35827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35842,7 +35842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35856,7 +35856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35870,7 +35870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35884,7 +35884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35953,7 +35953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36010,7 +36010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -36067,7 +36067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36124,7 +36124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36152,7 +36152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36192,7 +36192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36253,7 +36253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36339,7 +36339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36443,7 +36443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36653,7 +36653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37193,7 +37193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37672,7 +37672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37699,7 +37699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37942,7 +37942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37962,7 +37962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37977,7 +37977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37992,7 +37992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -38006,7 +38006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -38020,7 +38020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -38034,7 +38034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38109,7 +38109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38166,7 +38166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38223,7 +38223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38280,7 +38280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38333,7 +38333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38348,7 +38348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38494,7 +38494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38521,7 +38521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38548,7 +38548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38575,7 +38575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38608,7 +38608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38628,7 +38628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38723,7 +38723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38752,7 +38752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38767,7 +38767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38782,7 +38782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38797,7 +38797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38812,7 +38812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38846,7 +38846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38987,7 +38987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -39036,7 +39036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39104,7 +39104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39118,7 +39118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39150,7 +39150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39273,7 +39273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39378,7 +39378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39483,7 +39483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39588,7 +39588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39603,7 +39603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39618,7 +39618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39650,7 +39650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39682,7 +39682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39714,7 +39714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39742,7 +39742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39798,7 +39798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39855,7 +39855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39964,7 +39964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40015,7 +40015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40066,7 +40066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40117,7 +40117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40168,7 +40168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40183,7 +40183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40198,7 +40198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40212,7 +40212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40257,7 +40257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41840,7 +41840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41921,7 +41921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -42086,7 +42086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42137,7 +42137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42230,7 +42230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -42395,7 +42395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -42560,7 +42560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -42725,7 +42725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42853,7 +42853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42882,7 +42882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -43054,7 +43054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43219,7 +43219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -43278,7 +43278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43343,7 +43343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43444,7 +43444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43545,7 +43545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43638,7 +43638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43652,7 +43652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43666,7 +43666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43728,7 +43728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43773,7 +43773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43818,7 +43818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43983,7 +43983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -44034,7 +44034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44127,7 +44127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44292,7 +44292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44457,7 +44457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44622,7 +44622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44738,7 +44738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44764,7 +44764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44796,7 +44796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44828,7 +44828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44850,7 +44850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -45010,7 +45010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45159,7 +45159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45212,7 +45212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45277,7 +45277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45366,7 +45366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -45449,7 +45449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -45532,7 +45532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -45554,7 +45554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -45604,7 +45604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45618,7 +45618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45632,7 +45632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45694,7 +45694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45739,7 +45739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -45790,7 +45790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -45835,7 +45835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45850,7 +45850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45886,7 +45886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45917,7 +45917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45963,7 +45963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45992,7 +45992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46042,7 +46042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46082,7 +46082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46109,7 +46109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46147,7 +46147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46179,7 +46179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -46332,7 +46332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46485,7 +46485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -46638,7 +46638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -46791,7 +46791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -46944,7 +46944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -47097,7 +47097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -47250,7 +47250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -47402,7 +47402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -47554,7 +47554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47707,7 +47707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47860,7 +47860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -48013,7 +48013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -48166,7 +48166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -48325,7 +48325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -48376,7 +48376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -48427,7 +48427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -48478,7 +48478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -48529,7 +48529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -48543,7 +48543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -48557,7 +48557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -48577,7 +48577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -48671,7 +48671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -48685,7 +48685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -48699,7 +48699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -49029,7 +49029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -49049,7 +49049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -49063,7 +49063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -49091,7 +49091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -49291,7 +49291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAME70Q20B.svd
+++ b/data/Atmel/ATSAME70Q20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9287,7 +9287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9361,7 +9361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9406,7 +9406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9433,7 +9433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9484,7 +9484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9535,7 +9535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9586,7 +9586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9637,7 +9637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9694,7 +9694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9710,7 +9710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9744,7 +9744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9842,7 +9842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9950,7 +9950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9970,7 +9970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9984,7 +9984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10016,7 +10016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10048,7 +10048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10080,7 +10080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10112,7 +10112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10144,7 +10144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10177,7 +10177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10258,7 +10258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10321,7 +10321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10384,7 +10384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10447,7 +10447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10468,7 +10468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10489,7 +10489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10510,7 +10510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10524,7 +10524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10556,7 +10556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10570,7 +10570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10584,7 +10584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10616,7 +10616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10630,7 +10630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10658,7 +10658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10696,7 +10696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10855,7 +10855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10894,7 +10894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11122,7 +11122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11150,7 +11150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11194,7 +11194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11239,7 +11239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11254,7 +11254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11268,7 +11268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11319,7 +11319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11381,7 +11381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11401,7 +11401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11610,7 +11610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11642,7 +11642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11680,7 +11680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11694,7 +11694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11756,7 +11756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11770,7 +11770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11803,7 +11803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11944,7 +11944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11964,7 +11964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12140,7 +12140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12316,7 +12316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12492,7 +12492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12512,7 +12512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12596,7 +12596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12616,7 +12616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12636,7 +12636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12650,7 +12650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12706,7 +12706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12906,7 +12906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13106,7 +13106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13138,7 +13138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13177,7 +13177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13191,7 +13191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13205,7 +13205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13237,7 +13237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13305,7 +13305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13319,7 +13319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13474,7 +13474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13506,7 +13506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13539,7 +13539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13596,7 +13596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13797,7 +13797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13997,7 +13997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14197,7 +14197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14398,7 +14398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14599,7 +14599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14799,7 +14799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -14999,7 +14999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15025,7 +15025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15064,7 +15064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15109,7 +15109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15310,7 +15310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15511,7 +15511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15712,7 +15712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -15913,7 +15913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16114,7 +16114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16315,7 +16315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -16516,7 +16516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -16717,7 +16717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -16918,7 +16918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17119,7 +17119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17320,7 +17320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -17520,7 +17520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -17721,7 +17721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -17922,7 +17922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18123,7 +18123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18324,7 +18324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -18525,7 +18525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -18726,7 +18726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -18927,7 +18927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19128,7 +19128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19329,7 +19329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -19530,7 +19530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19733,7 +19733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -19933,7 +19933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20134,7 +20134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20335,7 +20335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -20536,7 +20536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -20550,7 +20550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -20751,7 +20751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -20952,7 +20952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21153,7 +21153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21354,7 +21354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -21555,7 +21555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -21756,7 +21756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -21957,7 +21957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22158,7 +22158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22359,7 +22359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -22560,7 +22560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -22761,7 +22761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -22962,7 +22962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23163,7 +23163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23364,7 +23364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -23565,7 +23565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -23766,7 +23766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23794,7 +23794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23815,7 +23815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24015,7 +24015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24631,7 +24631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -24687,7 +24687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -24720,7 +24720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24753,7 +24753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24786,7 +24786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -24807,7 +24807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -24873,7 +24873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -24936,7 +24936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -24999,7 +24999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25068,7 +25068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25227,7 +25227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25386,7 +25386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -25736,7 +25736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -25857,7 +25857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -25879,7 +25879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25927,7 +25927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26032,7 +26032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26137,7 +26137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26260,7 +26260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -26523,7 +26523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -26627,7 +26627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -26642,7 +26642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -26670,7 +26670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -26691,7 +26691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -26844,7 +26844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -26997,7 +26997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27150,7 +27150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27222,7 +27222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27266,7 +27266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -27425,7 +27425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -27584,7 +27584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -27743,7 +27743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -27902,7 +27902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -27916,7 +27916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28069,7 +28069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28222,7 +28222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -28375,7 +28375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -28528,7 +28528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -28562,7 +28562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28736,7 +28736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28769,7 +28769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28802,7 +28802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28835,7 +28835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28892,7 +28892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28949,7 +28949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29006,7 +29006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29063,7 +29063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29131,7 +29131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29146,7 +29146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29160,7 +29160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29180,7 +29180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29195,7 +29195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29312,7 +29312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29429,7 +29429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -29546,7 +29546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29663,7 +29663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29719,7 +29719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29775,7 +29775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29832,7 +29832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29889,7 +29889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -29946,7 +29946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30003,7 +30003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30029,7 +30029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30050,7 +30050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30065,7 +30065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30121,7 +30121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30155,7 +30155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30211,7 +30211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30231,7 +30231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30246,7 +30246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30278,7 +30278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30334,7 +30334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30417,7 +30417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30516,7 +30516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30549,7 +30549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30570,7 +30570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30614,7 +30614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30654,7 +30654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30848,7 +30848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30862,7 +30862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30877,7 +30877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30891,7 +30891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30906,7 +30906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30921,7 +30921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30941,7 +30941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30963,7 +30963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -30984,7 +30984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31005,7 +31005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31085,7 +31085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31123,7 +31123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31144,7 +31144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31224,7 +31224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31262,7 +31262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31310,7 +31310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31343,7 +31343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31463,7 +31463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31478,7 +31478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31493,7 +31493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31550,7 +31550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31601,7 +31601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31652,7 +31652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31703,7 +31703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31735,7 +31735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31749,7 +31749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31769,7 +31769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31947,7 +31947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31980,7 +31980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31995,7 +31995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32023,7 +32023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32063,7 +32063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32098,7 +32098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32159,7 +32159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32218,7 +32218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32247,7 +32247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32297,7 +32297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32331,7 +32331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32404,7 +32404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32618,7 +32618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32650,7 +32650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32688,7 +32688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32738,7 +32738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32770,7 +32770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32893,7 +32893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32938,7 +32938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32983,7 +32983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33028,7 +33028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33073,7 +33073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33125,7 +33125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33169,7 +33169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33183,7 +33183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33198,7 +33198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33238,7 +33238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33290,7 +33290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33304,7 +33304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33450,7 +33450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33529,7 +33529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33544,7 +33544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33559,7 +33559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33574,7 +33574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33589,7 +33589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33616,7 +33616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33649,7 +33649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33663,7 +33663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33678,7 +33678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33714,7 +33714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33746,7 +33746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -33778,7 +33778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -33798,7 +33798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -33928,7 +33928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -33966,7 +33966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -33981,7 +33981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -33996,7 +33996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34024,7 +34024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34064,7 +34064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34103,7 +34103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34195,7 +34195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34216,7 +34216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34266,7 +34266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34323,7 +34323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34374,7 +34374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34425,7 +34425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34478,7 +34478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34511,12 +34511,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -34608,7 +34608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34636,7 +34636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34684,7 +34684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34723,7 +34723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34737,7 +34737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34895,7 +34895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34997,7 +34997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35144,7 +35144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35252,7 +35252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35267,7 +35267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35282,7 +35282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35297,7 +35297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35311,7 +35311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35325,7 +35325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35339,7 +35339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35408,7 +35408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35465,7 +35465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35522,7 +35522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35579,7 +35579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35607,7 +35607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35638,7 +35638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -35647,7 +35647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35708,7 +35708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35794,7 +35794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35898,7 +35898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36108,7 +36108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36648,7 +36648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37093,6 +37093,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -37127,7 +37155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37154,7 +37182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37397,9 +37425,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -37833,7 +37861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37853,7 +37881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37868,7 +37896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37883,7 +37911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37897,7 +37925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37911,7 +37939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37925,7 +37953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38000,7 +38028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38057,7 +38085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38114,7 +38142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38171,7 +38199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38224,7 +38252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38239,7 +38267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38397,7 +38425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38430,7 +38458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38463,7 +38491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38496,7 +38524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38535,7 +38563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38555,7 +38583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38650,7 +38678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38679,7 +38707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38694,7 +38722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38709,7 +38737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38724,7 +38752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38739,7 +38767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38773,7 +38801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38914,7 +38942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38963,7 +38991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39031,7 +39059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39045,7 +39073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39077,7 +39105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39200,7 +39228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39305,7 +39333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39410,7 +39438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39515,7 +39543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39530,7 +39558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39545,7 +39573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39577,7 +39605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39609,7 +39637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39641,7 +39669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39669,7 +39697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39725,7 +39753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39782,7 +39810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39891,7 +39919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39942,7 +39970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39993,7 +40021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40044,7 +40072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40095,7 +40123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40110,7 +40138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40125,7 +40153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40139,7 +40167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40184,7 +40212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41010,6 +41038,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -41060,7 +41106,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -41101,80 +41193,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41272,12 +41290,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -41287,6 +41299,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41322,46 +41346,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -41390,6 +41374,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41443,7 +41445,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -41490,134 +41538,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41709,30 +41629,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -41742,6 +41638,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41777,64 +41685,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -41863,6 +41713,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41916,7 +41784,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -41963,134 +41877,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42182,30 +41968,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -42215,6 +41977,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42250,64 +42024,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -42336,6 +42052,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42413,7 +42147,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -42460,140 +42246,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42691,30 +42343,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -42724,6 +42352,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42754,64 +42394,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -43502,7 +43084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -43593,7 +43175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -43746,7 +43328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -43797,7 +43379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -43890,7 +43472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -44043,7 +43625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -44196,7 +43778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -44349,7 +43931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -44477,7 +44059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -44506,7 +44088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -44678,7 +44260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -44843,9 +44425,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45009,9 +44591,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45175,9 +44757,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45341,7 +44923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -45400,9 +44982,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45460,9 +45042,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45520,9 +45102,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45580,7 +45162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -45645,9 +45227,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45711,9 +45293,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45777,9 +45359,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45843,7 +45425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -45944,9 +45526,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46052,9 +45634,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46154,9 +45736,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46256,7 +45838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -46357,9 +45939,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46465,9 +46047,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46567,9 +46149,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46669,7 +46251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -46758,9 +46340,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46848,9 +46430,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46938,9 +46520,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47032,7 +46614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47046,7 +46628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47060,7 +46642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47122,7 +46704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47167,7 +46749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -47222,7 +46804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -47331,43 +46913,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47375,7 +46957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -47426,7 +47008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -47475,43 +47057,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47519,7 +47101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -47628,43 +47210,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47672,7 +47254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -47781,43 +47363,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47825,7 +47407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -47934,43 +47516,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47978,7 +47560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -48094,7 +47676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -48120,7 +47702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -48152,7 +47734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -48184,7 +47766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -48206,7 +47788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -48366,9 +47948,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -48533,7 +48115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -48682,9 +48264,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48832,9 +48414,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48982,9 +48564,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49132,7 +48714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -49185,9 +48767,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49239,9 +48821,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49293,9 +48875,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49347,7 +48929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -49412,9 +48994,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49478,9 +49060,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49544,9 +49126,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49610,7 +49192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -49699,9 +49281,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49789,9 +49371,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49879,9 +49461,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49969,7 +49551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -50052,9 +49634,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50136,9 +49718,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50220,9 +49802,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50304,7 +49886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -50387,9 +49969,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50471,9 +50053,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50555,9 +50137,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50639,7 +50221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -50661,7 +50243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -50711,7 +50293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50725,7 +50307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50739,7 +50321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50801,7 +50383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50846,7 +50428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -50903,7 +50485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -50948,7 +50530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -50963,7 +50545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -50999,7 +50581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51030,7 +50612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -51076,7 +50658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51105,7 +50687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51155,7 +50737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51195,7 +50777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51222,7 +50804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51260,7 +50842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51292,7 +50874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -51445,7 +51027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51598,7 +51180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -51751,7 +51333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -51904,7 +51486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -52057,7 +51639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -52210,7 +51792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -52363,7 +51945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -52515,7 +52097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -52667,7 +52249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -52820,7 +52402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -52973,7 +52555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -53126,7 +52708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -53279,7 +52861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -53438,7 +53020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -53489,7 +53071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -53540,7 +53122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -53591,7 +53173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -53642,7 +53224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -53656,7 +53238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -53670,7 +53252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -53690,7 +53272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -53784,7 +53366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -53798,7 +53380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -53812,7 +53394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -54405,7 +53987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -54425,7 +54007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -54439,7 +54021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -54467,7 +54049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -54667,7 +54249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -56556,6 +56138,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAME70Q21.svd
+++ b/data/Atmel/ATSAME70Q21.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4154,7 +4154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4258,7 +4258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4437,7 +4437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4458,7 +4458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4472,7 +4472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4574,7 +4574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4624,7 +4624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4638,7 +4638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4684,7 +4684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4831,7 +4831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4984,7 +4984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5137,7 +5137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5289,7 +5289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5339,7 +5339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5354,7 +5354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5368,7 +5368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5408,7 +5408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5422,7 +5422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5457,7 +5457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5471,7 +5471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5546,7 +5546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5566,7 +5566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5618,7 +5618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5658,7 +5658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5672,7 +5672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5686,7 +5686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5700,7 +5700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5714,7 +5714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6073,7 +6073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6103,7 +6103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6118,7 +6118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6133,7 +6133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6148,7 +6148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6163,7 +6163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6178,7 +6178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6193,7 +6193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6208,7 +6208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6223,7 +6223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6238,7 +6238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6253,7 +6253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6268,7 +6268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6328,7 +6328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6343,7 +6343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6358,7 +6358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6373,7 +6373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6388,7 +6388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6403,7 +6403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6418,7 +6418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6433,7 +6433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6448,7 +6448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6463,7 +6463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6477,7 +6477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6491,7 +6491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6519,7 +6519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6540,7 +6540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6566,7 +6566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6581,7 +6581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6596,7 +6596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6611,7 +6611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6626,7 +6626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6641,7 +6641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6656,7 +6656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6671,7 +6671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6688,7 +6688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6741,7 +6741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6757,7 +6757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6773,7 +6773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6787,7 +6787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6837,7 +6837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6877,7 +6877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6953,7 +6953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7006,7 +7006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7059,7 +7059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7125,7 +7125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7145,7 +7145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7188,7 +7188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7208,7 +7208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7251,7 +7251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7271,7 +7271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7314,7 +7314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7334,7 +7334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7377,7 +7377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7397,7 +7397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7460,7 +7460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7503,7 +7503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7523,7 +7523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7566,7 +7566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7586,7 +7586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7629,7 +7629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7649,7 +7649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7692,7 +7692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7712,7 +7712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7755,7 +7755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7775,7 +7775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7818,7 +7818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7838,7 +7838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7881,7 +7881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7901,7 +7901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7944,7 +7944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7964,7 +7964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8007,7 +8007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8027,7 +8027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8070,7 +8070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8090,7 +8090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8133,7 +8133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8153,7 +8153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8196,7 +8196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8216,7 +8216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8259,7 +8259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8279,7 +8279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8342,7 +8342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8385,7 +8385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8405,7 +8405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8448,7 +8448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8468,7 +8468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8511,7 +8511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8531,7 +8531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8574,7 +8574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8687,7 +8687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8776,7 +8776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8839,7 +8839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8885,7 +8885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8899,7 +8899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9156,7 +9156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9176,7 +9176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9241,7 +9241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9256,7 +9256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9271,7 +9271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9286,7 +9286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9439,7 +9439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9592,7 +9592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9898,7 +9898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9946,7 +9946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9978,7 +9978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10006,7 +10006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10029,7 +10029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10062,7 +10062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10181,7 +10181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10208,7 +10208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10259,7 +10259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10310,7 +10310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10361,7 +10361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10412,7 +10412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10455,7 +10455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10469,7 +10469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10485,7 +10485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10519,7 +10519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10617,7 +10617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10725,7 +10725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10745,7 +10745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10759,7 +10759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10791,7 +10791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10823,7 +10823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10855,7 +10855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10887,7 +10887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10919,7 +10919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11033,7 +11033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11096,7 +11096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11159,7 +11159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11222,7 +11222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11243,7 +11243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11264,7 +11264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11285,7 +11285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11299,7 +11299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11331,7 +11331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11345,7 +11345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11359,7 +11359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11391,7 +11391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11405,7 +11405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11433,7 +11433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11471,7 +11471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11530,7 +11530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11580,7 +11580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11630,7 +11630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11663,7 +11663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11833,7 +11833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11861,7 +11861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11905,7 +11905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11919,7 +11919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11976,7 +11976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12044,7 +12044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12064,7 +12064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12277,7 +12277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12309,7 +12309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12347,7 +12347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12361,7 +12361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12423,7 +12423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12437,7 +12437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12470,7 +12470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -12599,7 +12599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12787,7 +12787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12975,7 +12975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13163,7 +13163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13183,7 +13183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13267,7 +13267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13287,7 +13287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13307,7 +13307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13321,7 +13321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13377,7 +13377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13577,7 +13577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13777,7 +13777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13809,7 +13809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13848,7 +13848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13862,7 +13862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13876,7 +13876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13908,7 +13908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13976,7 +13976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13990,7 +13990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14145,7 +14145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14177,7 +14177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14210,7 +14210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14267,7 +14267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14468,7 +14468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14668,7 +14668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14868,7 +14868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15069,7 +15069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15270,7 +15270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15470,7 +15470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15670,7 +15670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15696,7 +15696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15735,7 +15735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15780,7 +15780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15981,7 +15981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16182,7 +16182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16383,7 +16383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16584,7 +16584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16785,7 +16785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16986,7 +16986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17187,7 +17187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17388,7 +17388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17589,7 +17589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17790,7 +17790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17991,7 +17991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18191,7 +18191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18392,7 +18392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18593,7 +18593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18794,7 +18794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18995,7 +18995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19196,7 +19196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19397,7 +19397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19598,7 +19598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19799,7 +19799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -20000,7 +20000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20201,7 +20201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20404,7 +20404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20604,7 +20604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20805,7 +20805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -21006,7 +21006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21207,7 +21207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21221,7 +21221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21422,7 +21422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21623,7 +21623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21824,7 +21824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -22025,7 +22025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22226,7 +22226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22427,7 +22427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22628,7 +22628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22829,7 +22829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -23030,7 +23030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23231,7 +23231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23432,7 +23432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23633,7 +23633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23834,7 +23834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -24035,7 +24035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24236,7 +24236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24437,7 +24437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24465,7 +24465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24486,7 +24486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24686,7 +24686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25302,7 +25302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25358,7 +25358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25391,7 +25391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25424,7 +25424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25457,7 +25457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25478,7 +25478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25544,7 +25544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25601,7 +25601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25721,7 +25721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25880,7 +25880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -26039,7 +26039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26389,7 +26389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26510,7 +26510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26532,7 +26532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26580,7 +26580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26679,7 +26679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26778,7 +26778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26895,7 +26895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26994,7 +26994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27152,7 +27152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27256,7 +27256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27271,7 +27271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27299,7 +27299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27320,7 +27320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27479,7 +27479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27638,7 +27638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27797,7 +27797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27869,7 +27869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27913,7 +27913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28072,7 +28072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28231,7 +28231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28390,7 +28390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28549,7 +28549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28563,7 +28563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28722,7 +28722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28881,7 +28881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29040,7 +29040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29199,7 +29199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29233,7 +29233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29407,7 +29407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29440,7 +29440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29473,7 +29473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29506,7 +29506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29563,7 +29563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29620,7 +29620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29677,7 +29677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29734,7 +29734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29802,7 +29802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29817,7 +29817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29831,7 +29831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29851,7 +29851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29866,7 +29866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29983,7 +29983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30100,7 +30100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30217,7 +30217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30334,7 +30334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30390,7 +30390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30446,7 +30446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30503,7 +30503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30560,7 +30560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30617,7 +30617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30674,7 +30674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30700,7 +30700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30721,7 +30721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30736,7 +30736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30792,7 +30792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30826,7 +30826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30882,7 +30882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30902,7 +30902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30917,7 +30917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30949,7 +30949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -31005,7 +31005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31088,7 +31088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31187,7 +31187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31207,7 +31207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31228,7 +31228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31272,7 +31272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31312,7 +31312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31454,7 +31454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31468,7 +31468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31483,7 +31483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31497,7 +31497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31512,7 +31512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31527,7 +31527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31547,7 +31547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31569,7 +31569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31590,7 +31590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31611,7 +31611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31691,7 +31691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31729,7 +31729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31750,7 +31750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31830,7 +31830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31868,7 +31868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31916,7 +31916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31949,7 +31949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32069,7 +32069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32084,7 +32084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32099,7 +32099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32156,7 +32156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32207,7 +32207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32258,7 +32258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32309,7 +32309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32341,7 +32341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32355,7 +32355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32375,7 +32375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32553,7 +32553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32586,7 +32586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32601,7 +32601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32629,7 +32629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32669,7 +32669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32704,7 +32704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32765,7 +32765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32824,7 +32824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32853,7 +32853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32903,7 +32903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32937,7 +32937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33010,7 +33010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33224,7 +33224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33256,7 +33256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33294,7 +33294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33344,7 +33344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33376,7 +33376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33499,7 +33499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33544,7 +33544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33589,7 +33589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33634,7 +33634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33679,7 +33679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33731,7 +33731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33775,7 +33775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33789,7 +33789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33804,7 +33804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33844,7 +33844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33896,7 +33896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33910,7 +33910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34056,7 +34056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34135,7 +34135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34150,7 +34150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34165,7 +34165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34180,7 +34180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34195,7 +34195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34222,7 +34222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34255,7 +34255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34269,7 +34269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34284,7 +34284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34320,7 +34320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34352,7 +34352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34384,7 +34384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34404,7 +34404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC MODE Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34534,7 +34534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC OCMS MODE Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -34572,7 +34572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC OCMS KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -34587,7 +34587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC OCMS KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -34602,7 +34602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34630,7 +34630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34670,7 +34670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34733,7 +34733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34789,7 +34789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34810,7 +34810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34837,7 +34837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34894,7 +34894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34945,7 +34945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34996,7 +34996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35049,7 +35049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35153,7 +35153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35181,7 +35181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35229,7 +35229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -35268,7 +35268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -35282,7 +35282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35440,7 +35440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35542,7 +35542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35689,7 +35689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35797,7 +35797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35812,7 +35812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35827,7 +35827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35842,7 +35842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35856,7 +35856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35870,7 +35870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35884,7 +35884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35953,7 +35953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36010,7 +36010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -36067,7 +36067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36124,7 +36124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36152,7 +36152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36192,7 +36192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36253,7 +36253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36339,7 +36339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36443,7 +36443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36653,7 +36653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37193,7 +37193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37672,7 +37672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37699,7 +37699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37942,7 +37942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37962,7 +37962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37977,7 +37977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37992,7 +37992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -38006,7 +38006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -38020,7 +38020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -38034,7 +38034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38109,7 +38109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38166,7 +38166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38223,7 +38223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38280,7 +38280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38333,7 +38333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38348,7 +38348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38494,7 +38494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38521,7 +38521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38548,7 +38548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38575,7 +38575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38608,7 +38608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38628,7 +38628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38723,7 +38723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38752,7 +38752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38767,7 +38767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38782,7 +38782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38797,7 +38797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38812,7 +38812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38846,7 +38846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38987,7 +38987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -39036,7 +39036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39104,7 +39104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39118,7 +39118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39150,7 +39150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39273,7 +39273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39378,7 +39378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39483,7 +39483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39588,7 +39588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39603,7 +39603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39618,7 +39618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39650,7 +39650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39682,7 +39682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39714,7 +39714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39742,7 +39742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39798,7 +39798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39855,7 +39855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39964,7 +39964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40015,7 +40015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40066,7 +40066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40117,7 +40117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40168,7 +40168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40183,7 +40183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40198,7 +40198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40212,7 +40212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40257,7 +40257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41840,7 +41840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41921,7 +41921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -42086,7 +42086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42137,7 +42137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42230,7 +42230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -42395,7 +42395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -42560,7 +42560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -42725,7 +42725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42853,7 +42853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42882,7 +42882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -43054,7 +43054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43219,7 +43219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -43278,7 +43278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43343,7 +43343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43444,7 +43444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43545,7 +43545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43638,7 +43638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43652,7 +43652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43666,7 +43666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43728,7 +43728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43773,7 +43773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43818,7 +43818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43983,7 +43983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -44034,7 +44034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44127,7 +44127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44292,7 +44292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44457,7 +44457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44622,7 +44622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44738,7 +44738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44764,7 +44764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44796,7 +44796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44828,7 +44828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44850,7 +44850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -45010,7 +45010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45159,7 +45159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45212,7 +45212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45277,7 +45277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45366,7 +45366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -45449,7 +45449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -45532,7 +45532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -45554,7 +45554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -45604,7 +45604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45618,7 +45618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45632,7 +45632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45694,7 +45694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45739,7 +45739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -45790,7 +45790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -45835,7 +45835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45850,7 +45850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45886,7 +45886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45917,7 +45917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45963,7 +45963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45992,7 +45992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46042,7 +46042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46082,7 +46082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46109,7 +46109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46147,7 +46147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46179,7 +46179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -46332,7 +46332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46485,7 +46485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -46638,7 +46638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -46791,7 +46791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -46944,7 +46944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -47097,7 +47097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -47250,7 +47250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -47402,7 +47402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -47554,7 +47554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47707,7 +47707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47860,7 +47860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -48013,7 +48013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -48166,7 +48166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -48325,7 +48325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -48376,7 +48376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -48427,7 +48427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -48478,7 +48478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -48529,7 +48529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -48543,7 +48543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -48557,7 +48557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -48577,7 +48577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -48671,7 +48671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -48685,7 +48685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -48699,7 +48699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -49029,7 +49029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -49049,7 +49049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -49063,7 +49063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -49091,7 +49091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -49291,7 +49291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -49491,7 +49491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -49691,7 +49691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAME70Q21B.svd
+++ b/data/Atmel/ATSAME70Q21B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9287,7 +9287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9361,7 +9361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9406,7 +9406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9433,7 +9433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9484,7 +9484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9535,7 +9535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9586,7 +9586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9637,7 +9637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9694,7 +9694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9710,7 +9710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9744,7 +9744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9842,7 +9842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9950,7 +9950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9970,7 +9970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9984,7 +9984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10016,7 +10016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10048,7 +10048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10080,7 +10080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10112,7 +10112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10144,7 +10144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10177,7 +10177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10258,7 +10258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10321,7 +10321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10384,7 +10384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10447,7 +10447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10468,7 +10468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10489,7 +10489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10510,7 +10510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10524,7 +10524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10556,7 +10556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10570,7 +10570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10584,7 +10584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10616,7 +10616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10630,7 +10630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10658,7 +10658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10696,7 +10696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10855,7 +10855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10894,7 +10894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11122,7 +11122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11150,7 +11150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11194,7 +11194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11239,7 +11239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11254,7 +11254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11268,7 +11268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11319,7 +11319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11381,7 +11381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11401,7 +11401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11610,7 +11610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11642,7 +11642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11680,7 +11680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11694,7 +11694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11756,7 +11756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11770,7 +11770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11803,7 +11803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11944,7 +11944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11964,7 +11964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12140,7 +12140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12316,7 +12316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12492,7 +12492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12512,7 +12512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12596,7 +12596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12616,7 +12616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12636,7 +12636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12650,7 +12650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12706,7 +12706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12906,7 +12906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13106,7 +13106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13138,7 +13138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13177,7 +13177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13191,7 +13191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13205,7 +13205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13237,7 +13237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13305,7 +13305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13319,7 +13319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13474,7 +13474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13506,7 +13506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13539,7 +13539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13596,7 +13596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13797,7 +13797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13997,7 +13997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14197,7 +14197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14398,7 +14398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14599,7 +14599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14799,7 +14799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -14999,7 +14999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15025,7 +15025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15064,7 +15064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15109,7 +15109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15310,7 +15310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15511,7 +15511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15712,7 +15712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -15913,7 +15913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16114,7 +16114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16315,7 +16315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -16516,7 +16516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -16717,7 +16717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -16918,7 +16918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17119,7 +17119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17320,7 +17320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -17520,7 +17520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -17721,7 +17721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -17922,7 +17922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18123,7 +18123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18324,7 +18324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -18525,7 +18525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -18726,7 +18726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -18927,7 +18927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19128,7 +19128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19329,7 +19329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -19530,7 +19530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19733,7 +19733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -19933,7 +19933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20134,7 +20134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20335,7 +20335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -20536,7 +20536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -20550,7 +20550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -20751,7 +20751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -20952,7 +20952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21153,7 +21153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21354,7 +21354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -21555,7 +21555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -21756,7 +21756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -21957,7 +21957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22158,7 +22158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22359,7 +22359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -22560,7 +22560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -22761,7 +22761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -22962,7 +22962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23163,7 +23163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23364,7 +23364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -23565,7 +23565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -23766,7 +23766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23794,7 +23794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23815,7 +23815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24015,7 +24015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24631,7 +24631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -24687,7 +24687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -24720,7 +24720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24753,7 +24753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24786,7 +24786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -24807,7 +24807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -24873,7 +24873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -24936,7 +24936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -24999,7 +24999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25068,7 +25068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25227,7 +25227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25386,7 +25386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -25736,7 +25736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -25857,7 +25857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -25879,7 +25879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25927,7 +25927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26032,7 +26032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26137,7 +26137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26260,7 +26260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -26523,7 +26523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -26627,7 +26627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -26642,7 +26642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -26670,7 +26670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -26691,7 +26691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -26844,7 +26844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -26997,7 +26997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27150,7 +27150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27222,7 +27222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27266,7 +27266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -27425,7 +27425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -27584,7 +27584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -27743,7 +27743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -27902,7 +27902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -27916,7 +27916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28069,7 +28069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28222,7 +28222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -28375,7 +28375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -28528,7 +28528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -28562,7 +28562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28736,7 +28736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28769,7 +28769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28802,7 +28802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28835,7 +28835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28892,7 +28892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28949,7 +28949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29006,7 +29006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29063,7 +29063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29131,7 +29131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29146,7 +29146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29160,7 +29160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29180,7 +29180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29195,7 +29195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29312,7 +29312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29429,7 +29429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -29546,7 +29546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29663,7 +29663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29719,7 +29719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29775,7 +29775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29832,7 +29832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29889,7 +29889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -29946,7 +29946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30003,7 +30003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30029,7 +30029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30050,7 +30050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30065,7 +30065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30121,7 +30121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30155,7 +30155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30211,7 +30211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30231,7 +30231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30246,7 +30246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30278,7 +30278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30334,7 +30334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30417,7 +30417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30516,7 +30516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30549,7 +30549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30570,7 +30570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30614,7 +30614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30654,7 +30654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30848,7 +30848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30862,7 +30862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30877,7 +30877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30891,7 +30891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30906,7 +30906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30921,7 +30921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30941,7 +30941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30963,7 +30963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -30984,7 +30984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31005,7 +31005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31085,7 +31085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31123,7 +31123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31144,7 +31144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31224,7 +31224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31262,7 +31262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31310,7 +31310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31343,7 +31343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31463,7 +31463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31478,7 +31478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31493,7 +31493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31550,7 +31550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31601,7 +31601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31652,7 +31652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31703,7 +31703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31735,7 +31735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31749,7 +31749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31769,7 +31769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31947,7 +31947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31980,7 +31980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31995,7 +31995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32023,7 +32023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32063,7 +32063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32098,7 +32098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32159,7 +32159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32218,7 +32218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32247,7 +32247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32297,7 +32297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32331,7 +32331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32404,7 +32404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32618,7 +32618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32650,7 +32650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32688,7 +32688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32738,7 +32738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32770,7 +32770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32893,7 +32893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32938,7 +32938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32983,7 +32983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33028,7 +33028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33073,7 +33073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33125,7 +33125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33169,7 +33169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33183,7 +33183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33198,7 +33198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33238,7 +33238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33290,7 +33290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33304,7 +33304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33450,7 +33450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33529,7 +33529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33544,7 +33544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33559,7 +33559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33574,7 +33574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33589,7 +33589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33616,7 +33616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33649,7 +33649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33663,7 +33663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33678,7 +33678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33714,7 +33714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33746,7 +33746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -33778,7 +33778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -33798,7 +33798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -33928,7 +33928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -33966,7 +33966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -33981,7 +33981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -33996,7 +33996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34024,7 +34024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34064,7 +34064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34103,7 +34103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34195,7 +34195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34216,7 +34216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34266,7 +34266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34323,7 +34323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34374,7 +34374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34425,7 +34425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34478,7 +34478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34511,12 +34511,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -34608,7 +34608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34636,7 +34636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34684,7 +34684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34723,7 +34723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34737,7 +34737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34895,7 +34895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34997,7 +34997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35144,7 +35144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35252,7 +35252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35267,7 +35267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35282,7 +35282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35297,7 +35297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35311,7 +35311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35325,7 +35325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35339,7 +35339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35408,7 +35408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35465,7 +35465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35522,7 +35522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35579,7 +35579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35607,7 +35607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35638,7 +35638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -35647,7 +35647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35708,7 +35708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35794,7 +35794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35898,7 +35898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36108,7 +36108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36648,7 +36648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37093,6 +37093,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -37127,7 +37155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37154,7 +37182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37397,9 +37425,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -37833,7 +37861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37853,7 +37881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37868,7 +37896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37883,7 +37911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37897,7 +37925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37911,7 +37939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37925,7 +37953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38000,7 +38028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38057,7 +38085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38114,7 +38142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38171,7 +38199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38224,7 +38252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38239,7 +38267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38397,7 +38425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38430,7 +38458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38463,7 +38491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38496,7 +38524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38535,7 +38563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38555,7 +38583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38650,7 +38678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38679,7 +38707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38694,7 +38722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38709,7 +38737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38724,7 +38752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38739,7 +38767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38773,7 +38801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38914,7 +38942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38963,7 +38991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39031,7 +39059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39045,7 +39073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39077,7 +39105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39200,7 +39228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39305,7 +39333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39410,7 +39438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39515,7 +39543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39530,7 +39558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39545,7 +39573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39577,7 +39605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39609,7 +39637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39641,7 +39669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39669,7 +39697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39725,7 +39753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39782,7 +39810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39891,7 +39919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39942,7 +39970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39993,7 +40021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40044,7 +40072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40095,7 +40123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40110,7 +40138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40125,7 +40153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40139,7 +40167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40184,7 +40212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41010,6 +41038,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -41060,7 +41106,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -41101,80 +41193,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41272,12 +41290,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -41287,6 +41299,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41322,46 +41346,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -41390,6 +41374,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41443,7 +41445,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -41490,134 +41538,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41709,30 +41629,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -41742,6 +41638,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41777,64 +41685,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -41863,6 +41713,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41916,7 +41784,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -41963,134 +41877,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42182,30 +41968,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -42215,6 +41977,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42250,64 +42024,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -42336,6 +42052,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42413,7 +42147,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -42460,140 +42246,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42691,30 +42343,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -42724,6 +42352,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42754,64 +42394,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -43502,7 +43084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -43593,7 +43175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -43746,7 +43328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -43797,7 +43379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -43890,7 +43472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -44043,7 +43625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -44196,7 +43778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -44349,7 +43931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -44477,7 +44059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -44506,7 +44088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -44678,7 +44260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -44843,9 +44425,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45009,9 +44591,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45175,9 +44757,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45341,7 +44923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -45400,9 +44982,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45460,9 +45042,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45520,9 +45102,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45580,7 +45162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -45645,9 +45227,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45711,9 +45293,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45777,9 +45359,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45843,7 +45425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -45944,9 +45526,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46052,9 +45634,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46154,9 +45736,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46256,7 +45838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -46357,9 +45939,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46465,9 +46047,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46567,9 +46149,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46669,7 +46251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -46758,9 +46340,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46848,9 +46430,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46938,9 +46520,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47032,7 +46614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47046,7 +46628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47060,7 +46642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47122,7 +46704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47167,7 +46749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -47222,7 +46804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -47331,43 +46913,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47375,7 +46957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -47426,7 +47008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -47475,43 +47057,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47519,7 +47101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -47628,43 +47210,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47672,7 +47254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -47781,43 +47363,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47825,7 +47407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -47934,43 +47516,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47978,7 +47560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -48094,7 +47676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -48120,7 +47702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -48152,7 +47734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -48184,7 +47766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -48206,7 +47788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -48366,9 +47948,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -48533,7 +48115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -48682,9 +48264,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48832,9 +48414,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48982,9 +48564,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49132,7 +48714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -49185,9 +48767,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49239,9 +48821,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49293,9 +48875,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49347,7 +48929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -49412,9 +48994,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49478,9 +49060,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49544,9 +49126,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49610,7 +49192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -49699,9 +49281,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49789,9 +49371,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49879,9 +49461,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49969,7 +49551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -50052,9 +49634,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50136,9 +49718,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50220,9 +49802,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50304,7 +49886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -50387,9 +49969,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50471,9 +50053,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50555,9 +50137,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50639,7 +50221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -50661,7 +50243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -50711,7 +50293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50725,7 +50307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50739,7 +50321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50801,7 +50383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50846,7 +50428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -50903,7 +50485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -50948,7 +50530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -50963,7 +50545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -50999,7 +50581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51030,7 +50612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -51076,7 +50658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51105,7 +50687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51155,7 +50737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51195,7 +50777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51222,7 +50804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51260,7 +50842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51292,7 +50874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -51445,7 +51027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51598,7 +51180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -51751,7 +51333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -51904,7 +51486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -52057,7 +51639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -52210,7 +51792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -52363,7 +51945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -52515,7 +52097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -52667,7 +52249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -52820,7 +52402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -52973,7 +52555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -53126,7 +52708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -53279,7 +52861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -53438,7 +53020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -53489,7 +53071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -53540,7 +53122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -53591,7 +53173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -53642,7 +53224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -53656,7 +53238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -53670,7 +53252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -53690,7 +53272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -53784,7 +53366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -53798,7 +53380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -53812,7 +53394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -54405,7 +53987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -54425,7 +54007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -54439,7 +54021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -54467,7 +54049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -54667,7 +54249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -54867,7 +54449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -55067,7 +54649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>
@@ -56956,6 +56538,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMS70J19.svd
+++ b/data/Atmel/ATSAMS70J19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4177,7 +4177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4251,7 +4251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4296,7 +4296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4323,7 +4323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4374,7 +4374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4425,7 +4425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4476,7 +4476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4527,7 +4527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4570,7 +4570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4584,7 +4584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4600,7 +4600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -4634,7 +4634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4732,7 +4732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4840,7 +4840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4860,7 +4860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4874,7 +4874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4906,7 +4906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4938,7 +4938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4970,7 +4970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5002,7 +5002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5034,7 +5034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5067,7 +5067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5148,7 +5148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5211,7 +5211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5274,7 +5274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5337,7 +5337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5358,7 +5358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -5379,7 +5379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5400,7 +5400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5414,7 +5414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5460,7 +5460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -5520,7 +5520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5548,7 +5548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5586,7 +5586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -5645,7 +5645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5695,7 +5695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5745,7 +5745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5760,7 +5760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -5892,7 +5892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -5920,7 +5920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -6362,7 +6362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -6563,7 +6563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -6965,7 +6965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -7166,7 +7166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -7367,7 +7367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -7568,7 +7568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -7769,7 +7769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -7970,7 +7970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -8171,7 +8171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -8371,7 +8371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -8572,7 +8572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -8773,7 +8773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -8974,7 +8974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -9175,7 +9175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -9376,7 +9376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -9577,7 +9577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -9778,7 +9778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -9979,7 +9979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -10180,7 +10180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -10381,7 +10381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -10584,7 +10584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -10784,7 +10784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -10985,7 +10985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -11186,7 +11186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -11387,7 +11387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -11401,7 +11401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -11602,7 +11602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -11803,7 +11803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -12004,7 +12004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -12205,7 +12205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -12406,7 +12406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -12607,7 +12607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -12808,7 +12808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -13009,7 +13009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -13210,7 +13210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -13411,7 +13411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -13612,7 +13612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -13813,7 +13813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -14014,7 +14014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -14215,7 +14215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -14416,7 +14416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -14617,7 +14617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -14645,7 +14645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -14666,7 +14666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -14866,7 +14866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -15482,7 +15482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -15538,7 +15538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -15571,7 +15571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -15604,7 +15604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -15637,7 +15637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -15658,7 +15658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -15708,7 +15708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15765,7 +15765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15822,7 +15822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15885,7 +15885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16044,7 +16044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16203,7 +16203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16553,7 +16553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -16674,7 +16674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16696,7 +16696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -16744,7 +16744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16843,7 +16843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16942,7 +16942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17059,7 +17059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -17158,7 +17158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -17316,7 +17316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -17420,7 +17420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -17435,7 +17435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -17463,7 +17463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -17484,7 +17484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -17643,7 +17643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -17802,7 +17802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -17961,7 +17961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -18033,7 +18033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -18077,7 +18077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -18236,7 +18236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -18395,7 +18395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -18554,7 +18554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -18713,7 +18713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -18727,7 +18727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -18886,7 +18886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -19045,7 +19045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -19204,7 +19204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -19363,7 +19363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -19397,7 +19397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -19571,7 +19571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -19604,7 +19604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -19637,7 +19637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -19670,7 +19670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -19727,7 +19727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -19784,7 +19784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -19841,7 +19841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -19898,7 +19898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -19966,7 +19966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -19981,7 +19981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -19995,7 +19995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -20015,7 +20015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -20030,7 +20030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -20147,7 +20147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -20264,7 +20264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -20381,7 +20381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -20498,7 +20498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -20554,7 +20554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -20610,7 +20610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -20667,7 +20667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -20724,7 +20724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -20781,7 +20781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -20838,7 +20838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -20864,7 +20864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -20885,7 +20885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -20900,7 +20900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -20956,7 +20956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -20990,7 +20990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -21046,7 +21046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -21066,7 +21066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -21081,7 +21081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -21113,7 +21113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -21169,7 +21169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -21252,7 +21252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -21351,7 +21351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -21371,7 +21371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21392,7 +21392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21436,7 +21436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21476,7 +21476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -21618,7 +21618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21632,7 +21632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21647,7 +21647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21661,7 +21661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -21676,7 +21676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -21691,7 +21691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -21711,7 +21711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -21733,7 +21733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -21754,7 +21754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -21775,7 +21775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -21855,7 +21855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -21893,7 +21893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -21914,7 +21914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -21994,7 +21994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -22032,7 +22032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -22080,7 +22080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22113,7 +22113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22233,7 +22233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22248,7 +22248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -22263,7 +22263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -22320,7 +22320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -22371,7 +22371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -22422,7 +22422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -22473,7 +22473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -22505,7 +22505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -22519,7 +22519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -22539,7 +22539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -22717,7 +22717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22750,7 +22750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22765,7 +22765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22793,7 +22793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22833,7 +22833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22868,7 +22868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22929,7 +22929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22988,7 +22988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23017,7 +23017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23101,7 +23101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23174,7 +23174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23388,7 +23388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23420,7 +23420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23458,7 +23458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23508,7 +23508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23540,7 +23540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23663,7 +23663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23708,7 +23708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23753,7 +23753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -23798,7 +23798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -23843,7 +23843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -23895,7 +23895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23939,7 +23939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23953,7 +23953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24008,7 +24008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -24047,7 +24047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -24061,7 +24061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24219,7 +24219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24321,7 +24321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24468,7 +24468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24576,7 +24576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24591,7 +24591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -24606,7 +24606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24621,7 +24621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24635,7 +24635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24649,7 +24649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -24663,7 +24663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24732,7 +24732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24789,7 +24789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -24846,7 +24846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -24903,7 +24903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24931,7 +24931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24971,7 +24971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25032,7 +25032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25118,7 +25118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25222,7 +25222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25432,7 +25432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25972,7 +25972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26451,7 +26451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26478,7 +26478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26721,7 +26721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26741,7 +26741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26756,7 +26756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -26771,7 +26771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -26785,7 +26785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -26799,7 +26799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -26813,7 +26813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -26888,7 +26888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -26945,7 +26945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -27002,7 +27002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -27059,7 +27059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -27112,7 +27112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27127,7 +27127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -27273,7 +27273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -27300,7 +27300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -27327,7 +27327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -27354,7 +27354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -27387,7 +27387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -27407,7 +27407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27502,7 +27502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27531,7 +27531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27546,7 +27546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27561,7 +27561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27576,7 +27576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27591,7 +27591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27625,7 +27625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27766,7 +27766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27815,7 +27815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27883,7 +27883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27897,7 +27897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27929,7 +27929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28052,7 +28052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28157,7 +28157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28262,7 +28262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28367,7 +28367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28382,7 +28382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28397,7 +28397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28429,7 +28429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28461,7 +28461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28493,7 +28493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28521,7 +28521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28569,7 +28569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -28626,7 +28626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -28735,7 +28735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -28786,7 +28786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -28837,7 +28837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -28888,7 +28888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -28939,7 +28939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -28954,7 +28954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -28969,7 +28969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -28983,7 +28983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -29028,7 +29028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -30587,7 +30587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -30668,7 +30668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -30833,7 +30833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -30884,7 +30884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -30977,7 +30977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -31142,7 +31142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -31307,7 +31307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -31472,7 +31472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -31600,7 +31600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -31629,7 +31629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -31801,7 +31801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -31966,7 +31966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -32025,7 +32025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -32090,7 +32090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -32191,7 +32191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -32292,7 +32292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -32385,7 +32385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32399,7 +32399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32413,7 +32413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32475,7 +32475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32520,7 +32520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -32565,7 +32565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -32730,7 +32730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -32781,7 +32781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -32874,7 +32874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -33039,7 +33039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -33204,7 +33204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -33369,7 +33369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -33485,7 +33485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -33511,7 +33511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -33543,7 +33543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -33575,7 +33575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -33597,7 +33597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -33757,7 +33757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -33906,7 +33906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -33959,7 +33959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -34024,7 +34024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -34113,7 +34113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -34196,7 +34196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -34279,7 +34279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -34301,7 +34301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -34351,7 +34351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34365,7 +34365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34379,7 +34379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34441,7 +34441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34486,7 +34486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -34537,7 +34537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -34582,7 +34582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -34597,7 +34597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -34633,7 +34633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34664,7 +34664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34710,7 +34710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34739,7 +34739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34789,7 +34789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34829,7 +34829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34856,7 +34856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34894,7 +34894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34926,7 +34926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35079,7 +35079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35232,7 +35232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35385,7 +35385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35538,7 +35538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35691,7 +35691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35844,7 +35844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35997,7 +35997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36149,7 +36149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36301,7 +36301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36454,7 +36454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36607,7 +36607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36760,7 +36760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -36913,7 +36913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -37072,7 +37072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37123,7 +37123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37174,7 +37174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37225,7 +37225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37276,7 +37276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37290,7 +37290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37304,7 +37304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37324,7 +37324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37418,7 +37418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37432,7 +37432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37446,7 +37446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37776,7 +37776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37796,7 +37796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37810,7 +37810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -37838,7 +37838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMS70J19B.svd
+++ b/data/Atmel/ATSAMS70J19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4257,7 +4257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4302,7 +4302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4380,7 +4380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4431,7 +4431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4482,7 +4482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4533,7 +4533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4576,7 +4576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4590,7 +4590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4606,7 +4606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -4640,7 +4640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4738,7 +4738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4846,7 +4846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4866,7 +4866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4880,7 +4880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4912,7 +4912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4944,7 +4944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4976,7 +4976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5008,7 +5008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5040,7 +5040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5073,7 +5073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5154,7 +5154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5217,7 +5217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5280,7 +5280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5343,7 +5343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5364,7 +5364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -5385,7 +5385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5406,7 +5406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5420,7 +5420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5452,7 +5452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5480,7 +5480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5512,7 +5512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5554,7 +5554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5592,7 +5592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -5651,7 +5651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5701,7 +5701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5751,7 +5751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5772,7 +5772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -5962,7 +5962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -5990,7 +5990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -6231,7 +6231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -6432,7 +6432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -6633,7 +6633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -6834,7 +6834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -7035,7 +7035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -7236,7 +7236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -7437,7 +7437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -7638,7 +7638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -7839,7 +7839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -8040,7 +8040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -8241,7 +8241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -8843,7 +8843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -9044,7 +9044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -9446,7 +9446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -9647,7 +9647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -9848,7 +9848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -10049,7 +10049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -10250,7 +10250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -10451,7 +10451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -10654,7 +10654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -10854,7 +10854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -11055,7 +11055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -11256,7 +11256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -11457,7 +11457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -11471,7 +11471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -11672,7 +11672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -11873,7 +11873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -12074,7 +12074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -12275,7 +12275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -12476,7 +12476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -12677,7 +12677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -12878,7 +12878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -13079,7 +13079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -13280,7 +13280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -13481,7 +13481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -13682,7 +13682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -13883,7 +13883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -14084,7 +14084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -14285,7 +14285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -14486,7 +14486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -14687,7 +14687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -14715,7 +14715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -14736,7 +14736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -14936,7 +14936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -15552,7 +15552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -15608,7 +15608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -15641,7 +15641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -15674,7 +15674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -15707,7 +15707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -15728,7 +15728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -15778,7 +15778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15841,7 +15841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15904,7 +15904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15973,7 +15973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16096,7 +16096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16219,7 +16219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16533,7 +16533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -16654,7 +16654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16676,7 +16676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -16724,7 +16724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16829,7 +16829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16934,7 +16934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17057,7 +17057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -17162,7 +17162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -17320,7 +17320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -17424,7 +17424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -17439,7 +17439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -17467,7 +17467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -17488,7 +17488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -17611,7 +17611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -17734,7 +17734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -17857,7 +17857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -17929,7 +17929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -17973,7 +17973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -18096,7 +18096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -18219,7 +18219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -18342,7 +18342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -18465,7 +18465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -18479,7 +18479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -18602,7 +18602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -18725,7 +18725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -18848,7 +18848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -18971,7 +18971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -19005,7 +19005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -19179,7 +19179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -19212,7 +19212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -19245,7 +19245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -19278,7 +19278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -19335,7 +19335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -19392,7 +19392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -19449,7 +19449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -19506,7 +19506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -19574,7 +19574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -19589,7 +19589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -19603,7 +19603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -19623,7 +19623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -19638,7 +19638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -19755,7 +19755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -19872,7 +19872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -19989,7 +19989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -20106,7 +20106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -20162,7 +20162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -20218,7 +20218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -20275,7 +20275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -20332,7 +20332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -20389,7 +20389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -20446,7 +20446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -20472,7 +20472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -20493,7 +20493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -20508,7 +20508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -20564,7 +20564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -20598,7 +20598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -20654,7 +20654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -20674,7 +20674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -20689,7 +20689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -20721,7 +20721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -20777,7 +20777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -20860,7 +20860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -20959,7 +20959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -20992,7 +20992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21013,7 +21013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21057,7 +21057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21097,7 +21097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -21291,7 +21291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21305,7 +21305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21320,7 +21320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21334,7 +21334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -21349,7 +21349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -21364,7 +21364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -21384,7 +21384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -21406,7 +21406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -21427,7 +21427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -21448,7 +21448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -21528,7 +21528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -21566,7 +21566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -21587,7 +21587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -21667,7 +21667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -21705,7 +21705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -21753,7 +21753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -21786,7 +21786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -21906,7 +21906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21921,7 +21921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21936,7 +21936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21993,7 +21993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -22044,7 +22044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -22095,7 +22095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -22146,7 +22146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -22178,7 +22178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -22192,7 +22192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -22212,7 +22212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -22390,7 +22390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22423,7 +22423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22438,7 +22438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22466,7 +22466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22506,7 +22506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22541,7 +22541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22602,7 +22602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22661,7 +22661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22690,7 +22690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22740,7 +22740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22774,7 +22774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22847,7 +22847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23061,7 +23061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23093,7 +23093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23131,7 +23131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23181,7 +23181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23213,7 +23213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23336,7 +23336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23381,7 +23381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23426,7 +23426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -23471,7 +23471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -23516,7 +23516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -23568,7 +23568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23612,7 +23612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23626,7 +23626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23641,7 +23641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23681,7 +23681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -23720,7 +23720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -23734,7 +23734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23892,7 +23892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23994,7 +23994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24141,7 +24141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24249,7 +24249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24264,7 +24264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -24279,7 +24279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24294,7 +24294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24308,7 +24308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24322,7 +24322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -24336,7 +24336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24405,7 +24405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24462,7 +24462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -24519,7 +24519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -24576,7 +24576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24604,7 +24604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24635,7 +24635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -24644,7 +24644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24705,7 +24705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24791,7 +24791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24895,7 +24895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25105,7 +25105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25645,7 +25645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26090,6 +26090,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -26124,7 +26152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26151,7 +26179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26394,9 +26422,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -26830,7 +26858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26850,7 +26878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26865,7 +26893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -26880,7 +26908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -26894,7 +26922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -26908,7 +26936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -26922,7 +26950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -26997,7 +27025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -27054,7 +27082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -27111,7 +27139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -27168,7 +27196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -27221,7 +27249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27236,7 +27264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -27394,7 +27422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -27427,7 +27455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -27460,7 +27488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -27493,7 +27521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -27532,7 +27560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -27552,7 +27580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27647,7 +27675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27676,7 +27704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27691,7 +27719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27706,7 +27734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27721,7 +27749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27736,7 +27764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27770,7 +27798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27911,7 +27939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27960,7 +27988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28028,7 +28056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28042,7 +28070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28074,7 +28102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28197,7 +28225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28302,7 +28330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28407,7 +28435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28512,7 +28540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28527,7 +28555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28542,7 +28570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28574,7 +28602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28606,7 +28634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28638,7 +28666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28666,7 +28694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28714,7 +28742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -28771,7 +28799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -28880,7 +28908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -28931,7 +28959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -28982,7 +29010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -29033,7 +29061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -29084,7 +29112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -29099,7 +29127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -29114,7 +29142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -29128,7 +29156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -29173,7 +29201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -29983,6 +30011,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -30033,7 +30079,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -30074,80 +30166,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30245,12 +30263,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -30260,6 +30272,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30295,46 +30319,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -30363,6 +30347,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30416,7 +30418,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -30463,134 +30511,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30682,30 +30602,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -30715,6 +30611,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30750,64 +30658,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -30836,6 +30686,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30889,7 +30757,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -30936,134 +30850,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31155,30 +30941,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -31188,6 +30950,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31223,64 +30997,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -31309,6 +31025,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31386,7 +31120,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -31433,140 +31219,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31664,30 +31316,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -31697,6 +31325,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31727,64 +31367,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -32467,7 +32049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -32558,7 +32140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -32711,7 +32293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -32762,7 +32344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -32855,7 +32437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33008,7 +32590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -33161,7 +32743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -33314,7 +32896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -33442,7 +33024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -33471,7 +33053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -33643,7 +33225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -33808,9 +33390,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -33974,9 +33556,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -34140,9 +33722,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -34306,7 +33888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -34365,9 +33947,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34425,9 +34007,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34485,9 +34067,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34545,7 +34127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -34610,9 +34192,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34676,9 +34258,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34742,9 +34324,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34808,7 +34390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -34909,9 +34491,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -35017,9 +34599,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -35119,9 +34701,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -35221,7 +34803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -35322,9 +34904,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35430,9 +35012,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35532,9 +35114,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35634,7 +35216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -35723,9 +35305,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35813,9 +35395,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35903,9 +35485,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35997,7 +35579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36011,7 +35593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -36025,7 +35607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -36087,7 +35669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -36132,7 +35714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -36187,7 +35769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -36296,43 +35878,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36340,7 +35922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -36391,7 +35973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -36440,43 +36022,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36484,7 +36066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -36593,43 +36175,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36637,7 +36219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -36746,43 +36328,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36790,7 +36372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -36899,43 +36481,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36943,7 +36525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -37059,7 +36641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -37085,7 +36667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -37117,7 +36699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -37149,7 +36731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -37171,7 +36753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -37331,9 +36913,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -37498,7 +37080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -37647,9 +37229,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37797,9 +37379,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37947,9 +37529,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38097,7 +37679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -38150,9 +37732,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38204,9 +37786,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38258,9 +37840,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38312,7 +37894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -38377,9 +37959,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38443,9 +38025,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38509,9 +38091,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38575,7 +38157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -38664,9 +38246,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38754,9 +38336,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38844,9 +38426,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38934,7 +38516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -39017,9 +38599,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39101,9 +38683,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39185,9 +38767,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39269,7 +38851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -39352,9 +38934,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39436,9 +39018,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39520,9 +39102,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39604,7 +39186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -39626,7 +39208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -39676,7 +39258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39690,7 +39272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39704,7 +39286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39766,7 +39348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39811,7 +39393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -39868,7 +39450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -39913,7 +39495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -39928,7 +39510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -39964,7 +39546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39995,7 +39577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40041,7 +39623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40070,7 +39652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40120,7 +39702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40160,7 +39742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40187,7 +39769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40225,7 +39807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40257,7 +39839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -40410,7 +39992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40563,7 +40145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -40716,7 +40298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -40869,7 +40451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -41022,7 +40604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -41175,7 +40757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -41328,7 +40910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -41480,7 +41062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -41632,7 +41214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -41785,7 +41367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -41938,7 +41520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -42091,7 +41673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -42244,7 +41826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -42403,7 +41985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42454,7 +42036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42505,7 +42087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42556,7 +42138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42607,7 +42189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -42621,7 +42203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -42635,7 +42217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -42655,7 +42237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -42749,7 +42331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -42763,7 +42345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -42777,7 +42359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -43260,7 +42842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -43280,7 +42862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -43294,7 +42876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -43322,7 +42904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -45211,6 +44793,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMS70J20.svd
+++ b/data/Atmel/ATSAMS70J20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4177,7 +4177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4251,7 +4251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4296,7 +4296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4323,7 +4323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4374,7 +4374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4425,7 +4425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4476,7 +4476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4527,7 +4527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4570,7 +4570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4584,7 +4584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4600,7 +4600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -4634,7 +4634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4732,7 +4732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4840,7 +4840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4860,7 +4860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4874,7 +4874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4906,7 +4906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4938,7 +4938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4970,7 +4970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5002,7 +5002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5034,7 +5034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5067,7 +5067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5148,7 +5148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5211,7 +5211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5274,7 +5274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5337,7 +5337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5358,7 +5358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -5379,7 +5379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5400,7 +5400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5414,7 +5414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5460,7 +5460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -5520,7 +5520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5548,7 +5548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5586,7 +5586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -5645,7 +5645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5695,7 +5695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5745,7 +5745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5760,7 +5760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -5892,7 +5892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -5920,7 +5920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -6362,7 +6362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -6563,7 +6563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -6965,7 +6965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -7166,7 +7166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -7367,7 +7367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -7568,7 +7568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -7769,7 +7769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -7970,7 +7970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -8171,7 +8171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -8371,7 +8371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -8572,7 +8572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -8773,7 +8773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -8974,7 +8974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -9175,7 +9175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -9376,7 +9376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -9577,7 +9577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -9778,7 +9778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -9979,7 +9979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -10180,7 +10180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -10381,7 +10381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -10584,7 +10584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -10784,7 +10784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -10985,7 +10985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -11186,7 +11186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -11387,7 +11387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -11401,7 +11401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -11602,7 +11602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -11803,7 +11803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -12004,7 +12004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -12205,7 +12205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -12406,7 +12406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -12607,7 +12607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -12808,7 +12808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -13009,7 +13009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -13210,7 +13210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -13411,7 +13411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -13612,7 +13612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -13813,7 +13813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -14014,7 +14014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -14215,7 +14215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -14416,7 +14416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -14617,7 +14617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -14645,7 +14645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -14666,7 +14666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -14866,7 +14866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -15482,7 +15482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -15538,7 +15538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -15571,7 +15571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -15604,7 +15604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -15637,7 +15637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -15658,7 +15658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -15708,7 +15708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15765,7 +15765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15822,7 +15822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15885,7 +15885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16044,7 +16044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16203,7 +16203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16553,7 +16553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -16674,7 +16674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16696,7 +16696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -16744,7 +16744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16843,7 +16843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16942,7 +16942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17059,7 +17059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -17158,7 +17158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -17316,7 +17316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -17420,7 +17420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -17435,7 +17435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -17463,7 +17463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -17484,7 +17484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -17643,7 +17643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -17802,7 +17802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -17961,7 +17961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -18033,7 +18033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -18077,7 +18077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -18236,7 +18236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -18395,7 +18395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -18554,7 +18554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -18713,7 +18713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -18727,7 +18727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -18886,7 +18886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -19045,7 +19045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -19204,7 +19204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -19363,7 +19363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -19397,7 +19397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -19571,7 +19571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -19604,7 +19604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -19637,7 +19637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -19670,7 +19670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -19727,7 +19727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -19784,7 +19784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -19841,7 +19841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -19898,7 +19898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -19966,7 +19966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -19981,7 +19981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -19995,7 +19995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -20015,7 +20015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -20030,7 +20030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -20147,7 +20147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -20264,7 +20264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -20381,7 +20381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -20498,7 +20498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -20554,7 +20554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -20610,7 +20610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -20667,7 +20667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -20724,7 +20724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -20781,7 +20781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -20838,7 +20838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -20864,7 +20864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -20885,7 +20885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -20900,7 +20900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -20956,7 +20956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -20990,7 +20990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -21046,7 +21046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -21066,7 +21066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -21081,7 +21081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -21113,7 +21113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -21169,7 +21169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -21252,7 +21252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -21351,7 +21351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -21371,7 +21371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21392,7 +21392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21436,7 +21436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21476,7 +21476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -21618,7 +21618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21632,7 +21632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21647,7 +21647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21661,7 +21661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -21676,7 +21676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -21691,7 +21691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -21711,7 +21711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -21733,7 +21733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -21754,7 +21754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -21775,7 +21775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -21855,7 +21855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -21893,7 +21893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -21914,7 +21914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -21994,7 +21994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -22032,7 +22032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -22080,7 +22080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22113,7 +22113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22233,7 +22233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22248,7 +22248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -22263,7 +22263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -22320,7 +22320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -22371,7 +22371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -22422,7 +22422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -22473,7 +22473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -22505,7 +22505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -22519,7 +22519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -22539,7 +22539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -22717,7 +22717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22750,7 +22750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22765,7 +22765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22793,7 +22793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22833,7 +22833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22868,7 +22868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22929,7 +22929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22988,7 +22988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23017,7 +23017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23101,7 +23101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23174,7 +23174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23388,7 +23388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23420,7 +23420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23458,7 +23458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23508,7 +23508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23540,7 +23540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23663,7 +23663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23708,7 +23708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23753,7 +23753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -23798,7 +23798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -23843,7 +23843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -23895,7 +23895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23939,7 +23939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23953,7 +23953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24008,7 +24008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -24047,7 +24047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -24061,7 +24061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24219,7 +24219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24321,7 +24321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24468,7 +24468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24576,7 +24576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24591,7 +24591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -24606,7 +24606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24621,7 +24621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24635,7 +24635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24649,7 +24649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -24663,7 +24663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24732,7 +24732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24789,7 +24789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -24846,7 +24846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -24903,7 +24903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24931,7 +24931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24971,7 +24971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25032,7 +25032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25118,7 +25118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25222,7 +25222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25432,7 +25432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25972,7 +25972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26451,7 +26451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26478,7 +26478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26721,7 +26721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26741,7 +26741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26756,7 +26756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -26771,7 +26771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -26785,7 +26785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -26799,7 +26799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -26813,7 +26813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -26888,7 +26888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -26945,7 +26945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -27002,7 +27002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -27059,7 +27059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -27112,7 +27112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27127,7 +27127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -27273,7 +27273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -27300,7 +27300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -27327,7 +27327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -27354,7 +27354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -27387,7 +27387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -27407,7 +27407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27502,7 +27502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27531,7 +27531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27546,7 +27546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27561,7 +27561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27576,7 +27576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27591,7 +27591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27625,7 +27625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27766,7 +27766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27815,7 +27815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27883,7 +27883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27897,7 +27897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27929,7 +27929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28052,7 +28052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28157,7 +28157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28262,7 +28262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28367,7 +28367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28382,7 +28382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28397,7 +28397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28429,7 +28429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28461,7 +28461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28493,7 +28493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28521,7 +28521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28569,7 +28569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -28626,7 +28626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -28735,7 +28735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -28786,7 +28786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -28837,7 +28837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -28888,7 +28888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -28939,7 +28939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -28954,7 +28954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -28969,7 +28969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -28983,7 +28983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -29028,7 +29028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -30587,7 +30587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -30668,7 +30668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -30833,7 +30833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -30884,7 +30884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -30977,7 +30977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -31142,7 +31142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -31307,7 +31307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -31472,7 +31472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -31600,7 +31600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -31629,7 +31629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -31801,7 +31801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -31966,7 +31966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -32025,7 +32025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -32090,7 +32090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -32191,7 +32191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -32292,7 +32292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -32385,7 +32385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32399,7 +32399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32413,7 +32413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32475,7 +32475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32520,7 +32520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -32565,7 +32565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -32730,7 +32730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -32781,7 +32781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -32874,7 +32874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -33039,7 +33039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -33204,7 +33204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -33369,7 +33369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -33485,7 +33485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -33511,7 +33511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -33543,7 +33543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -33575,7 +33575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -33597,7 +33597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -33757,7 +33757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -33906,7 +33906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -33959,7 +33959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -34024,7 +34024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -34113,7 +34113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -34196,7 +34196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -34279,7 +34279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -34301,7 +34301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -34351,7 +34351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34365,7 +34365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34379,7 +34379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34441,7 +34441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34486,7 +34486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -34537,7 +34537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -34582,7 +34582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -34597,7 +34597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -34633,7 +34633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34664,7 +34664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34710,7 +34710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34739,7 +34739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34789,7 +34789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34829,7 +34829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34856,7 +34856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34894,7 +34894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34926,7 +34926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35079,7 +35079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35232,7 +35232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35385,7 +35385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35538,7 +35538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35691,7 +35691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35844,7 +35844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35997,7 +35997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36149,7 +36149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36301,7 +36301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36454,7 +36454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36607,7 +36607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36760,7 +36760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -36913,7 +36913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -37072,7 +37072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37123,7 +37123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37174,7 +37174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37225,7 +37225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37276,7 +37276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37290,7 +37290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37304,7 +37304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37324,7 +37324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37418,7 +37418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37432,7 +37432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37446,7 +37446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37776,7 +37776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37796,7 +37796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37810,7 +37810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -37838,7 +37838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -38038,7 +38038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMS70J20B.svd
+++ b/data/Atmel/ATSAMS70J20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4257,7 +4257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4302,7 +4302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4380,7 +4380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4431,7 +4431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4482,7 +4482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4533,7 +4533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4576,7 +4576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4590,7 +4590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4606,7 +4606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -4640,7 +4640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4738,7 +4738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4846,7 +4846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4866,7 +4866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4880,7 +4880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4912,7 +4912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4944,7 +4944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4976,7 +4976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5008,7 +5008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5040,7 +5040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5073,7 +5073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5154,7 +5154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5217,7 +5217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5280,7 +5280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5343,7 +5343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5364,7 +5364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -5385,7 +5385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5406,7 +5406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5420,7 +5420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5452,7 +5452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5480,7 +5480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5512,7 +5512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5554,7 +5554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5592,7 +5592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -5651,7 +5651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5701,7 +5701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5751,7 +5751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5772,7 +5772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -5962,7 +5962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -5990,7 +5990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -6231,7 +6231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -6432,7 +6432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -6633,7 +6633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -6834,7 +6834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -7035,7 +7035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -7236,7 +7236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -7437,7 +7437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -7638,7 +7638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -7839,7 +7839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -8040,7 +8040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -8241,7 +8241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -8843,7 +8843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -9044,7 +9044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -9446,7 +9446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -9647,7 +9647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -9848,7 +9848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -10049,7 +10049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -10250,7 +10250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -10451,7 +10451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -10654,7 +10654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -10854,7 +10854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -11055,7 +11055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -11256,7 +11256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -11457,7 +11457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -11471,7 +11471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -11672,7 +11672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -11873,7 +11873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -12074,7 +12074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -12275,7 +12275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -12476,7 +12476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -12677,7 +12677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -12878,7 +12878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -13079,7 +13079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -13280,7 +13280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -13481,7 +13481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -13682,7 +13682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -13883,7 +13883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -14084,7 +14084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -14285,7 +14285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -14486,7 +14486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -14687,7 +14687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -14715,7 +14715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -14736,7 +14736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -14936,7 +14936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -15552,7 +15552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -15608,7 +15608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -15641,7 +15641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -15674,7 +15674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -15707,7 +15707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -15728,7 +15728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -15778,7 +15778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15841,7 +15841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15904,7 +15904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15973,7 +15973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16096,7 +16096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16219,7 +16219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16533,7 +16533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -16654,7 +16654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16676,7 +16676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -16724,7 +16724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16829,7 +16829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16934,7 +16934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17057,7 +17057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -17162,7 +17162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -17320,7 +17320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -17424,7 +17424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -17439,7 +17439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -17467,7 +17467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -17488,7 +17488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -17611,7 +17611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -17734,7 +17734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -17857,7 +17857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -17929,7 +17929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -17973,7 +17973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -18096,7 +18096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -18219,7 +18219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -18342,7 +18342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -18465,7 +18465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -18479,7 +18479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -18602,7 +18602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -18725,7 +18725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -18848,7 +18848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -18971,7 +18971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -19005,7 +19005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -19179,7 +19179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -19212,7 +19212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -19245,7 +19245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -19278,7 +19278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -19335,7 +19335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -19392,7 +19392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -19449,7 +19449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -19506,7 +19506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -19574,7 +19574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -19589,7 +19589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -19603,7 +19603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -19623,7 +19623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -19638,7 +19638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -19755,7 +19755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -19872,7 +19872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -19989,7 +19989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -20106,7 +20106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -20162,7 +20162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -20218,7 +20218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -20275,7 +20275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -20332,7 +20332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -20389,7 +20389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -20446,7 +20446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -20472,7 +20472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -20493,7 +20493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -20508,7 +20508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -20564,7 +20564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -20598,7 +20598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -20654,7 +20654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -20674,7 +20674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -20689,7 +20689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -20721,7 +20721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -20777,7 +20777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -20860,7 +20860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -20959,7 +20959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -20992,7 +20992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21013,7 +21013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21057,7 +21057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21097,7 +21097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -21291,7 +21291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21305,7 +21305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21320,7 +21320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21334,7 +21334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -21349,7 +21349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -21364,7 +21364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -21384,7 +21384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -21406,7 +21406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -21427,7 +21427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -21448,7 +21448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -21528,7 +21528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -21566,7 +21566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -21587,7 +21587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -21667,7 +21667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -21705,7 +21705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -21753,7 +21753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -21786,7 +21786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -21906,7 +21906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21921,7 +21921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21936,7 +21936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21993,7 +21993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -22044,7 +22044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -22095,7 +22095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -22146,7 +22146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -22178,7 +22178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -22192,7 +22192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -22212,7 +22212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -22390,7 +22390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22423,7 +22423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22438,7 +22438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22466,7 +22466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22506,7 +22506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22541,7 +22541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22602,7 +22602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22661,7 +22661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22690,7 +22690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22740,7 +22740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22774,7 +22774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22847,7 +22847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23061,7 +23061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23093,7 +23093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23131,7 +23131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23181,7 +23181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23213,7 +23213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23336,7 +23336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23381,7 +23381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23426,7 +23426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -23471,7 +23471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -23516,7 +23516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -23568,7 +23568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23612,7 +23612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23626,7 +23626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23641,7 +23641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23681,7 +23681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -23720,7 +23720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -23734,7 +23734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23892,7 +23892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23994,7 +23994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24141,7 +24141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24249,7 +24249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24264,7 +24264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -24279,7 +24279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24294,7 +24294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24308,7 +24308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24322,7 +24322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -24336,7 +24336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24405,7 +24405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24462,7 +24462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -24519,7 +24519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -24576,7 +24576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24604,7 +24604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24635,7 +24635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -24644,7 +24644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24705,7 +24705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24791,7 +24791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24895,7 +24895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25105,7 +25105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25645,7 +25645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26090,6 +26090,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -26124,7 +26152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26151,7 +26179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26394,9 +26422,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -26830,7 +26858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26850,7 +26878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26865,7 +26893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -26880,7 +26908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -26894,7 +26922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -26908,7 +26936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -26922,7 +26950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -26997,7 +27025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -27054,7 +27082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -27111,7 +27139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -27168,7 +27196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -27221,7 +27249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27236,7 +27264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -27394,7 +27422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -27427,7 +27455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -27460,7 +27488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -27493,7 +27521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -27532,7 +27560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -27552,7 +27580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27647,7 +27675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27676,7 +27704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27691,7 +27719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27706,7 +27734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27721,7 +27749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27736,7 +27764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27770,7 +27798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27911,7 +27939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27960,7 +27988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28028,7 +28056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28042,7 +28070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28074,7 +28102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28197,7 +28225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28302,7 +28330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28407,7 +28435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28512,7 +28540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28527,7 +28555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28542,7 +28570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28574,7 +28602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28606,7 +28634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28638,7 +28666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28666,7 +28694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28714,7 +28742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -28771,7 +28799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -28880,7 +28908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -28931,7 +28959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -28982,7 +29010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -29033,7 +29061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -29084,7 +29112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -29099,7 +29127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -29114,7 +29142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -29128,7 +29156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -29173,7 +29201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -29983,6 +30011,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -30033,7 +30079,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -30074,80 +30166,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30245,12 +30263,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -30260,6 +30272,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30295,46 +30319,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -30363,6 +30347,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30416,7 +30418,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -30463,134 +30511,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30682,30 +30602,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -30715,6 +30611,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30750,64 +30658,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -30836,6 +30686,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30889,7 +30757,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -30936,134 +30850,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31155,30 +30941,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -31188,6 +30950,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31223,64 +30997,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -31309,6 +31025,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31386,7 +31120,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -31433,140 +31219,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31664,30 +31316,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -31697,6 +31325,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31727,64 +31367,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -32467,7 +32049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -32558,7 +32140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -32711,7 +32293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -32762,7 +32344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -32855,7 +32437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33008,7 +32590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -33161,7 +32743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -33314,7 +32896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -33442,7 +33024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -33471,7 +33053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -33643,7 +33225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -33808,9 +33390,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -33974,9 +33556,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -34140,9 +33722,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -34306,7 +33888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -34365,9 +33947,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34425,9 +34007,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34485,9 +34067,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34545,7 +34127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -34610,9 +34192,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34676,9 +34258,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34742,9 +34324,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34808,7 +34390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -34909,9 +34491,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -35017,9 +34599,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -35119,9 +34701,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -35221,7 +34803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -35322,9 +34904,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35430,9 +35012,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35532,9 +35114,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35634,7 +35216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -35723,9 +35305,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35813,9 +35395,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35903,9 +35485,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35997,7 +35579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36011,7 +35593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -36025,7 +35607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -36087,7 +35669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -36132,7 +35714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -36187,7 +35769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -36296,43 +35878,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36340,7 +35922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -36391,7 +35973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -36440,43 +36022,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36484,7 +36066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -36593,43 +36175,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36637,7 +36219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -36746,43 +36328,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36790,7 +36372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -36899,43 +36481,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36943,7 +36525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -37059,7 +36641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -37085,7 +36667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -37117,7 +36699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -37149,7 +36731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -37171,7 +36753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -37331,9 +36913,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -37498,7 +37080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -37647,9 +37229,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37797,9 +37379,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37947,9 +37529,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38097,7 +37679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -38150,9 +37732,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38204,9 +37786,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38258,9 +37840,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38312,7 +37894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -38377,9 +37959,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38443,9 +38025,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38509,9 +38091,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38575,7 +38157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -38664,9 +38246,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38754,9 +38336,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38844,9 +38426,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38934,7 +38516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -39017,9 +38599,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39101,9 +38683,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39185,9 +38767,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39269,7 +38851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -39352,9 +38934,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39436,9 +39018,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39520,9 +39102,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39604,7 +39186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -39626,7 +39208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -39676,7 +39258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39690,7 +39272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39704,7 +39286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39766,7 +39348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39811,7 +39393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -39868,7 +39450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -39913,7 +39495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -39928,7 +39510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -39964,7 +39546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39995,7 +39577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40041,7 +39623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40070,7 +39652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40120,7 +39702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40160,7 +39742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40187,7 +39769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40225,7 +39807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40257,7 +39839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -40410,7 +39992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40563,7 +40145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -40716,7 +40298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -40869,7 +40451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -41022,7 +40604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -41175,7 +40757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -41328,7 +40910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -41480,7 +41062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -41632,7 +41214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -41785,7 +41367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -41938,7 +41520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -42091,7 +41673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -42244,7 +41826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -42403,7 +41985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42454,7 +42036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42505,7 +42087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42556,7 +42138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42607,7 +42189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -42621,7 +42203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -42635,7 +42217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -42655,7 +42237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -42749,7 +42331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -42763,7 +42345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -42777,7 +42359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -43260,7 +42842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -43280,7 +42862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -43294,7 +42876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -43322,7 +42904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -43522,7 +43104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -45411,6 +44993,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMS70J21.svd
+++ b/data/Atmel/ATSAMS70J21.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4177,7 +4177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4251,7 +4251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4296,7 +4296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4323,7 +4323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4374,7 +4374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4425,7 +4425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4476,7 +4476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4527,7 +4527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4570,7 +4570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4584,7 +4584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4600,7 +4600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -4634,7 +4634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4732,7 +4732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4840,7 +4840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4860,7 +4860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4874,7 +4874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4906,7 +4906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4938,7 +4938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4970,7 +4970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5002,7 +5002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5034,7 +5034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5067,7 +5067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5148,7 +5148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5211,7 +5211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5274,7 +5274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5337,7 +5337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5358,7 +5358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -5379,7 +5379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5400,7 +5400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5414,7 +5414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5460,7 +5460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5506,7 +5506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -5520,7 +5520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5548,7 +5548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5586,7 +5586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -5645,7 +5645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5695,7 +5695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5745,7 +5745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5760,7 +5760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -5892,7 +5892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -5920,7 +5920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -6362,7 +6362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -6563,7 +6563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -6965,7 +6965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -7166,7 +7166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -7367,7 +7367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -7568,7 +7568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -7769,7 +7769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -7970,7 +7970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -8171,7 +8171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -8371,7 +8371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -8572,7 +8572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -8773,7 +8773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -8974,7 +8974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -9175,7 +9175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -9376,7 +9376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -9577,7 +9577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -9778,7 +9778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -9979,7 +9979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -10180,7 +10180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -10381,7 +10381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -10584,7 +10584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -10784,7 +10784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -10985,7 +10985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -11186,7 +11186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -11387,7 +11387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -11401,7 +11401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -11602,7 +11602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -11803,7 +11803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -12004,7 +12004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -12205,7 +12205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -12406,7 +12406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -12607,7 +12607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -12808,7 +12808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -13009,7 +13009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -13210,7 +13210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -13411,7 +13411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -13612,7 +13612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -13813,7 +13813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -14014,7 +14014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -14215,7 +14215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -14416,7 +14416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -14617,7 +14617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -14645,7 +14645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -14666,7 +14666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -14866,7 +14866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -15482,7 +15482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -15538,7 +15538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -15571,7 +15571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -15604,7 +15604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -15637,7 +15637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -15658,7 +15658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -15708,7 +15708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15765,7 +15765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15822,7 +15822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15885,7 +15885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16044,7 +16044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16203,7 +16203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16553,7 +16553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -16674,7 +16674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16696,7 +16696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -16744,7 +16744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16843,7 +16843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16942,7 +16942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17059,7 +17059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -17158,7 +17158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -17316,7 +17316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -17420,7 +17420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -17435,7 +17435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -17463,7 +17463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -17484,7 +17484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -17643,7 +17643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -17802,7 +17802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -17961,7 +17961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -18033,7 +18033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -18077,7 +18077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -18236,7 +18236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -18395,7 +18395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -18554,7 +18554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -18713,7 +18713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -18727,7 +18727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -18886,7 +18886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -19045,7 +19045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -19204,7 +19204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -19363,7 +19363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -19397,7 +19397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -19571,7 +19571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -19604,7 +19604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -19637,7 +19637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -19670,7 +19670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -19727,7 +19727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -19784,7 +19784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -19841,7 +19841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -19898,7 +19898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -19966,7 +19966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -19981,7 +19981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -19995,7 +19995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -20015,7 +20015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -20030,7 +20030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -20147,7 +20147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -20264,7 +20264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -20381,7 +20381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -20498,7 +20498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -20554,7 +20554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -20610,7 +20610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -20667,7 +20667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -20724,7 +20724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -20781,7 +20781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -20838,7 +20838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -20864,7 +20864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -20885,7 +20885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -20900,7 +20900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -20956,7 +20956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -20990,7 +20990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -21046,7 +21046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -21066,7 +21066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -21081,7 +21081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -21113,7 +21113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -21169,7 +21169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -21252,7 +21252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -21351,7 +21351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -21371,7 +21371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21392,7 +21392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21436,7 +21436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21476,7 +21476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -21618,7 +21618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21632,7 +21632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21647,7 +21647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21661,7 +21661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -21676,7 +21676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -21691,7 +21691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -21711,7 +21711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -21733,7 +21733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -21754,7 +21754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -21775,7 +21775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -21855,7 +21855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -21893,7 +21893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -21914,7 +21914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -21994,7 +21994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -22032,7 +22032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -22080,7 +22080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22113,7 +22113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22233,7 +22233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22248,7 +22248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -22263,7 +22263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -22320,7 +22320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -22371,7 +22371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -22422,7 +22422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -22473,7 +22473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -22505,7 +22505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -22519,7 +22519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -22539,7 +22539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -22717,7 +22717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22750,7 +22750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22765,7 +22765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22793,7 +22793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22833,7 +22833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22868,7 +22868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22929,7 +22929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22988,7 +22988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23017,7 +23017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23101,7 +23101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23174,7 +23174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23388,7 +23388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23420,7 +23420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23458,7 +23458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23508,7 +23508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23540,7 +23540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23663,7 +23663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23708,7 +23708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23753,7 +23753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -23798,7 +23798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -23843,7 +23843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -23895,7 +23895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23939,7 +23939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23953,7 +23953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24008,7 +24008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -24047,7 +24047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -24061,7 +24061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24219,7 +24219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24321,7 +24321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24468,7 +24468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24576,7 +24576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24591,7 +24591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -24606,7 +24606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24621,7 +24621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24635,7 +24635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24649,7 +24649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -24663,7 +24663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24732,7 +24732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24789,7 +24789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -24846,7 +24846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -24903,7 +24903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24931,7 +24931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24971,7 +24971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25032,7 +25032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25118,7 +25118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25222,7 +25222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25432,7 +25432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25972,7 +25972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26451,7 +26451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26478,7 +26478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26721,7 +26721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26741,7 +26741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26756,7 +26756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -26771,7 +26771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -26785,7 +26785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -26799,7 +26799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -26813,7 +26813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -26888,7 +26888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -26945,7 +26945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -27002,7 +27002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -27059,7 +27059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -27112,7 +27112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27127,7 +27127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -27273,7 +27273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -27300,7 +27300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -27327,7 +27327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -27354,7 +27354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -27387,7 +27387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -27407,7 +27407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27502,7 +27502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27531,7 +27531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27546,7 +27546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27561,7 +27561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27576,7 +27576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27591,7 +27591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27625,7 +27625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27766,7 +27766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27815,7 +27815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27883,7 +27883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27897,7 +27897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27929,7 +27929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28052,7 +28052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28157,7 +28157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28262,7 +28262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28367,7 +28367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28382,7 +28382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28397,7 +28397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28429,7 +28429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28461,7 +28461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28493,7 +28493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28521,7 +28521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28569,7 +28569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -28626,7 +28626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -28735,7 +28735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -28786,7 +28786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -28837,7 +28837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -28888,7 +28888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -28939,7 +28939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -28954,7 +28954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -28969,7 +28969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -28983,7 +28983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -29028,7 +29028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -30587,7 +30587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -30668,7 +30668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -30833,7 +30833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -30884,7 +30884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -30977,7 +30977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -31142,7 +31142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -31307,7 +31307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -31472,7 +31472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -31600,7 +31600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -31629,7 +31629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -31801,7 +31801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -31966,7 +31966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -32025,7 +32025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -32090,7 +32090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -32191,7 +32191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -32292,7 +32292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -32385,7 +32385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32399,7 +32399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32413,7 +32413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32475,7 +32475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32520,7 +32520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -32565,7 +32565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -32730,7 +32730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -32781,7 +32781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -32874,7 +32874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -33039,7 +33039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -33204,7 +33204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -33369,7 +33369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -33485,7 +33485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -33511,7 +33511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -33543,7 +33543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -33575,7 +33575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -33597,7 +33597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -33757,7 +33757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -33906,7 +33906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -33959,7 +33959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -34024,7 +34024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -34113,7 +34113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -34196,7 +34196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -34279,7 +34279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -34301,7 +34301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -34351,7 +34351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34365,7 +34365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34379,7 +34379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34441,7 +34441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34486,7 +34486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -34537,7 +34537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -34582,7 +34582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -34597,7 +34597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -34633,7 +34633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34664,7 +34664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34710,7 +34710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34739,7 +34739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34789,7 +34789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34829,7 +34829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34856,7 +34856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34894,7 +34894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34926,7 +34926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35079,7 +35079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35232,7 +35232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35385,7 +35385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35538,7 +35538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35691,7 +35691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35844,7 +35844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35997,7 +35997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36149,7 +36149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36301,7 +36301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36454,7 +36454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36607,7 +36607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36760,7 +36760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -36913,7 +36913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -37072,7 +37072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37123,7 +37123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37174,7 +37174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37225,7 +37225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37276,7 +37276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37290,7 +37290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37304,7 +37304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37324,7 +37324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37418,7 +37418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37432,7 +37432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37446,7 +37446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37776,7 +37776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37796,7 +37796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37810,7 +37810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -37838,7 +37838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -38038,7 +38038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -38238,7 +38238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -38438,7 +38438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMS70J21B.svd
+++ b/data/Atmel/ATSAMS70J21B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4257,7 +4257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4302,7 +4302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4380,7 +4380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4431,7 +4431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4482,7 +4482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4533,7 +4533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4576,7 +4576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4590,7 +4590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4606,7 +4606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -4640,7 +4640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4738,7 +4738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4846,7 +4846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4866,7 +4866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4880,7 +4880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4912,7 +4912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4944,7 +4944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4976,7 +4976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5008,7 +5008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5040,7 +5040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5073,7 +5073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5154,7 +5154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5217,7 +5217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5280,7 +5280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5343,7 +5343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5364,7 +5364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -5385,7 +5385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5406,7 +5406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5420,7 +5420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5452,7 +5452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5480,7 +5480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5512,7 +5512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5554,7 +5554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5592,7 +5592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -5651,7 +5651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5701,7 +5701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5751,7 +5751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5772,7 +5772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -5962,7 +5962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -5990,7 +5990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -6231,7 +6231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -6432,7 +6432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -6633,7 +6633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -6834,7 +6834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -7035,7 +7035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -7236,7 +7236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -7437,7 +7437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -7638,7 +7638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -7839,7 +7839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -8040,7 +8040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -8241,7 +8241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -8843,7 +8843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -9044,7 +9044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -9446,7 +9446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -9647,7 +9647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -9848,7 +9848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -10049,7 +10049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -10250,7 +10250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -10451,7 +10451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -10654,7 +10654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -10854,7 +10854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -11055,7 +11055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -11256,7 +11256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -11457,7 +11457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -11471,7 +11471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -11672,7 +11672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -11873,7 +11873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -12074,7 +12074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -12275,7 +12275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -12476,7 +12476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -12677,7 +12677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -12878,7 +12878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -13079,7 +13079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -13280,7 +13280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -13481,7 +13481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -13682,7 +13682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -13883,7 +13883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -14084,7 +14084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -14285,7 +14285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -14486,7 +14486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -14687,7 +14687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -14715,7 +14715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -14736,7 +14736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -14936,7 +14936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -15552,7 +15552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -15608,7 +15608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -15641,7 +15641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -15674,7 +15674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -15707,7 +15707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -15728,7 +15728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -15778,7 +15778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15841,7 +15841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -15904,7 +15904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -15973,7 +15973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16096,7 +16096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16219,7 +16219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16533,7 +16533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -16654,7 +16654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16676,7 +16676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -16724,7 +16724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16829,7 +16829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16934,7 +16934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17057,7 +17057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -17162,7 +17162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -17320,7 +17320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -17424,7 +17424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -17439,7 +17439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -17467,7 +17467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -17488,7 +17488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -17611,7 +17611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -17734,7 +17734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -17857,7 +17857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -17929,7 +17929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -17973,7 +17973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -18096,7 +18096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -18219,7 +18219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -18342,7 +18342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -18465,7 +18465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -18479,7 +18479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -18602,7 +18602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -18725,7 +18725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -18848,7 +18848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -18971,7 +18971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -19005,7 +19005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -19179,7 +19179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -19212,7 +19212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -19245,7 +19245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -19278,7 +19278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -19335,7 +19335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -19392,7 +19392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -19449,7 +19449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -19506,7 +19506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -19574,7 +19574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -19589,7 +19589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -19603,7 +19603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -19623,7 +19623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -19638,7 +19638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -19755,7 +19755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -19872,7 +19872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -19989,7 +19989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -20106,7 +20106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -20162,7 +20162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -20218,7 +20218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -20275,7 +20275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -20332,7 +20332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -20389,7 +20389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -20446,7 +20446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -20472,7 +20472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -20493,7 +20493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -20508,7 +20508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -20564,7 +20564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -20598,7 +20598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -20654,7 +20654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -20674,7 +20674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -20689,7 +20689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -20721,7 +20721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -20777,7 +20777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -20860,7 +20860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -20959,7 +20959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -20992,7 +20992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21013,7 +21013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21057,7 +21057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21097,7 +21097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -21291,7 +21291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -21305,7 +21305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -21320,7 +21320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -21334,7 +21334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -21349,7 +21349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -21364,7 +21364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -21384,7 +21384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -21406,7 +21406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -21427,7 +21427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -21448,7 +21448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -21528,7 +21528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -21566,7 +21566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -21587,7 +21587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -21667,7 +21667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -21705,7 +21705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -21753,7 +21753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -21786,7 +21786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -21906,7 +21906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21921,7 +21921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21936,7 +21936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21993,7 +21993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -22044,7 +22044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -22095,7 +22095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -22146,7 +22146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -22178,7 +22178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -22192,7 +22192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -22212,7 +22212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -22390,7 +22390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22423,7 +22423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22438,7 +22438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22466,7 +22466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22506,7 +22506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22541,7 +22541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22602,7 +22602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22661,7 +22661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22690,7 +22690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -22740,7 +22740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -22774,7 +22774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -22847,7 +22847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23061,7 +23061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23093,7 +23093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23131,7 +23131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23181,7 +23181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23213,7 +23213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23336,7 +23336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23381,7 +23381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23426,7 +23426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -23471,7 +23471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -23516,7 +23516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -23568,7 +23568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23612,7 +23612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23626,7 +23626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23641,7 +23641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23681,7 +23681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -23720,7 +23720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -23734,7 +23734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23892,7 +23892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23994,7 +23994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24141,7 +24141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24249,7 +24249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24264,7 +24264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -24279,7 +24279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24294,7 +24294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24308,7 +24308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24322,7 +24322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -24336,7 +24336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24405,7 +24405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24462,7 +24462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -24519,7 +24519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -24576,7 +24576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24604,7 +24604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24635,7 +24635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -24644,7 +24644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24705,7 +24705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24791,7 +24791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24895,7 +24895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25105,7 +25105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25645,7 +25645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26090,6 +26090,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -26124,7 +26152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26151,7 +26179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26394,9 +26422,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -26830,7 +26858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26850,7 +26878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26865,7 +26893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -26880,7 +26908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -26894,7 +26922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -26908,7 +26936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -26922,7 +26950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -26997,7 +27025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -27054,7 +27082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -27111,7 +27139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -27168,7 +27196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -27221,7 +27249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27236,7 +27264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -27394,7 +27422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -27427,7 +27455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -27460,7 +27488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -27493,7 +27521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -27532,7 +27560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -27552,7 +27580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27647,7 +27675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27676,7 +27704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27691,7 +27719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27706,7 +27734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27721,7 +27749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27736,7 +27764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27770,7 +27798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27911,7 +27939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27960,7 +27988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28028,7 +28056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28042,7 +28070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28074,7 +28102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28197,7 +28225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28302,7 +28330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28407,7 +28435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28512,7 +28540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28527,7 +28555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28542,7 +28570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28574,7 +28602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28606,7 +28634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28638,7 +28666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28666,7 +28694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28714,7 +28742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -28771,7 +28799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -28880,7 +28908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -28931,7 +28959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -28982,7 +29010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -29033,7 +29061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -29084,7 +29112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -29099,7 +29127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -29114,7 +29142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -29128,7 +29156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -29173,7 +29201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -29983,6 +30011,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -30033,7 +30079,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -30074,80 +30166,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30245,12 +30263,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -30260,6 +30272,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30295,46 +30319,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -30363,6 +30347,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30416,7 +30418,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -30463,134 +30511,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30682,30 +30602,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -30715,6 +30611,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30750,64 +30658,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -30836,6 +30686,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -30889,7 +30757,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -30936,134 +30850,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31155,30 +30941,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -31188,6 +30950,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31223,64 +30997,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -31309,6 +31025,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31386,7 +31120,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -31433,140 +31219,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31664,30 +31316,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -31697,6 +31325,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -31727,64 +31367,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -32467,7 +32049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -32558,7 +32140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -32711,7 +32293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -32762,7 +32344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -32855,7 +32437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33008,7 +32590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -33161,7 +32743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -33314,7 +32896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -33442,7 +33024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -33471,7 +33053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -33643,7 +33225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -33808,9 +33390,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -33974,9 +33556,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -34140,9 +33722,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -34306,7 +33888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -34365,9 +33947,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34425,9 +34007,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34485,9 +34067,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34545,7 +34127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -34610,9 +34192,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34676,9 +34258,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34742,9 +34324,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -34808,7 +34390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -34909,9 +34491,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -35017,9 +34599,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -35119,9 +34701,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -35221,7 +34803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -35322,9 +34904,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35430,9 +35012,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35532,9 +35114,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35634,7 +35216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -35723,9 +35305,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35813,9 +35395,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35903,9 +35485,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -35997,7 +35579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36011,7 +35593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -36025,7 +35607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -36087,7 +35669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -36132,7 +35714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -36187,7 +35769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -36296,43 +35878,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36340,7 +35922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -36391,7 +35973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -36440,43 +36022,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36484,7 +36066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -36593,43 +36175,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36637,7 +36219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -36746,43 +36328,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36790,7 +36372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -36899,43 +36481,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -36943,7 +36525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -37059,7 +36641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -37085,7 +36667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -37117,7 +36699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -37149,7 +36731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -37171,7 +36753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -37331,9 +36913,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -37498,7 +37080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -37647,9 +37229,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37797,9 +37379,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37947,9 +37529,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38097,7 +37679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -38150,9 +37732,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38204,9 +37786,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38258,9 +37840,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38312,7 +37894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -38377,9 +37959,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38443,9 +38025,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38509,9 +38091,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38575,7 +38157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -38664,9 +38246,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38754,9 +38336,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38844,9 +38426,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38934,7 +38516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -39017,9 +38599,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39101,9 +38683,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39185,9 +38767,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39269,7 +38851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -39352,9 +38934,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39436,9 +39018,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39520,9 +39102,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39604,7 +39186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -39626,7 +39208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -39676,7 +39258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39690,7 +39272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39704,7 +39286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39766,7 +39348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39811,7 +39393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -39868,7 +39450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -39913,7 +39495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -39928,7 +39510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -39964,7 +39546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39995,7 +39577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40041,7 +39623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40070,7 +39652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40120,7 +39702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40160,7 +39742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40187,7 +39769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40225,7 +39807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40257,7 +39839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -40410,7 +39992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40563,7 +40145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -40716,7 +40298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -40869,7 +40451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -41022,7 +40604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -41175,7 +40757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -41328,7 +40910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -41480,7 +41062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -41632,7 +41214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -41785,7 +41367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -41938,7 +41520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -42091,7 +41673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -42244,7 +41826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -42403,7 +41985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42454,7 +42036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42505,7 +42087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42556,7 +42138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42607,7 +42189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -42621,7 +42203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -42635,7 +42217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -42655,7 +42237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -42749,7 +42331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -42763,7 +42345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -42777,7 +42359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -43260,7 +42842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -43280,7 +42862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -43294,7 +42876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -43322,7 +42904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -43522,7 +43104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -43722,7 +43304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -43922,7 +43504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>
@@ -45811,6 +45393,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMS70N19.svd
+++ b/data/Atmel/ATSAMS70N19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4177,7 +4177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4216,7 +4216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4266,7 +4266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4375,7 +4375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4389,7 +4389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4646,7 +4646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4666,7 +4666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4776,7 +4776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4929,7 +4929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5082,7 +5082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5235,7 +5235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5468,7 +5468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5496,7 +5496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5519,7 +5519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5552,7 +5552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5626,7 +5626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5671,7 +5671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5698,7 +5698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5749,7 +5749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5800,7 +5800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5902,7 +5902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5945,7 +5945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5959,7 +5959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5975,7 +5975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6009,7 +6009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6107,7 +6107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6215,7 +6215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6249,7 +6249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6281,7 +6281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6345,7 +6345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6377,7 +6377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6409,7 +6409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6442,7 +6442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6523,7 +6523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6586,7 +6586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6649,7 +6649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6712,7 +6712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6733,7 +6733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6754,7 +6754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6775,7 +6775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6789,7 +6789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6835,7 +6835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6849,7 +6849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6881,7 +6881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6961,7 +6961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7020,7 +7020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7070,7 +7070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7120,7 +7120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7135,7 +7135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7267,7 +7267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7295,7 +7295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7335,7 +7335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7536,7 +7536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -7737,7 +7737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8139,7 +8139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8340,7 +8340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -8541,7 +8541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -8742,7 +8742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -8943,7 +8943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9144,7 +9144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9345,7 +9345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -9546,7 +9546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -9746,7 +9746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -9947,7 +9947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10148,7 +10148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10349,7 +10349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -10550,7 +10550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -10751,7 +10751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11153,7 +11153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11354,7 +11354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -11555,7 +11555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -11756,7 +11756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -11959,7 +11959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12159,7 +12159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12360,7 +12360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -12561,7 +12561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -12762,7 +12762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -12776,7 +12776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -12977,7 +12977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13178,7 +13178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13379,7 +13379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -13580,7 +13580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -13781,7 +13781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -13982,7 +13982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14183,7 +14183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14384,7 +14384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -14585,7 +14585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -14786,7 +14786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -14987,7 +14987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15188,7 +15188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15389,7 +15389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -15590,7 +15590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -15791,7 +15791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -15992,7 +15992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16020,7 +16020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16041,7 +16041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16241,7 +16241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -16857,7 +16857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -16913,7 +16913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -16946,7 +16946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -16979,7 +16979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17012,7 +17012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17033,7 +17033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17083,7 +17083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17140,7 +17140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17197,7 +17197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17260,7 +17260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17419,7 +17419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17578,7 +17578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -17928,7 +17928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18049,7 +18049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18071,7 +18071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18119,7 +18119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18218,7 +18218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18317,7 +18317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -18434,7 +18434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -18533,7 +18533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -18691,7 +18691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -18795,7 +18795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -18810,7 +18810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -18838,7 +18838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -18859,7 +18859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19018,7 +19018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19177,7 +19177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19336,7 +19336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19408,7 +19408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -19452,7 +19452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -19611,7 +19611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -19770,7 +19770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -19929,7 +19929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20088,7 +20088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20102,7 +20102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20261,7 +20261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20420,7 +20420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -20579,7 +20579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -20738,7 +20738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -20772,7 +20772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -20946,7 +20946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -20979,7 +20979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21012,7 +21012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21045,7 +21045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21102,7 +21102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21159,7 +21159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21216,7 +21216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21273,7 +21273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21341,7 +21341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21356,7 +21356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21370,7 +21370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21390,7 +21390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21405,7 +21405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -21522,7 +21522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -21639,7 +21639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -21756,7 +21756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -21873,7 +21873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -21929,7 +21929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -21985,7 +21985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22042,7 +22042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22099,7 +22099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22156,7 +22156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22213,7 +22213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22239,7 +22239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22260,7 +22260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22275,7 +22275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22331,7 +22331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22365,7 +22365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22421,7 +22421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22441,7 +22441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22456,7 +22456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22488,7 +22488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -22544,7 +22544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22627,7 +22627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22726,7 +22726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -22746,7 +22746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -22767,7 +22767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -22811,7 +22811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -22851,7 +22851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -22993,7 +22993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23007,7 +23007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23022,7 +23022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23036,7 +23036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23051,7 +23051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23066,7 +23066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23086,7 +23086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23108,7 +23108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23129,7 +23129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23150,7 +23150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23230,7 +23230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23268,7 +23268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23289,7 +23289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23369,7 +23369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23407,7 +23407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -23455,7 +23455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23488,7 +23488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23608,7 +23608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23623,7 +23623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23638,7 +23638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23695,7 +23695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23746,7 +23746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23797,7 +23797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23848,7 +23848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23880,7 +23880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -23894,7 +23894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -23914,7 +23914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24092,7 +24092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24125,7 +24125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24140,7 +24140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24168,7 +24168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24208,7 +24208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24243,7 +24243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24304,7 +24304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24363,7 +24363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24392,7 +24392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24442,7 +24442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24476,7 +24476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24549,7 +24549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24763,7 +24763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24795,7 +24795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24833,7 +24833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24883,7 +24883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24915,7 +24915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25038,7 +25038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25083,7 +25083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25128,7 +25128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25173,7 +25173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25218,7 +25218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25270,7 +25270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25314,7 +25314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25328,7 +25328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25343,7 +25343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25383,7 +25383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25446,7 +25446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25502,7 +25502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25523,7 +25523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25550,7 +25550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25607,7 +25607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25709,7 +25709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25762,7 +25762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -25866,7 +25866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -25894,7 +25894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -25934,7 +25934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -25973,7 +25973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -25987,7 +25987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26145,7 +26145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26247,7 +26247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26394,7 +26394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26502,7 +26502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26517,7 +26517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26532,7 +26532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26547,7 +26547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26561,7 +26561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26575,7 +26575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26589,7 +26589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26658,7 +26658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -26715,7 +26715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -26772,7 +26772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -26829,7 +26829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26857,7 +26857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26897,7 +26897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26958,7 +26958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27044,7 +27044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27148,7 +27148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27358,7 +27358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27898,7 +27898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28377,7 +28377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28404,7 +28404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28647,7 +28647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28667,7 +28667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28682,7 +28682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28697,7 +28697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28711,7 +28711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28725,7 +28725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28739,7 +28739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -28814,7 +28814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -28871,7 +28871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -28928,7 +28928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -28985,7 +28985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -29038,7 +29038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29053,7 +29053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -29199,7 +29199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -29226,7 +29226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -29253,7 +29253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -29280,7 +29280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -29313,7 +29313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -29333,7 +29333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29428,7 +29428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29457,7 +29457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29472,7 +29472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29487,7 +29487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29502,7 +29502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29517,7 +29517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29551,7 +29551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29692,7 +29692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29741,7 +29741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29809,7 +29809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29823,7 +29823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29855,7 +29855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29978,7 +29978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30083,7 +30083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30188,7 +30188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30293,7 +30293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30308,7 +30308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30323,7 +30323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30355,7 +30355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30387,7 +30387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30419,7 +30419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30447,7 +30447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30503,7 +30503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -30560,7 +30560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -30669,7 +30669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -30720,7 +30720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -30771,7 +30771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -30822,7 +30822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -30873,7 +30873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -30888,7 +30888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -30903,7 +30903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -30917,7 +30917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -30962,7 +30962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -32545,7 +32545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -32626,7 +32626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -32791,7 +32791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -32842,7 +32842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -32935,7 +32935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33100,7 +33100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -33265,7 +33265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -33430,7 +33430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -33558,7 +33558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -33587,7 +33587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -33759,7 +33759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -33924,7 +33924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -33983,7 +33983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -34048,7 +34048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -34149,7 +34149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -34250,7 +34250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -34343,7 +34343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34357,7 +34357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34371,7 +34371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34433,7 +34433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34478,7 +34478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -34523,7 +34523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -34688,7 +34688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -34739,7 +34739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -34832,7 +34832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -34997,7 +34997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -35162,7 +35162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -35327,7 +35327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -35443,7 +35443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -35469,7 +35469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -35501,7 +35501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -35533,7 +35533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -35555,7 +35555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -35715,7 +35715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -35864,7 +35864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -35917,7 +35917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -35982,7 +35982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -36071,7 +36071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -36154,7 +36154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -36237,7 +36237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -36259,7 +36259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -36309,7 +36309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36323,7 +36323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -36337,7 +36337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -36399,7 +36399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -36444,7 +36444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -36495,7 +36495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -36540,7 +36540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -36555,7 +36555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -36591,7 +36591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36622,7 +36622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36668,7 +36668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36697,7 +36697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36747,7 +36747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36787,7 +36787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36814,7 +36814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36852,7 +36852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36884,7 +36884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37037,7 +37037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37190,7 +37190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37343,7 +37343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37496,7 +37496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37649,7 +37649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -37802,7 +37802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -37955,7 +37955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38107,7 +38107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38259,7 +38259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38412,7 +38412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38565,7 +38565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38718,7 +38718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -38871,7 +38871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -39030,7 +39030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39081,7 +39081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39132,7 +39132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39183,7 +39183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39234,7 +39234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -39248,7 +39248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -39262,7 +39262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -39282,7 +39282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -39376,7 +39376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -39390,7 +39390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -39404,7 +39404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -39734,7 +39734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -39754,7 +39754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -39768,7 +39768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -39796,7 +39796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMS70N19B.svd
+++ b/data/Atmel/ATSAMS70N19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6079,7 +6079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6153,7 +6153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6198,7 +6198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6225,7 +6225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6276,7 +6276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6327,7 +6327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6378,7 +6378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6429,7 +6429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6472,7 +6472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6486,7 +6486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6502,7 +6502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6536,7 +6536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6742,7 +6742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6762,7 +6762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6776,7 +6776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6808,7 +6808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6840,7 +6840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6872,7 +6872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6904,7 +6904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6936,7 +6936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6969,7 +6969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7050,7 +7050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7113,7 +7113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7176,7 +7176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7239,7 +7239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7260,7 +7260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7281,7 +7281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7302,7 +7302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7316,7 +7316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7348,7 +7348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7362,7 +7362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7376,7 +7376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7408,7 +7408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7450,7 +7450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7488,7 +7488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7547,7 +7547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7597,7 +7597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7647,7 +7647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7668,7 +7668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7858,7 +7858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7886,7 +7886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7926,7 +7926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -8127,7 +8127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -8328,7 +8328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -8529,7 +8529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8730,7 +8730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8931,7 +8931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -9132,7 +9132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -9333,7 +9333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -9534,7 +9534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9735,7 +9735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9936,7 +9936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -10137,7 +10137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -10337,7 +10337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -10538,7 +10538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10739,7 +10739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10940,7 +10940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -11141,7 +11141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -11342,7 +11342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11744,7 +11744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11945,7 +11945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -12146,7 +12146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -12347,7 +12347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -12550,7 +12550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12750,7 +12750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12951,7 +12951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -13152,7 +13152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -13353,7 +13353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -13367,7 +13367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -13568,7 +13568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13769,7 +13769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13970,7 +13970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -14171,7 +14171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -14372,7 +14372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -14573,7 +14573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14774,7 +14774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14975,7 +14975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -15176,7 +15176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -15377,7 +15377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -15578,7 +15578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15779,7 +15779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15980,7 +15980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -16181,7 +16181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -16382,7 +16382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -16583,7 +16583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16611,7 +16611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16632,7 +16632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16832,7 +16832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -17448,7 +17448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -17504,7 +17504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -17537,7 +17537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -17570,7 +17570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17603,7 +17603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17624,7 +17624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17674,7 +17674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17737,7 +17737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17800,7 +17800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17869,7 +17869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -18010,7 +18010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -18151,7 +18151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18483,7 +18483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18604,7 +18604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18626,7 +18626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18674,7 +18674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18779,7 +18779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18884,7 +18884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19007,7 +19007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -19112,7 +19112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -19270,7 +19270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -19374,7 +19374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -19389,7 +19389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19417,7 +19417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19438,7 +19438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19567,7 +19567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19696,7 +19696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19825,7 +19825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19897,7 +19897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -19941,7 +19941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -20082,7 +20082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20223,7 +20223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -20364,7 +20364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20505,7 +20505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20519,7 +20519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20648,7 +20648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20777,7 +20777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -20906,7 +20906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -21035,7 +21035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -21069,7 +21069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -21243,7 +21243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -21276,7 +21276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21309,7 +21309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21342,7 +21342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21399,7 +21399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21456,7 +21456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21513,7 +21513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21570,7 +21570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21638,7 +21638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21653,7 +21653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21667,7 +21667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21687,7 +21687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21702,7 +21702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -21819,7 +21819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -21936,7 +21936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -22053,7 +22053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22170,7 +22170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22226,7 +22226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -22282,7 +22282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22339,7 +22339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22396,7 +22396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22453,7 +22453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22510,7 +22510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22536,7 +22536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22557,7 +22557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22572,7 +22572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22628,7 +22628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22662,7 +22662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22718,7 +22718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22738,7 +22738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22753,7 +22753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22785,7 +22785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -22841,7 +22841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22924,7 +22924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -23023,7 +23023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23056,7 +23056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23077,7 +23077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23121,7 +23121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23161,7 +23161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23355,7 +23355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23369,7 +23369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23384,7 +23384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23398,7 +23398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23413,7 +23413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23428,7 +23428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23448,7 +23448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23470,7 +23470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23491,7 +23491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23512,7 +23512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23592,7 +23592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23630,7 +23630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23651,7 +23651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23731,7 +23731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23769,7 +23769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -23817,7 +23817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23850,7 +23850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23970,7 +23970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23985,7 +23985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24000,7 +24000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24057,7 +24057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24108,7 +24108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24159,7 +24159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24210,7 +24210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24242,7 +24242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24256,7 +24256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24276,7 +24276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24454,7 +24454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24487,7 +24487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24502,7 +24502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24530,7 +24530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24570,7 +24570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24605,7 +24605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24666,7 +24666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24725,7 +24725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24754,7 +24754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24804,7 +24804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24838,7 +24838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24911,7 +24911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25125,7 +25125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25157,7 +25157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25195,7 +25195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25245,7 +25245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25277,7 +25277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25400,7 +25400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25445,7 +25445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25490,7 +25490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25535,7 +25535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25580,7 +25580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25632,7 +25632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25676,7 +25676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25690,7 +25690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25705,7 +25705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25745,7 +25745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25784,7 +25784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25876,7 +25876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25897,7 +25897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25947,7 +25947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26004,7 +26004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26055,7 +26055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26106,7 +26106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26159,7 +26159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26192,12 +26192,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -26289,7 +26289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26317,7 +26317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26357,7 +26357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -26396,7 +26396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -26410,7 +26410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26568,7 +26568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26670,7 +26670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26817,7 +26817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26925,7 +26925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26940,7 +26940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26955,7 +26955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26970,7 +26970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26984,7 +26984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26998,7 +26998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27012,7 +27012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27081,7 +27081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27138,7 +27138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27195,7 +27195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27252,7 +27252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27280,7 +27280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27311,7 +27311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -27320,7 +27320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27381,7 +27381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27467,7 +27467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27571,7 +27571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27781,7 +27781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28321,7 +28321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28766,6 +28766,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -28800,7 +28828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28827,7 +28855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29070,9 +29098,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -29506,7 +29534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29526,7 +29554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29541,7 +29569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -29556,7 +29584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -29570,7 +29598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -29584,7 +29612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -29598,7 +29626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -29673,7 +29701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -29730,7 +29758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -29787,7 +29815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -29844,7 +29872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -29897,7 +29925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29912,7 +29940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -30070,7 +30098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -30103,7 +30131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -30136,7 +30164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -30169,7 +30197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -30208,7 +30236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -30228,7 +30256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30323,7 +30351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30352,7 +30380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30367,7 +30395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30382,7 +30410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30397,7 +30425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30412,7 +30440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30446,7 +30474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30587,7 +30615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30636,7 +30664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30704,7 +30732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30718,7 +30746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30750,7 +30778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30873,7 +30901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30978,7 +31006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31083,7 +31111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31188,7 +31216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31203,7 +31231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31218,7 +31246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31250,7 +31278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31282,7 +31310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31314,7 +31342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31342,7 +31370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31398,7 +31426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -31455,7 +31483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -31564,7 +31592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -31615,7 +31643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -31666,7 +31694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -31717,7 +31745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -31768,7 +31796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -31783,7 +31811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -31798,7 +31826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -31812,7 +31840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -31857,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -32683,6 +32711,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -32733,7 +32779,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -32774,80 +32866,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -32945,12 +32963,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -32960,6 +32972,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -32995,46 +33019,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -33063,6 +33047,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33116,7 +33118,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -33163,134 +33211,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33382,30 +33302,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -33415,6 +33311,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33450,64 +33358,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -33536,6 +33386,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33589,7 +33457,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -33636,134 +33550,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33855,30 +33641,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -33888,6 +33650,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33923,64 +33697,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -34009,6 +33725,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34086,7 +33820,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -34133,140 +33919,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34364,30 +34016,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -34397,6 +34025,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34427,64 +34067,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -35175,7 +34757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -35266,7 +34848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -35419,7 +35001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -35470,7 +35052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -35563,7 +35145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -35716,7 +35298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -35869,7 +35451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36022,7 +35604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36150,7 +35732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36179,7 +35761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -36351,7 +35933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -36516,9 +36098,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -36682,9 +36264,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -36848,9 +36430,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37014,7 +36596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -37073,9 +36655,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37133,9 +36715,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37193,9 +36775,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37253,7 +36835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -37318,9 +36900,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37384,9 +36966,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37450,9 +37032,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37516,7 +37098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -37617,9 +37199,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37725,9 +37307,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37827,9 +37409,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37929,7 +37511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -38030,9 +37612,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38138,9 +37720,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38240,9 +37822,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38342,7 +37924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -38431,9 +38013,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38521,9 +38103,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38611,9 +38193,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38705,7 +38287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -38719,7 +38301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38733,7 +38315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -38795,7 +38377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -38840,7 +38422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -38895,7 +38477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -39004,43 +38586,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39048,7 +38630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -39099,7 +38681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -39148,43 +38730,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39192,7 +38774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -39301,43 +38883,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39345,7 +38927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -39454,43 +39036,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39498,7 +39080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -39607,43 +39189,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39651,7 +39233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -39767,7 +39349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -39793,7 +39375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -39825,7 +39407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -39857,7 +39439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -39879,7 +39461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -40039,9 +39621,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -40206,7 +39788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -40355,9 +39937,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -40505,9 +40087,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -40655,9 +40237,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -40805,7 +40387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -40858,9 +40440,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40912,9 +40494,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40966,9 +40548,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41020,7 +40602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -41085,9 +40667,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41151,9 +40733,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41217,9 +40799,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41283,7 +40865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -41372,9 +40954,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41462,9 +41044,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41552,9 +41134,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41642,7 +41224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -41725,9 +41307,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41809,9 +41391,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41893,9 +41475,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41977,7 +41559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -42060,9 +41642,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42144,9 +41726,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42228,9 +41810,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42312,7 +41894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -42334,7 +41916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -42384,7 +41966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42398,7 +41980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42412,7 +41994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42474,7 +42056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42519,7 +42101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -42576,7 +42158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -42621,7 +42203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -42636,7 +42218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -42672,7 +42254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -42703,7 +42285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -42749,7 +42331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42778,7 +42360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42828,7 +42410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42868,7 +42450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42895,7 +42477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42933,7 +42515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42965,7 +42547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -43118,7 +42700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43271,7 +42853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -43424,7 +43006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -43577,7 +43159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -43730,7 +43312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -43883,7 +43465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -44036,7 +43618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -44188,7 +43770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -44340,7 +43922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -44493,7 +44075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -44646,7 +44228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -44799,7 +44381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -44952,7 +44534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -45111,7 +44693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45162,7 +44744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45213,7 +44795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45264,7 +44846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45315,7 +44897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -45329,7 +44911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -45343,7 +44925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -45363,7 +44945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -45457,7 +45039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -45471,7 +45053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -45485,7 +45067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -46048,7 +45630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -46068,7 +45650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -46082,7 +45664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -46110,7 +45692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -47999,6 +47581,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMS70N20.svd
+++ b/data/Atmel/ATSAMS70N20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4177,7 +4177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4216,7 +4216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4266,7 +4266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4375,7 +4375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4389,7 +4389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4646,7 +4646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4666,7 +4666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4776,7 +4776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4929,7 +4929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5082,7 +5082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5235,7 +5235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5468,7 +5468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5496,7 +5496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5519,7 +5519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5552,7 +5552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5626,7 +5626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5671,7 +5671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5698,7 +5698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5749,7 +5749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5800,7 +5800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5902,7 +5902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5945,7 +5945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5959,7 +5959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5975,7 +5975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6009,7 +6009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6107,7 +6107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6215,7 +6215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6249,7 +6249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6281,7 +6281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6345,7 +6345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6377,7 +6377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6409,7 +6409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6442,7 +6442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6523,7 +6523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6586,7 +6586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6649,7 +6649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6712,7 +6712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6733,7 +6733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6754,7 +6754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6775,7 +6775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6789,7 +6789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6835,7 +6835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6849,7 +6849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6881,7 +6881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6961,7 +6961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7020,7 +7020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7070,7 +7070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7120,7 +7120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7135,7 +7135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7267,7 +7267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7295,7 +7295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7335,7 +7335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7536,7 +7536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -7737,7 +7737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8139,7 +8139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8340,7 +8340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -8541,7 +8541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -8742,7 +8742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -8943,7 +8943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9144,7 +9144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9345,7 +9345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -9546,7 +9546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -9746,7 +9746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -9947,7 +9947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10148,7 +10148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10349,7 +10349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -10550,7 +10550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -10751,7 +10751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11153,7 +11153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11354,7 +11354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -11555,7 +11555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -11756,7 +11756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -11959,7 +11959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12159,7 +12159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12360,7 +12360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -12561,7 +12561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -12762,7 +12762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -12776,7 +12776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -12977,7 +12977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13178,7 +13178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13379,7 +13379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -13580,7 +13580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -13781,7 +13781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -13982,7 +13982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14183,7 +14183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14384,7 +14384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -14585,7 +14585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -14786,7 +14786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -14987,7 +14987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15188,7 +15188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15389,7 +15389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -15590,7 +15590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -15791,7 +15791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -15992,7 +15992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16020,7 +16020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16041,7 +16041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16241,7 +16241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -16857,7 +16857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -16913,7 +16913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -16946,7 +16946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -16979,7 +16979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17012,7 +17012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17033,7 +17033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17083,7 +17083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17140,7 +17140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17197,7 +17197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17260,7 +17260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17419,7 +17419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17578,7 +17578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -17928,7 +17928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18049,7 +18049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18071,7 +18071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18119,7 +18119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18218,7 +18218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18317,7 +18317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -18434,7 +18434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -18533,7 +18533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -18691,7 +18691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -18795,7 +18795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -18810,7 +18810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -18838,7 +18838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -18859,7 +18859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19018,7 +19018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19177,7 +19177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19336,7 +19336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19408,7 +19408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -19452,7 +19452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -19611,7 +19611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -19770,7 +19770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -19929,7 +19929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20088,7 +20088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20102,7 +20102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20261,7 +20261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20420,7 +20420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -20579,7 +20579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -20738,7 +20738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -20772,7 +20772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -20946,7 +20946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -20979,7 +20979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21012,7 +21012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21045,7 +21045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21102,7 +21102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21159,7 +21159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21216,7 +21216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21273,7 +21273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21341,7 +21341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21356,7 +21356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21370,7 +21370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21390,7 +21390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21405,7 +21405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -21522,7 +21522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -21639,7 +21639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -21756,7 +21756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -21873,7 +21873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -21929,7 +21929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -21985,7 +21985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22042,7 +22042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22099,7 +22099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22156,7 +22156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22213,7 +22213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22239,7 +22239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22260,7 +22260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22275,7 +22275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22331,7 +22331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22365,7 +22365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22421,7 +22421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22441,7 +22441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22456,7 +22456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22488,7 +22488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -22544,7 +22544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22627,7 +22627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22726,7 +22726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -22746,7 +22746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -22767,7 +22767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -22811,7 +22811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -22851,7 +22851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -22993,7 +22993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23007,7 +23007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23022,7 +23022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23036,7 +23036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23051,7 +23051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23066,7 +23066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23086,7 +23086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23108,7 +23108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23129,7 +23129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23150,7 +23150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23230,7 +23230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23268,7 +23268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23289,7 +23289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23369,7 +23369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23407,7 +23407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -23455,7 +23455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23488,7 +23488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23608,7 +23608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23623,7 +23623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23638,7 +23638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23695,7 +23695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23746,7 +23746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23797,7 +23797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23848,7 +23848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23880,7 +23880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -23894,7 +23894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -23914,7 +23914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24092,7 +24092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24125,7 +24125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24140,7 +24140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24168,7 +24168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24208,7 +24208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24243,7 +24243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24304,7 +24304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24363,7 +24363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24392,7 +24392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24442,7 +24442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24476,7 +24476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24549,7 +24549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24763,7 +24763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24795,7 +24795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24833,7 +24833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24883,7 +24883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24915,7 +24915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25038,7 +25038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25083,7 +25083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25128,7 +25128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25173,7 +25173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25218,7 +25218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25270,7 +25270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25314,7 +25314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25328,7 +25328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25343,7 +25343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25383,7 +25383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25446,7 +25446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25502,7 +25502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25523,7 +25523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25550,7 +25550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25607,7 +25607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25709,7 +25709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25762,7 +25762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -25866,7 +25866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -25894,7 +25894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -25934,7 +25934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -25973,7 +25973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -25987,7 +25987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26145,7 +26145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26247,7 +26247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26394,7 +26394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26502,7 +26502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26517,7 +26517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26532,7 +26532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26547,7 +26547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26561,7 +26561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26575,7 +26575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26589,7 +26589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26658,7 +26658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -26715,7 +26715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -26772,7 +26772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -26829,7 +26829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26857,7 +26857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26897,7 +26897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26958,7 +26958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27044,7 +27044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27148,7 +27148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27358,7 +27358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27898,7 +27898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28377,7 +28377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28404,7 +28404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28647,7 +28647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28667,7 +28667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28682,7 +28682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28697,7 +28697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28711,7 +28711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28725,7 +28725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28739,7 +28739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -28814,7 +28814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -28871,7 +28871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -28928,7 +28928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -28985,7 +28985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -29038,7 +29038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29053,7 +29053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -29199,7 +29199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -29226,7 +29226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -29253,7 +29253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -29280,7 +29280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -29313,7 +29313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -29333,7 +29333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29428,7 +29428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29457,7 +29457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29472,7 +29472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29487,7 +29487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29502,7 +29502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29517,7 +29517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29551,7 +29551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29692,7 +29692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29741,7 +29741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29809,7 +29809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29823,7 +29823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29855,7 +29855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29978,7 +29978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30083,7 +30083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30188,7 +30188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30293,7 +30293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30308,7 +30308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30323,7 +30323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30355,7 +30355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30387,7 +30387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30419,7 +30419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30447,7 +30447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30503,7 +30503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -30560,7 +30560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -30669,7 +30669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -30720,7 +30720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -30771,7 +30771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -30822,7 +30822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -30873,7 +30873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -30888,7 +30888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -30903,7 +30903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -30917,7 +30917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -30962,7 +30962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -32545,7 +32545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -32626,7 +32626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -32791,7 +32791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -32842,7 +32842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -32935,7 +32935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33100,7 +33100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -33265,7 +33265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -33430,7 +33430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -33558,7 +33558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -33587,7 +33587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -33759,7 +33759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -33924,7 +33924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -33983,7 +33983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -34048,7 +34048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -34149,7 +34149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -34250,7 +34250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -34343,7 +34343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34357,7 +34357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34371,7 +34371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34433,7 +34433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34478,7 +34478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -34523,7 +34523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -34688,7 +34688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -34739,7 +34739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -34832,7 +34832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -34997,7 +34997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -35162,7 +35162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -35327,7 +35327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -35443,7 +35443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -35469,7 +35469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -35501,7 +35501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -35533,7 +35533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -35555,7 +35555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -35715,7 +35715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -35864,7 +35864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -35917,7 +35917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -35982,7 +35982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -36071,7 +36071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -36154,7 +36154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -36237,7 +36237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -36259,7 +36259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -36309,7 +36309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36323,7 +36323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -36337,7 +36337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -36399,7 +36399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -36444,7 +36444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -36495,7 +36495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -36540,7 +36540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -36555,7 +36555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -36591,7 +36591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36622,7 +36622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36668,7 +36668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36697,7 +36697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36747,7 +36747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36787,7 +36787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36814,7 +36814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36852,7 +36852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36884,7 +36884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37037,7 +37037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37190,7 +37190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37343,7 +37343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37496,7 +37496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37649,7 +37649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -37802,7 +37802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -37955,7 +37955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38107,7 +38107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38259,7 +38259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38412,7 +38412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38565,7 +38565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38718,7 +38718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -38871,7 +38871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -39030,7 +39030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39081,7 +39081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39132,7 +39132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39183,7 +39183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39234,7 +39234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -39248,7 +39248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -39262,7 +39262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -39282,7 +39282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -39376,7 +39376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -39390,7 +39390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -39404,7 +39404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -39734,7 +39734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -39754,7 +39754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -39768,7 +39768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -39796,7 +39796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -39996,7 +39996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMS70N20B.svd
+++ b/data/Atmel/ATSAMS70N20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6079,7 +6079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6153,7 +6153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6198,7 +6198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6225,7 +6225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6276,7 +6276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6327,7 +6327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6378,7 +6378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6429,7 +6429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6472,7 +6472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6486,7 +6486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6502,7 +6502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6536,7 +6536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6742,7 +6742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6762,7 +6762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6776,7 +6776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6808,7 +6808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6840,7 +6840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6872,7 +6872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6904,7 +6904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6936,7 +6936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6969,7 +6969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7050,7 +7050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7113,7 +7113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7176,7 +7176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7239,7 +7239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7260,7 +7260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7281,7 +7281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7302,7 +7302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7316,7 +7316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7348,7 +7348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7362,7 +7362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7376,7 +7376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7408,7 +7408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7450,7 +7450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7488,7 +7488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7547,7 +7547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7597,7 +7597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7647,7 +7647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7668,7 +7668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7858,7 +7858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7886,7 +7886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7926,7 +7926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -8127,7 +8127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -8328,7 +8328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -8529,7 +8529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8730,7 +8730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8931,7 +8931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -9132,7 +9132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -9333,7 +9333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -9534,7 +9534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9735,7 +9735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9936,7 +9936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -10137,7 +10137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -10337,7 +10337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -10538,7 +10538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10739,7 +10739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10940,7 +10940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -11141,7 +11141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -11342,7 +11342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11744,7 +11744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11945,7 +11945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -12146,7 +12146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -12347,7 +12347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -12550,7 +12550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12750,7 +12750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12951,7 +12951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -13152,7 +13152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -13353,7 +13353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -13367,7 +13367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -13568,7 +13568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13769,7 +13769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13970,7 +13970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -14171,7 +14171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -14372,7 +14372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -14573,7 +14573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14774,7 +14774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14975,7 +14975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -15176,7 +15176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -15377,7 +15377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -15578,7 +15578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15779,7 +15779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15980,7 +15980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -16181,7 +16181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -16382,7 +16382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -16583,7 +16583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16611,7 +16611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16632,7 +16632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16832,7 +16832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -17448,7 +17448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -17504,7 +17504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -17537,7 +17537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -17570,7 +17570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17603,7 +17603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17624,7 +17624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17674,7 +17674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17737,7 +17737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17800,7 +17800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17869,7 +17869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -18010,7 +18010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -18151,7 +18151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18483,7 +18483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18604,7 +18604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18626,7 +18626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18674,7 +18674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18779,7 +18779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18884,7 +18884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19007,7 +19007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -19112,7 +19112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -19270,7 +19270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -19374,7 +19374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -19389,7 +19389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19417,7 +19417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19438,7 +19438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19567,7 +19567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19696,7 +19696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19825,7 +19825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19897,7 +19897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -19941,7 +19941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -20082,7 +20082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20223,7 +20223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -20364,7 +20364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20505,7 +20505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20519,7 +20519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20648,7 +20648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20777,7 +20777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -20906,7 +20906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -21035,7 +21035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -21069,7 +21069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -21243,7 +21243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -21276,7 +21276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21309,7 +21309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21342,7 +21342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21399,7 +21399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21456,7 +21456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21513,7 +21513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21570,7 +21570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21638,7 +21638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21653,7 +21653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21667,7 +21667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21687,7 +21687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21702,7 +21702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -21819,7 +21819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -21936,7 +21936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -22053,7 +22053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22170,7 +22170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22226,7 +22226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -22282,7 +22282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22339,7 +22339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22396,7 +22396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22453,7 +22453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22510,7 +22510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22536,7 +22536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22557,7 +22557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22572,7 +22572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22628,7 +22628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22662,7 +22662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22718,7 +22718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22738,7 +22738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22753,7 +22753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22785,7 +22785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -22841,7 +22841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22924,7 +22924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -23023,7 +23023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23056,7 +23056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23077,7 +23077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23121,7 +23121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23161,7 +23161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23355,7 +23355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23369,7 +23369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23384,7 +23384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23398,7 +23398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23413,7 +23413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23428,7 +23428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23448,7 +23448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23470,7 +23470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23491,7 +23491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23512,7 +23512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23592,7 +23592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23630,7 +23630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23651,7 +23651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23731,7 +23731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23769,7 +23769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -23817,7 +23817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23850,7 +23850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23970,7 +23970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23985,7 +23985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24000,7 +24000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24057,7 +24057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24108,7 +24108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24159,7 +24159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24210,7 +24210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24242,7 +24242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24256,7 +24256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24276,7 +24276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24454,7 +24454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24487,7 +24487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24502,7 +24502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24530,7 +24530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24570,7 +24570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24605,7 +24605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24666,7 +24666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24725,7 +24725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24754,7 +24754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24804,7 +24804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24838,7 +24838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24911,7 +24911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25125,7 +25125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25157,7 +25157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25195,7 +25195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25245,7 +25245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25277,7 +25277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25400,7 +25400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25445,7 +25445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25490,7 +25490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25535,7 +25535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25580,7 +25580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25632,7 +25632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25676,7 +25676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25690,7 +25690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25705,7 +25705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25745,7 +25745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25784,7 +25784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25876,7 +25876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25897,7 +25897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25947,7 +25947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26004,7 +26004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26055,7 +26055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26106,7 +26106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26159,7 +26159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26192,12 +26192,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -26289,7 +26289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26317,7 +26317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26357,7 +26357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -26396,7 +26396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -26410,7 +26410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26568,7 +26568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26670,7 +26670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26817,7 +26817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26925,7 +26925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26940,7 +26940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26955,7 +26955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26970,7 +26970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26984,7 +26984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26998,7 +26998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27012,7 +27012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27081,7 +27081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27138,7 +27138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27195,7 +27195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27252,7 +27252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27280,7 +27280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27311,7 +27311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -27320,7 +27320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27381,7 +27381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27467,7 +27467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27571,7 +27571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27781,7 +27781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28321,7 +28321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28766,6 +28766,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -28800,7 +28828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28827,7 +28855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29070,9 +29098,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -29506,7 +29534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29526,7 +29554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29541,7 +29569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -29556,7 +29584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -29570,7 +29598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -29584,7 +29612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -29598,7 +29626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -29673,7 +29701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -29730,7 +29758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -29787,7 +29815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -29844,7 +29872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -29897,7 +29925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29912,7 +29940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -30070,7 +30098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -30103,7 +30131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -30136,7 +30164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -30169,7 +30197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -30208,7 +30236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -30228,7 +30256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30323,7 +30351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30352,7 +30380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30367,7 +30395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30382,7 +30410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30397,7 +30425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30412,7 +30440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30446,7 +30474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30587,7 +30615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30636,7 +30664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30704,7 +30732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30718,7 +30746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30750,7 +30778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30873,7 +30901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30978,7 +31006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31083,7 +31111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31188,7 +31216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31203,7 +31231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31218,7 +31246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31250,7 +31278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31282,7 +31310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31314,7 +31342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31342,7 +31370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31398,7 +31426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -31455,7 +31483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -31564,7 +31592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -31615,7 +31643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -31666,7 +31694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -31717,7 +31745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -31768,7 +31796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -31783,7 +31811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -31798,7 +31826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -31812,7 +31840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -31857,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -32683,6 +32711,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -32733,7 +32779,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -32774,80 +32866,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -32945,12 +32963,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -32960,6 +32972,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -32995,46 +33019,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -33063,6 +33047,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33116,7 +33118,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -33163,134 +33211,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33382,30 +33302,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -33415,6 +33311,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33450,64 +33358,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -33536,6 +33386,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33589,7 +33457,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -33636,134 +33550,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33855,30 +33641,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -33888,6 +33650,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33923,64 +33697,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -34009,6 +33725,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34086,7 +33820,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -34133,140 +33919,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34364,30 +34016,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -34397,6 +34025,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34427,64 +34067,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -35175,7 +34757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -35266,7 +34848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -35419,7 +35001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -35470,7 +35052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -35563,7 +35145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -35716,7 +35298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -35869,7 +35451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36022,7 +35604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36150,7 +35732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36179,7 +35761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -36351,7 +35933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -36516,9 +36098,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -36682,9 +36264,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -36848,9 +36430,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37014,7 +36596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -37073,9 +36655,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37133,9 +36715,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37193,9 +36775,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37253,7 +36835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -37318,9 +36900,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37384,9 +36966,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37450,9 +37032,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37516,7 +37098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -37617,9 +37199,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37725,9 +37307,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37827,9 +37409,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37929,7 +37511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -38030,9 +37612,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38138,9 +37720,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38240,9 +37822,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38342,7 +37924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -38431,9 +38013,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38521,9 +38103,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38611,9 +38193,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38705,7 +38287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -38719,7 +38301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38733,7 +38315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -38795,7 +38377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -38840,7 +38422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -38895,7 +38477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -39004,43 +38586,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39048,7 +38630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -39099,7 +38681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -39148,43 +38730,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39192,7 +38774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -39301,43 +38883,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39345,7 +38927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -39454,43 +39036,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39498,7 +39080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -39607,43 +39189,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39651,7 +39233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -39767,7 +39349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -39793,7 +39375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -39825,7 +39407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -39857,7 +39439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -39879,7 +39461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -40039,9 +39621,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -40206,7 +39788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -40355,9 +39937,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -40505,9 +40087,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -40655,9 +40237,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -40805,7 +40387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -40858,9 +40440,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40912,9 +40494,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40966,9 +40548,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41020,7 +40602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -41085,9 +40667,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41151,9 +40733,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41217,9 +40799,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41283,7 +40865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -41372,9 +40954,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41462,9 +41044,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41552,9 +41134,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41642,7 +41224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -41725,9 +41307,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41809,9 +41391,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41893,9 +41475,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41977,7 +41559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -42060,9 +41642,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42144,9 +41726,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42228,9 +41810,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42312,7 +41894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -42334,7 +41916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -42384,7 +41966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42398,7 +41980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42412,7 +41994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42474,7 +42056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42519,7 +42101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -42576,7 +42158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -42621,7 +42203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -42636,7 +42218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -42672,7 +42254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -42703,7 +42285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -42749,7 +42331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42778,7 +42360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42828,7 +42410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42868,7 +42450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42895,7 +42477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42933,7 +42515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42965,7 +42547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -43118,7 +42700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43271,7 +42853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -43424,7 +43006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -43577,7 +43159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -43730,7 +43312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -43883,7 +43465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -44036,7 +43618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -44188,7 +43770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -44340,7 +43922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -44493,7 +44075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -44646,7 +44228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -44799,7 +44381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -44952,7 +44534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -45111,7 +44693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45162,7 +44744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45213,7 +44795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45264,7 +44846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45315,7 +44897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -45329,7 +44911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -45343,7 +44925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -45363,7 +44945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -45457,7 +45039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -45471,7 +45053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -45485,7 +45067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -46048,7 +45630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -46068,7 +45650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -46082,7 +45664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -46110,7 +45692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -46310,7 +45892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -48199,6 +47781,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMS70N21.svd
+++ b/data/Atmel/ATSAMS70N21.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4177,7 +4177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4216,7 +4216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4266,7 +4266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4375,7 +4375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4389,7 +4389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4646,7 +4646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4666,7 +4666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4776,7 +4776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4929,7 +4929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5082,7 +5082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5235,7 +5235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5468,7 +5468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5496,7 +5496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5519,7 +5519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5552,7 +5552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5626,7 +5626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5671,7 +5671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5698,7 +5698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5749,7 +5749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5800,7 +5800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5902,7 +5902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5945,7 +5945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5959,7 +5959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5975,7 +5975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6009,7 +6009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6107,7 +6107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6215,7 +6215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6249,7 +6249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6281,7 +6281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6345,7 +6345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6377,7 +6377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6409,7 +6409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6442,7 +6442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6523,7 +6523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6586,7 +6586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6649,7 +6649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6712,7 +6712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6733,7 +6733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6754,7 +6754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6775,7 +6775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6789,7 +6789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6835,7 +6835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6849,7 +6849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6881,7 +6881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6961,7 +6961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7020,7 +7020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7070,7 +7070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7120,7 +7120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7135,7 +7135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7267,7 +7267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7295,7 +7295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7335,7 +7335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7536,7 +7536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -7737,7 +7737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8139,7 +8139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8340,7 +8340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -8541,7 +8541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -8742,7 +8742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -8943,7 +8943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9144,7 +9144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9345,7 +9345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -9546,7 +9546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -9746,7 +9746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -9947,7 +9947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10148,7 +10148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10349,7 +10349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -10550,7 +10550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -10751,7 +10751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11153,7 +11153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11354,7 +11354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -11555,7 +11555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -11756,7 +11756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -11959,7 +11959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12159,7 +12159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12360,7 +12360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -12561,7 +12561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -12762,7 +12762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -12776,7 +12776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -12977,7 +12977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13178,7 +13178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13379,7 +13379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -13580,7 +13580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -13781,7 +13781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -13982,7 +13982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14183,7 +14183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14384,7 +14384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -14585,7 +14585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -14786,7 +14786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -14987,7 +14987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15188,7 +15188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15389,7 +15389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -15590,7 +15590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -15791,7 +15791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -15992,7 +15992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16020,7 +16020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16041,7 +16041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16241,7 +16241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -16857,7 +16857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -16913,7 +16913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -16946,7 +16946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -16979,7 +16979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17012,7 +17012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17033,7 +17033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17083,7 +17083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17140,7 +17140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17197,7 +17197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17260,7 +17260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17419,7 +17419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17578,7 +17578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -17928,7 +17928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18049,7 +18049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18071,7 +18071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18119,7 +18119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18218,7 +18218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18317,7 +18317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -18434,7 +18434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -18533,7 +18533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -18691,7 +18691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -18795,7 +18795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -18810,7 +18810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -18838,7 +18838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -18859,7 +18859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19018,7 +19018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19177,7 +19177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19336,7 +19336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19408,7 +19408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -19452,7 +19452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -19611,7 +19611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -19770,7 +19770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -19929,7 +19929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20088,7 +20088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20102,7 +20102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20261,7 +20261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20420,7 +20420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -20579,7 +20579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -20738,7 +20738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -20772,7 +20772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -20946,7 +20946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -20979,7 +20979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21012,7 +21012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21045,7 +21045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21102,7 +21102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21159,7 +21159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21216,7 +21216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21273,7 +21273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21341,7 +21341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21356,7 +21356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21370,7 +21370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21390,7 +21390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21405,7 +21405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -21522,7 +21522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -21639,7 +21639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -21756,7 +21756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -21873,7 +21873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -21929,7 +21929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -21985,7 +21985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22042,7 +22042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22099,7 +22099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22156,7 +22156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22213,7 +22213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22239,7 +22239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22260,7 +22260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22275,7 +22275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22331,7 +22331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22365,7 +22365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22421,7 +22421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22441,7 +22441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22456,7 +22456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22488,7 +22488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -22544,7 +22544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22627,7 +22627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22726,7 +22726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -22746,7 +22746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -22767,7 +22767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -22811,7 +22811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -22851,7 +22851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -22993,7 +22993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23007,7 +23007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23022,7 +23022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23036,7 +23036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23051,7 +23051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23066,7 +23066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23086,7 +23086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23108,7 +23108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23129,7 +23129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23150,7 +23150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23230,7 +23230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23268,7 +23268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23289,7 +23289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23369,7 +23369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23407,7 +23407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -23455,7 +23455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23488,7 +23488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23608,7 +23608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23623,7 +23623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23638,7 +23638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23695,7 +23695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23746,7 +23746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23797,7 +23797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23848,7 +23848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23880,7 +23880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -23894,7 +23894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -23914,7 +23914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24092,7 +24092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24125,7 +24125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24140,7 +24140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24168,7 +24168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24208,7 +24208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24243,7 +24243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24304,7 +24304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24363,7 +24363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24392,7 +24392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24442,7 +24442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24476,7 +24476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24549,7 +24549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24763,7 +24763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24795,7 +24795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24833,7 +24833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24883,7 +24883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24915,7 +24915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25038,7 +25038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25083,7 +25083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25128,7 +25128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25173,7 +25173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25218,7 +25218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25270,7 +25270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25314,7 +25314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25328,7 +25328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25343,7 +25343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25383,7 +25383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25446,7 +25446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25502,7 +25502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25523,7 +25523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25550,7 +25550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25607,7 +25607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25658,7 +25658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25709,7 +25709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25762,7 +25762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -25866,7 +25866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -25894,7 +25894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -25934,7 +25934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -25973,7 +25973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -25987,7 +25987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26145,7 +26145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26247,7 +26247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26394,7 +26394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26502,7 +26502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26517,7 +26517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26532,7 +26532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26547,7 +26547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26561,7 +26561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26575,7 +26575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26589,7 +26589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26658,7 +26658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -26715,7 +26715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -26772,7 +26772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -26829,7 +26829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26857,7 +26857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26897,7 +26897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26958,7 +26958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27044,7 +27044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27148,7 +27148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27358,7 +27358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27898,7 +27898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28377,7 +28377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28404,7 +28404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28647,7 +28647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28667,7 +28667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28682,7 +28682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28697,7 +28697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28711,7 +28711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28725,7 +28725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28739,7 +28739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -28814,7 +28814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -28871,7 +28871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -28928,7 +28928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -28985,7 +28985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -29038,7 +29038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29053,7 +29053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -29199,7 +29199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -29226,7 +29226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -29253,7 +29253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -29280,7 +29280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -29313,7 +29313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -29333,7 +29333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29428,7 +29428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29457,7 +29457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29472,7 +29472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29487,7 +29487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29502,7 +29502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29517,7 +29517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -29551,7 +29551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29692,7 +29692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29741,7 +29741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29809,7 +29809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29823,7 +29823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29855,7 +29855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29978,7 +29978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30083,7 +30083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30188,7 +30188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30293,7 +30293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30308,7 +30308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30323,7 +30323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30355,7 +30355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30387,7 +30387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30419,7 +30419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30447,7 +30447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30503,7 +30503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -30560,7 +30560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -30669,7 +30669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -30720,7 +30720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -30771,7 +30771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -30822,7 +30822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -30873,7 +30873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -30888,7 +30888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -30903,7 +30903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -30917,7 +30917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -30962,7 +30962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -32545,7 +32545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -32626,7 +32626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -32791,7 +32791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -32842,7 +32842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -32935,7 +32935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33100,7 +33100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -33265,7 +33265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -33430,7 +33430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -33558,7 +33558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -33587,7 +33587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -33759,7 +33759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -33924,7 +33924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -33983,7 +33983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -34048,7 +34048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -34149,7 +34149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -34250,7 +34250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -34343,7 +34343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34357,7 +34357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34371,7 +34371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34433,7 +34433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34478,7 +34478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -34523,7 +34523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -34688,7 +34688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -34739,7 +34739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -34832,7 +34832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -34997,7 +34997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -35162,7 +35162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -35327,7 +35327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -35443,7 +35443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -35469,7 +35469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -35501,7 +35501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -35533,7 +35533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -35555,7 +35555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -35715,7 +35715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -35864,7 +35864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -35917,7 +35917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -35982,7 +35982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -36071,7 +36071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -36154,7 +36154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -36237,7 +36237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -36259,7 +36259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -36309,7 +36309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36323,7 +36323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -36337,7 +36337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -36399,7 +36399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -36444,7 +36444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -36495,7 +36495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -36540,7 +36540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -36555,7 +36555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -36591,7 +36591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36622,7 +36622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36668,7 +36668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36697,7 +36697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36747,7 +36747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36787,7 +36787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36814,7 +36814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36852,7 +36852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36884,7 +36884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37037,7 +37037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37190,7 +37190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37343,7 +37343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37496,7 +37496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37649,7 +37649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -37802,7 +37802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -37955,7 +37955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38107,7 +38107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38259,7 +38259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38412,7 +38412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38565,7 +38565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38718,7 +38718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -38871,7 +38871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -39030,7 +39030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39081,7 +39081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39132,7 +39132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39183,7 +39183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39234,7 +39234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -39248,7 +39248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -39262,7 +39262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -39282,7 +39282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -39376,7 +39376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -39390,7 +39390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -39404,7 +39404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -39734,7 +39734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -39754,7 +39754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -39768,7 +39768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -39796,7 +39796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -39996,7 +39996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -40196,7 +40196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -40396,7 +40396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMS70N21B.svd
+++ b/data/Atmel/ATSAMS70N21B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6079,7 +6079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6153,7 +6153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6198,7 +6198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6225,7 +6225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6276,7 +6276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6327,7 +6327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6378,7 +6378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6429,7 +6429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6472,7 +6472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6486,7 +6486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6502,7 +6502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6536,7 +6536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6742,7 +6742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6762,7 +6762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6776,7 +6776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6808,7 +6808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6840,7 +6840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6872,7 +6872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6904,7 +6904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6936,7 +6936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6969,7 +6969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7050,7 +7050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7113,7 +7113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7176,7 +7176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7239,7 +7239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7260,7 +7260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7281,7 +7281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7302,7 +7302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7316,7 +7316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7348,7 +7348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7362,7 +7362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7376,7 +7376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7408,7 +7408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7450,7 +7450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7488,7 +7488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7547,7 +7547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7597,7 +7597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7647,7 +7647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7668,7 +7668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7858,7 +7858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7886,7 +7886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7926,7 +7926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -8127,7 +8127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -8328,7 +8328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -8529,7 +8529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8730,7 +8730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8931,7 +8931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -9132,7 +9132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -9333,7 +9333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -9534,7 +9534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9735,7 +9735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9936,7 +9936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -10137,7 +10137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -10337,7 +10337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -10538,7 +10538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10739,7 +10739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10940,7 +10940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -11141,7 +11141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -11342,7 +11342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11744,7 +11744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11945,7 +11945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -12146,7 +12146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -12347,7 +12347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -12550,7 +12550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12750,7 +12750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12951,7 +12951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -13152,7 +13152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -13353,7 +13353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -13367,7 +13367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -13568,7 +13568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13769,7 +13769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13970,7 +13970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -14171,7 +14171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -14372,7 +14372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -14573,7 +14573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14774,7 +14774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14975,7 +14975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -15176,7 +15176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -15377,7 +15377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -15578,7 +15578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15779,7 +15779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15980,7 +15980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -16181,7 +16181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -16382,7 +16382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -16583,7 +16583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16611,7 +16611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16632,7 +16632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16832,7 +16832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -17448,7 +17448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -17504,7 +17504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -17537,7 +17537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -17570,7 +17570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17603,7 +17603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17624,7 +17624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17674,7 +17674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17737,7 +17737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17800,7 +17800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17869,7 +17869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -18010,7 +18010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -18151,7 +18151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18483,7 +18483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18604,7 +18604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18626,7 +18626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18674,7 +18674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18779,7 +18779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18884,7 +18884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19007,7 +19007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -19112,7 +19112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -19270,7 +19270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -19374,7 +19374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -19389,7 +19389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19417,7 +19417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19438,7 +19438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19567,7 +19567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19696,7 +19696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19825,7 +19825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19897,7 +19897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -19941,7 +19941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -20082,7 +20082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20223,7 +20223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -20364,7 +20364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20505,7 +20505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20519,7 +20519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20648,7 +20648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20777,7 +20777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -20906,7 +20906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -21035,7 +21035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -21069,7 +21069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -21243,7 +21243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -21276,7 +21276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21309,7 +21309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21342,7 +21342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21399,7 +21399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21456,7 +21456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21513,7 +21513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21570,7 +21570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21638,7 +21638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21653,7 +21653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21667,7 +21667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21687,7 +21687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21702,7 +21702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -21819,7 +21819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -21936,7 +21936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -22053,7 +22053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22170,7 +22170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22226,7 +22226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -22282,7 +22282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22339,7 +22339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22396,7 +22396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22453,7 +22453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22510,7 +22510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22536,7 +22536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22557,7 +22557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22572,7 +22572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22628,7 +22628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22662,7 +22662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22718,7 +22718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22738,7 +22738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22753,7 +22753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22785,7 +22785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -22841,7 +22841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22924,7 +22924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -23023,7 +23023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23056,7 +23056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23077,7 +23077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23121,7 +23121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23161,7 +23161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23355,7 +23355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23369,7 +23369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23384,7 +23384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23398,7 +23398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23413,7 +23413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23428,7 +23428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23448,7 +23448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23470,7 +23470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23491,7 +23491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23512,7 +23512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23592,7 +23592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23630,7 +23630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23651,7 +23651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23731,7 +23731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23769,7 +23769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -23817,7 +23817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23850,7 +23850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23970,7 +23970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23985,7 +23985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24000,7 +24000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24057,7 +24057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24108,7 +24108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24159,7 +24159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24210,7 +24210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24242,7 +24242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24256,7 +24256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24276,7 +24276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24454,7 +24454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24487,7 +24487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24502,7 +24502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24530,7 +24530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24570,7 +24570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24605,7 +24605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24666,7 +24666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24725,7 +24725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24754,7 +24754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24804,7 +24804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24838,7 +24838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24911,7 +24911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25125,7 +25125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25157,7 +25157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25195,7 +25195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25245,7 +25245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25277,7 +25277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25400,7 +25400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25445,7 +25445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25490,7 +25490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25535,7 +25535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25580,7 +25580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25632,7 +25632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25676,7 +25676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25690,7 +25690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25705,7 +25705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25745,7 +25745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25784,7 +25784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25876,7 +25876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25897,7 +25897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25947,7 +25947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26004,7 +26004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26055,7 +26055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26106,7 +26106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26159,7 +26159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26192,12 +26192,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -26289,7 +26289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26317,7 +26317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26357,7 +26357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -26396,7 +26396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -26410,7 +26410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26568,7 +26568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26670,7 +26670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26817,7 +26817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26925,7 +26925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26940,7 +26940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26955,7 +26955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26970,7 +26970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26984,7 +26984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26998,7 +26998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27012,7 +27012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27081,7 +27081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27138,7 +27138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27195,7 +27195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27252,7 +27252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27280,7 +27280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27311,7 +27311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -27320,7 +27320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27381,7 +27381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27467,7 +27467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27571,7 +27571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27781,7 +27781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28321,7 +28321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28766,6 +28766,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -28800,7 +28828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28827,7 +28855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29070,9 +29098,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -29506,7 +29534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29526,7 +29554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29541,7 +29569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -29556,7 +29584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -29570,7 +29598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -29584,7 +29612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -29598,7 +29626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -29673,7 +29701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -29730,7 +29758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -29787,7 +29815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -29844,7 +29872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -29897,7 +29925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29912,7 +29940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -30070,7 +30098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -30103,7 +30131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -30136,7 +30164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -30169,7 +30197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -30208,7 +30236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -30228,7 +30256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30323,7 +30351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30352,7 +30380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30367,7 +30395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30382,7 +30410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30397,7 +30425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30412,7 +30440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30446,7 +30474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30587,7 +30615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30636,7 +30664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30704,7 +30732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30718,7 +30746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30750,7 +30778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30873,7 +30901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30978,7 +31006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31083,7 +31111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31188,7 +31216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31203,7 +31231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31218,7 +31246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31250,7 +31278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31282,7 +31310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31314,7 +31342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31342,7 +31370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31398,7 +31426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -31455,7 +31483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -31564,7 +31592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -31615,7 +31643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -31666,7 +31694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -31717,7 +31745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -31768,7 +31796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -31783,7 +31811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -31798,7 +31826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -31812,7 +31840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -31857,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -32683,6 +32711,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -32733,7 +32779,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -32774,80 +32866,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -32945,12 +32963,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -32960,6 +32972,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -32995,46 +33019,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -33063,6 +33047,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33116,7 +33118,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -33163,134 +33211,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33382,30 +33302,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -33415,6 +33311,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33450,64 +33358,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -33536,6 +33386,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33589,7 +33457,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -33636,134 +33550,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33855,30 +33641,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -33888,6 +33650,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33923,64 +33697,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -34009,6 +33725,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34086,7 +33820,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -34133,140 +33919,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34364,30 +34016,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -34397,6 +34025,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34427,64 +34067,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -35175,7 +34757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -35266,7 +34848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -35419,7 +35001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -35470,7 +35052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -35563,7 +35145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -35716,7 +35298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -35869,7 +35451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36022,7 +35604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36150,7 +35732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36179,7 +35761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -36351,7 +35933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -36516,9 +36098,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -36682,9 +36264,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -36848,9 +36430,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37014,7 +36596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -37073,9 +36655,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37133,9 +36715,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37193,9 +36775,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37253,7 +36835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -37318,9 +36900,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37384,9 +36966,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37450,9 +37032,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -37516,7 +37098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -37617,9 +37199,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37725,9 +37307,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37827,9 +37409,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37929,7 +37511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -38030,9 +37612,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38138,9 +37720,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38240,9 +37822,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38342,7 +37924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -38431,9 +38013,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38521,9 +38103,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38611,9 +38193,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38705,7 +38287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -38719,7 +38301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38733,7 +38315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -38795,7 +38377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -38840,7 +38422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -38895,7 +38477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -39004,43 +38586,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39048,7 +38630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -39099,7 +38681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -39148,43 +38730,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39192,7 +38774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -39301,43 +38883,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39345,7 +38927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -39454,43 +39036,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39498,7 +39080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -39607,43 +39189,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -39651,7 +39233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -39767,7 +39349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -39793,7 +39375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -39825,7 +39407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -39857,7 +39439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -39879,7 +39461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -40039,9 +39621,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -40206,7 +39788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -40355,9 +39937,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -40505,9 +40087,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -40655,9 +40237,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -40805,7 +40387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -40858,9 +40440,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40912,9 +40494,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40966,9 +40548,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41020,7 +40602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -41085,9 +40667,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41151,9 +40733,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41217,9 +40799,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41283,7 +40865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -41372,9 +40954,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41462,9 +41044,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41552,9 +41134,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41642,7 +41224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -41725,9 +41307,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41809,9 +41391,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41893,9 +41475,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41977,7 +41559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -42060,9 +41642,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42144,9 +41726,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42228,9 +41810,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42312,7 +41894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -42334,7 +41916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -42384,7 +41966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42398,7 +41980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42412,7 +41994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42474,7 +42056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42519,7 +42101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -42576,7 +42158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -42621,7 +42203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -42636,7 +42218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -42672,7 +42254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -42703,7 +42285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -42749,7 +42331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42778,7 +42360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42828,7 +42410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42868,7 +42450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42895,7 +42477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42933,7 +42515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42965,7 +42547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -43118,7 +42700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43271,7 +42853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -43424,7 +43006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -43577,7 +43159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -43730,7 +43312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -43883,7 +43465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -44036,7 +43618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -44188,7 +43770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -44340,7 +43922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -44493,7 +44075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -44646,7 +44228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -44799,7 +44381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -44952,7 +44534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -45111,7 +44693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45162,7 +44744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45213,7 +44795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45264,7 +44846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45315,7 +44897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -45329,7 +44911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -45343,7 +44925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -45363,7 +44945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -45457,7 +45039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -45471,7 +45053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -45485,7 +45067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -46048,7 +45630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -46068,7 +45650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -46082,7 +45664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -46110,7 +45692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -46310,7 +45892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -46510,7 +46092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -46710,7 +46292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>
@@ -48599,6 +48181,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMS70Q19.svd
+++ b/data/Atmel/ATSAMS70Q19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4177,7 +4177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4216,7 +4216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4266,7 +4266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4375,7 +4375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4389,7 +4389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4646,7 +4646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4666,7 +4666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4776,7 +4776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4929,7 +4929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5082,7 +5082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5235,7 +5235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5468,7 +5468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5496,7 +5496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5519,7 +5519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5552,7 +5552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5626,7 +5626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5671,7 +5671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5698,7 +5698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5749,7 +5749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5800,7 +5800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5902,7 +5902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5945,7 +5945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5959,7 +5959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5975,7 +5975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6009,7 +6009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6107,7 +6107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6215,7 +6215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6249,7 +6249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6281,7 +6281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6345,7 +6345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6377,7 +6377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6409,7 +6409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6442,7 +6442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6523,7 +6523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6586,7 +6586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6649,7 +6649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6712,7 +6712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6733,7 +6733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6754,7 +6754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6775,7 +6775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6789,7 +6789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6835,7 +6835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6849,7 +6849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6881,7 +6881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6961,7 +6961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7020,7 +7020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7070,7 +7070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7120,7 +7120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7135,7 +7135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7267,7 +7267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7295,7 +7295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7335,7 +7335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7536,7 +7536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -7737,7 +7737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8139,7 +8139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8340,7 +8340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -8541,7 +8541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -8742,7 +8742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -8943,7 +8943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9144,7 +9144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9345,7 +9345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -9546,7 +9546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -9746,7 +9746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -9947,7 +9947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10148,7 +10148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10349,7 +10349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -10550,7 +10550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -10751,7 +10751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11153,7 +11153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11354,7 +11354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -11555,7 +11555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -11756,7 +11756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -11959,7 +11959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12159,7 +12159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12360,7 +12360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -12561,7 +12561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -12762,7 +12762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -12776,7 +12776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -12977,7 +12977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13178,7 +13178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13379,7 +13379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -13580,7 +13580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -13781,7 +13781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -13982,7 +13982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14183,7 +14183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14384,7 +14384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -14585,7 +14585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -14786,7 +14786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -14987,7 +14987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15188,7 +15188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15389,7 +15389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -15590,7 +15590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -15791,7 +15791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -15992,7 +15992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16020,7 +16020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16041,7 +16041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16241,7 +16241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -16857,7 +16857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -16913,7 +16913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -16946,7 +16946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -16979,7 +16979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17012,7 +17012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17033,7 +17033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17099,7 +17099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17156,7 +17156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17213,7 +17213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17276,7 +17276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17435,7 +17435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17594,7 +17594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -17944,7 +17944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18065,7 +18065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18087,7 +18087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18135,7 +18135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18234,7 +18234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18333,7 +18333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -18450,7 +18450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -18549,7 +18549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -18707,7 +18707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -18811,7 +18811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -18826,7 +18826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -18854,7 +18854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -18875,7 +18875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19034,7 +19034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19193,7 +19193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19352,7 +19352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19424,7 +19424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -19468,7 +19468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -19627,7 +19627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -19786,7 +19786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -19945,7 +19945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20104,7 +20104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20118,7 +20118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20277,7 +20277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20436,7 +20436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -20595,7 +20595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -20754,7 +20754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -20788,7 +20788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -20962,7 +20962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -20995,7 +20995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21028,7 +21028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21061,7 +21061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21118,7 +21118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21175,7 +21175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21232,7 +21232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21289,7 +21289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21357,7 +21357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21372,7 +21372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21386,7 +21386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21406,7 +21406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21421,7 +21421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -21538,7 +21538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -21655,7 +21655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -21772,7 +21772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -21889,7 +21889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -21945,7 +21945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -22001,7 +22001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22058,7 +22058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22115,7 +22115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22172,7 +22172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22229,7 +22229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22255,7 +22255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22276,7 +22276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22291,7 +22291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22347,7 +22347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22381,7 +22381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22437,7 +22437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22457,7 +22457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22472,7 +22472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22504,7 +22504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -22560,7 +22560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22643,7 +22643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22742,7 +22742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -22762,7 +22762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -22783,7 +22783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -22827,7 +22827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -22867,7 +22867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23009,7 +23009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23023,7 +23023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23038,7 +23038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23052,7 +23052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23082,7 +23082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23102,7 +23102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23124,7 +23124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23145,7 +23145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23166,7 +23166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23246,7 +23246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23284,7 +23284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23305,7 +23305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23385,7 +23385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23423,7 +23423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -23471,7 +23471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23504,7 +23504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23624,7 +23624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23639,7 +23639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23654,7 +23654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23711,7 +23711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23762,7 +23762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23813,7 +23813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23864,7 +23864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23896,7 +23896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -23910,7 +23910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -23930,7 +23930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24108,7 +24108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24141,7 +24141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24156,7 +24156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24184,7 +24184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24224,7 +24224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24259,7 +24259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24320,7 +24320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24379,7 +24379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24408,7 +24408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24458,7 +24458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24492,7 +24492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24565,7 +24565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24779,7 +24779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24811,7 +24811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24849,7 +24849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24899,7 +24899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24931,7 +24931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25054,7 +25054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25099,7 +25099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25144,7 +25144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25189,7 +25189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25234,7 +25234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25286,7 +25286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25330,7 +25330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25344,7 +25344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25359,7 +25359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25399,7 +25399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25451,7 +25451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25465,7 +25465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25611,7 +25611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25690,7 +25690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25705,7 +25705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25720,7 +25720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25735,7 +25735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25750,7 +25750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25777,7 +25777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25810,7 +25810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25824,7 +25824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -25839,7 +25839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -25875,7 +25875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -25907,7 +25907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -25939,7 +25939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -25959,7 +25959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC MODE Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26089,7 +26089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC OCMS MODE Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -26127,7 +26127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC OCMS KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -26142,7 +26142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC OCMS KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -26157,7 +26157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26185,7 +26185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26225,7 +26225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26288,7 +26288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26344,7 +26344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26392,7 +26392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26449,7 +26449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26500,7 +26500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26551,7 +26551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26604,7 +26604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26708,7 +26708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26736,7 +26736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26784,7 +26784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -26823,7 +26823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -26837,7 +26837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26995,7 +26995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27097,7 +27097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27244,7 +27244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27352,7 +27352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27367,7 +27367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -27382,7 +27382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27397,7 +27397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -27411,7 +27411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27425,7 +27425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27439,7 +27439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27508,7 +27508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27565,7 +27565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27622,7 +27622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27679,7 +27679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27707,7 +27707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27747,7 +27747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27808,7 +27808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27894,7 +27894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27998,7 +27998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28208,7 +28208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28748,7 +28748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29227,7 +29227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29254,7 +29254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29497,7 +29497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29517,7 +29517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29532,7 +29532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -29547,7 +29547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -29561,7 +29561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -29575,7 +29575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -29589,7 +29589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -29664,7 +29664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -29721,7 +29721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -29778,7 +29778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -29835,7 +29835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -29888,7 +29888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29903,7 +29903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -30049,7 +30049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -30076,7 +30076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -30103,7 +30103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -30130,7 +30130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -30163,7 +30163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -30183,7 +30183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30278,7 +30278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30307,7 +30307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30322,7 +30322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30337,7 +30337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30352,7 +30352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30367,7 +30367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30401,7 +30401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30542,7 +30542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30591,7 +30591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30659,7 +30659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30673,7 +30673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30705,7 +30705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30828,7 +30828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30933,7 +30933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31038,7 +31038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31143,7 +31143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31158,7 +31158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31173,7 +31173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31205,7 +31205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31237,7 +31237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31269,7 +31269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31297,7 +31297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31353,7 +31353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -31410,7 +31410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -31519,7 +31519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -31570,7 +31570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -31621,7 +31621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -31672,7 +31672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -31723,7 +31723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -31738,7 +31738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -31753,7 +31753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -31767,7 +31767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -31812,7 +31812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -33395,7 +33395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -33476,7 +33476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -33641,7 +33641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -33692,7 +33692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -33785,7 +33785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33950,7 +33950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -34115,7 +34115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -34280,7 +34280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -34408,7 +34408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -34437,7 +34437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -34609,7 +34609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -34774,7 +34774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -34833,7 +34833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -34898,7 +34898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -34999,7 +34999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -35100,7 +35100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -35193,7 +35193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -35207,7 +35207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -35221,7 +35221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35283,7 +35283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35328,7 +35328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -35373,7 +35373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -35538,7 +35538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -35589,7 +35589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -35682,7 +35682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -35847,7 +35847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -36012,7 +36012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -36177,7 +36177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -36293,7 +36293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -36319,7 +36319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -36351,7 +36351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -36383,7 +36383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -36405,7 +36405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -36565,7 +36565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -36714,7 +36714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -36767,7 +36767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -36832,7 +36832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -36921,7 +36921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -37004,7 +37004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -37087,7 +37087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -37109,7 +37109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -37159,7 +37159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37173,7 +37173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37187,7 +37187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37249,7 +37249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37294,7 +37294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -37345,7 +37345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -37390,7 +37390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -37405,7 +37405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -37441,7 +37441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37472,7 +37472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -37518,7 +37518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37547,7 +37547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37597,7 +37597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -37637,7 +37637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37664,7 +37664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37702,7 +37702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -37734,7 +37734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37887,7 +37887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38040,7 +38040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38193,7 +38193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38346,7 +38346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38499,7 +38499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38652,7 +38652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38805,7 +38805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38957,7 +38957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39109,7 +39109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39262,7 +39262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39415,7 +39415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39568,7 +39568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -39721,7 +39721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -39880,7 +39880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39931,7 +39931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39982,7 +39982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40033,7 +40033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40084,7 +40084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -40098,7 +40098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -40112,7 +40112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -40132,7 +40132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -40226,7 +40226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -40240,7 +40240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -40254,7 +40254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -40584,7 +40584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -40604,7 +40604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -40618,7 +40618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -40646,7 +40646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMS70Q19B.svd
+++ b/data/Atmel/ATSAMS70Q19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6087,7 +6087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6206,7 +6206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6233,7 +6233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6284,7 +6284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6335,7 +6335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6386,7 +6386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6437,7 +6437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6480,7 +6480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6494,7 +6494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6510,7 +6510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6544,7 +6544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6642,7 +6642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6750,7 +6750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6770,7 +6770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6784,7 +6784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6816,7 +6816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6880,7 +6880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6912,7 +6912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6944,7 +6944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6977,7 +6977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7058,7 +7058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7121,7 +7121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7184,7 +7184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7247,7 +7247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7268,7 +7268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7310,7 +7310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7324,7 +7324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7356,7 +7356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7384,7 +7384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7416,7 +7416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7430,7 +7430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7458,7 +7458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7496,7 +7496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7555,7 +7555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7605,7 +7605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7655,7 +7655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7676,7 +7676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7866,7 +7866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7894,7 +7894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7934,7 +7934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -8336,7 +8336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -8537,7 +8537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8738,7 +8738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8939,7 +8939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -9140,7 +9140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -9341,7 +9341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -9542,7 +9542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9743,7 +9743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9944,7 +9944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -10145,7 +10145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -10345,7 +10345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -10546,7 +10546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10747,7 +10747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10948,7 +10948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -11149,7 +11149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -11350,7 +11350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -11551,7 +11551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11752,7 +11752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11953,7 +11953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -12154,7 +12154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -12355,7 +12355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -12558,7 +12558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12758,7 +12758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12959,7 +12959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -13160,7 +13160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -13361,7 +13361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -13375,7 +13375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -13576,7 +13576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13777,7 +13777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13978,7 +13978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -14179,7 +14179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -14380,7 +14380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -14581,7 +14581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14782,7 +14782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14983,7 +14983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -15184,7 +15184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -15385,7 +15385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -15586,7 +15586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15787,7 +15787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15988,7 +15988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -16189,7 +16189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -16390,7 +16390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -16591,7 +16591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16619,7 +16619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16640,7 +16640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16840,7 +16840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -17456,7 +17456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -17512,7 +17512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -17545,7 +17545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -17578,7 +17578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17611,7 +17611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17632,7 +17632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17698,7 +17698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17761,7 +17761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17824,7 +17824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17893,7 +17893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -18052,7 +18052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -18211,7 +18211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18561,7 +18561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18682,7 +18682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18704,7 +18704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18752,7 +18752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18857,7 +18857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18962,7 +18962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19085,7 +19085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -19190,7 +19190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -19348,7 +19348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -19452,7 +19452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -19467,7 +19467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19495,7 +19495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19516,7 +19516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19651,7 +19651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19786,7 +19786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19921,7 +19921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19993,7 +19993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -20037,7 +20037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -20196,7 +20196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20355,7 +20355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -20514,7 +20514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20673,7 +20673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20687,7 +20687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20822,7 +20822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20957,7 +20957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -21092,7 +21092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -21227,7 +21227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -21261,7 +21261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -21435,7 +21435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -21468,7 +21468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21501,7 +21501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21534,7 +21534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21591,7 +21591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21648,7 +21648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21705,7 +21705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21762,7 +21762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21830,7 +21830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21845,7 +21845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21859,7 +21859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21879,7 +21879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21894,7 +21894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -22011,7 +22011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -22128,7 +22128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -22245,7 +22245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22362,7 +22362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22418,7 +22418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -22474,7 +22474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22531,7 +22531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22588,7 +22588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22645,7 +22645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22702,7 +22702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22728,7 +22728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22749,7 +22749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22764,7 +22764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22820,7 +22820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22854,7 +22854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22910,7 +22910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22930,7 +22930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22945,7 +22945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22977,7 +22977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -23033,7 +23033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -23116,7 +23116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -23215,7 +23215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23248,7 +23248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23269,7 +23269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23313,7 +23313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23353,7 +23353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23547,7 +23547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23561,7 +23561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23576,7 +23576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23590,7 +23590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23605,7 +23605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23620,7 +23620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23640,7 +23640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23662,7 +23662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23683,7 +23683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23704,7 +23704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23784,7 +23784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23822,7 +23822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23843,7 +23843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23923,7 +23923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23961,7 +23961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -24009,7 +24009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24042,7 +24042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24162,7 +24162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24177,7 +24177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24192,7 +24192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24249,7 +24249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24300,7 +24300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24351,7 +24351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24402,7 +24402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24434,7 +24434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24448,7 +24448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24468,7 +24468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24646,7 +24646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24679,7 +24679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24694,7 +24694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24722,7 +24722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24762,7 +24762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24797,7 +24797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24858,7 +24858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24917,7 +24917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24946,7 +24946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24996,7 +24996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25030,7 +25030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25103,7 +25103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25317,7 +25317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25349,7 +25349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25387,7 +25387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25437,7 +25437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25469,7 +25469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25592,7 +25592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25637,7 +25637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25682,7 +25682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25727,7 +25727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25772,7 +25772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25824,7 +25824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25868,7 +25868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25882,7 +25882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25897,7 +25897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25937,7 +25937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25989,7 +25989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26003,7 +26003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26149,7 +26149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26228,7 +26228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26243,7 +26243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26258,7 +26258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26273,7 +26273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26288,7 +26288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26315,7 +26315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26348,7 +26348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26362,7 +26362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26377,7 +26377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26413,7 +26413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26445,7 +26445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26477,7 +26477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26497,7 +26497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26627,7 +26627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -26665,7 +26665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -26680,7 +26680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -26695,7 +26695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26723,7 +26723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26763,7 +26763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26802,7 +26802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26894,7 +26894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26915,7 +26915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26965,7 +26965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27022,7 +27022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27073,7 +27073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27124,7 +27124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27177,7 +27177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27210,12 +27210,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -27307,7 +27307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27335,7 +27335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27383,7 +27383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -27422,7 +27422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -27436,7 +27436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27594,7 +27594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27696,7 +27696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27843,7 +27843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27951,7 +27951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27966,7 +27966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -27981,7 +27981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27996,7 +27996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28010,7 +28010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28024,7 +28024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -28038,7 +28038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28107,7 +28107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28164,7 +28164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -28221,7 +28221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28278,7 +28278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28306,7 +28306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28337,7 +28337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -28346,7 +28346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28407,7 +28407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28493,7 +28493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28597,7 +28597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28807,7 +28807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29347,7 +29347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29792,6 +29792,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -29826,7 +29854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29853,7 +29881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30096,9 +30124,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -30532,7 +30560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30552,7 +30580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30567,7 +30595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30582,7 +30610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30596,7 +30624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30610,7 +30638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30624,7 +30652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -30699,7 +30727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -30756,7 +30784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -30813,7 +30841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -30870,7 +30898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -30923,7 +30951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30938,7 +30966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -31096,7 +31124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -31129,7 +31157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -31162,7 +31190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -31195,7 +31223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -31234,7 +31262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -31254,7 +31282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31349,7 +31377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31378,7 +31406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31393,7 +31421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31408,7 +31436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31423,7 +31451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31438,7 +31466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31472,7 +31500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31613,7 +31641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31662,7 +31690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31730,7 +31758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31744,7 +31772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31776,7 +31804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31899,7 +31927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32004,7 +32032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -32109,7 +32137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -32214,7 +32242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32229,7 +32257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32244,7 +32272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32276,7 +32304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32308,7 +32336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32340,7 +32368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32368,7 +32396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32424,7 +32452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -32481,7 +32509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -32590,7 +32618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -32641,7 +32669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -32692,7 +32720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -32743,7 +32771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -32794,7 +32822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -32809,7 +32837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -32824,7 +32852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -32838,7 +32866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -32883,7 +32911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -33709,6 +33737,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -33759,7 +33805,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -33800,80 +33892,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33971,12 +33989,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -33986,6 +33998,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34021,46 +34045,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -34089,6 +34073,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34142,7 +34144,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -34189,134 +34237,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34408,30 +34328,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -34441,6 +34337,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34476,64 +34384,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -34562,6 +34412,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34615,7 +34483,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -34662,134 +34576,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34881,30 +34667,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -34914,6 +34676,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34949,64 +34723,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -35035,6 +34751,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35112,7 +34846,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -35159,140 +34945,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35390,30 +35042,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -35423,6 +35051,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35453,64 +35093,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -36201,7 +35783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36292,7 +35874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36445,7 +36027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36496,7 +36078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36589,7 +36171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36742,7 +36324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36895,7 +36477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37048,7 +36630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37176,7 +36758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37205,7 +36787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -37377,7 +36959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -37542,9 +37124,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37708,9 +37290,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37874,9 +37456,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38040,7 +37622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -38099,9 +37681,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38159,9 +37741,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38219,9 +37801,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38279,7 +37861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -38344,9 +37926,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38410,9 +37992,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38476,9 +38058,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38542,7 +38124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -38643,9 +38225,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38751,9 +38333,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38853,9 +38435,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38955,7 +38537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -39056,9 +38638,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39164,9 +38746,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39266,9 +38848,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39368,7 +38950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -39457,9 +39039,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39547,9 +39129,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39637,9 +39219,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39731,7 +39313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39745,7 +39327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39759,7 +39341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39821,7 +39403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39866,7 +39448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -39921,7 +39503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -40030,43 +39612,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40074,7 +39656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -40125,7 +39707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -40174,43 +39756,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40218,7 +39800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -40327,43 +39909,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40371,7 +39953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -40480,43 +40062,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40524,7 +40106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -40633,43 +40215,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40677,7 +40259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -40793,7 +40375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -40819,7 +40401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -40851,7 +40433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -40883,7 +40465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -40905,7 +40487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -41065,9 +40647,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -41232,7 +40814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -41381,9 +40963,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41531,9 +41113,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41681,9 +41263,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41831,7 +41413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -41884,9 +41466,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41938,9 +41520,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41992,9 +41574,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42046,7 +41628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -42111,9 +41693,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42177,9 +41759,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42243,9 +41825,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42309,7 +41891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -42398,9 +41980,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42488,9 +42070,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42578,9 +42160,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42668,7 +42250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -42751,9 +42333,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42835,9 +42417,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42919,9 +42501,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43003,7 +42585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -43086,9 +42668,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43170,9 +42752,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43254,9 +42836,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43338,7 +42920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -43360,7 +42942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -43410,7 +42992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43424,7 +43006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43438,7 +43020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43500,7 +43082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43545,7 +43127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -43602,7 +43184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -43647,7 +43229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -43662,7 +43244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -43698,7 +43280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43729,7 +43311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43775,7 +43357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43804,7 +43386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43854,7 +43436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43894,7 +43476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43921,7 +43503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43959,7 +43541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43991,7 +43573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -44144,7 +43726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -44297,7 +43879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -44450,7 +44032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -44603,7 +44185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -44756,7 +44338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -44909,7 +44491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -45062,7 +44644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -45214,7 +44796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -45366,7 +44948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45519,7 +45101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -45672,7 +45254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -45825,7 +45407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -45978,7 +45560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -46137,7 +45719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46188,7 +45770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46239,7 +45821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46290,7 +45872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46341,7 +45923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -46355,7 +45937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -46369,7 +45951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -46389,7 +45971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -46483,7 +46065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -46497,7 +46079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -46511,7 +46093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -47104,7 +46686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -47124,7 +46706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -47138,7 +46720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -47166,7 +46748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -49055,6 +48637,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMS70Q20.svd
+++ b/data/Atmel/ATSAMS70Q20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4177,7 +4177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4216,7 +4216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4266,7 +4266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4375,7 +4375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4389,7 +4389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4646,7 +4646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4666,7 +4666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4776,7 +4776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4929,7 +4929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5082,7 +5082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5235,7 +5235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5468,7 +5468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5496,7 +5496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5519,7 +5519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5552,7 +5552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5626,7 +5626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5671,7 +5671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5698,7 +5698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5749,7 +5749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5800,7 +5800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5902,7 +5902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5945,7 +5945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5959,7 +5959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5975,7 +5975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6009,7 +6009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6107,7 +6107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6215,7 +6215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6249,7 +6249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6281,7 +6281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6345,7 +6345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6377,7 +6377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6409,7 +6409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6442,7 +6442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6523,7 +6523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6586,7 +6586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6649,7 +6649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6712,7 +6712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6733,7 +6733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6754,7 +6754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6775,7 +6775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6789,7 +6789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6835,7 +6835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6849,7 +6849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6881,7 +6881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6961,7 +6961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7020,7 +7020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7070,7 +7070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7120,7 +7120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7135,7 +7135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7267,7 +7267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7295,7 +7295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7335,7 +7335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7536,7 +7536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -7737,7 +7737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8139,7 +8139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8340,7 +8340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -8541,7 +8541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -8742,7 +8742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -8943,7 +8943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9144,7 +9144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9345,7 +9345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -9546,7 +9546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -9746,7 +9746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -9947,7 +9947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10148,7 +10148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10349,7 +10349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -10550,7 +10550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -10751,7 +10751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11153,7 +11153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11354,7 +11354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -11555,7 +11555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -11756,7 +11756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -11959,7 +11959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12159,7 +12159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12360,7 +12360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -12561,7 +12561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -12762,7 +12762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -12776,7 +12776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -12977,7 +12977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13178,7 +13178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13379,7 +13379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -13580,7 +13580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -13781,7 +13781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -13982,7 +13982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14183,7 +14183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14384,7 +14384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -14585,7 +14585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -14786,7 +14786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -14987,7 +14987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15188,7 +15188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15389,7 +15389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -15590,7 +15590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -15791,7 +15791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -15992,7 +15992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16020,7 +16020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16041,7 +16041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16241,7 +16241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -16857,7 +16857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -16913,7 +16913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -16946,7 +16946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -16979,7 +16979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17012,7 +17012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17033,7 +17033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17099,7 +17099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17156,7 +17156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17213,7 +17213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17276,7 +17276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17435,7 +17435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17594,7 +17594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -17944,7 +17944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18065,7 +18065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18087,7 +18087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18135,7 +18135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18234,7 +18234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18333,7 +18333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -18450,7 +18450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -18549,7 +18549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -18707,7 +18707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -18811,7 +18811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -18826,7 +18826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -18854,7 +18854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -18875,7 +18875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19034,7 +19034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19193,7 +19193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19352,7 +19352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19424,7 +19424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -19468,7 +19468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -19627,7 +19627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -19786,7 +19786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -19945,7 +19945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20104,7 +20104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20118,7 +20118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20277,7 +20277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20436,7 +20436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -20595,7 +20595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -20754,7 +20754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -20788,7 +20788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -20962,7 +20962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -20995,7 +20995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21028,7 +21028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21061,7 +21061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21118,7 +21118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21175,7 +21175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21232,7 +21232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21289,7 +21289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21357,7 +21357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21372,7 +21372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21386,7 +21386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21406,7 +21406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21421,7 +21421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -21538,7 +21538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -21655,7 +21655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -21772,7 +21772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -21889,7 +21889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -21945,7 +21945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -22001,7 +22001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22058,7 +22058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22115,7 +22115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22172,7 +22172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22229,7 +22229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22255,7 +22255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22276,7 +22276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22291,7 +22291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22347,7 +22347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22381,7 +22381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22437,7 +22437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22457,7 +22457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22472,7 +22472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22504,7 +22504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -22560,7 +22560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22643,7 +22643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22742,7 +22742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -22762,7 +22762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -22783,7 +22783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -22827,7 +22827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -22867,7 +22867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23009,7 +23009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23023,7 +23023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23038,7 +23038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23052,7 +23052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23082,7 +23082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23102,7 +23102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23124,7 +23124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23145,7 +23145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23166,7 +23166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23246,7 +23246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23284,7 +23284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23305,7 +23305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23385,7 +23385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23423,7 +23423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -23471,7 +23471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23504,7 +23504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23624,7 +23624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23639,7 +23639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23654,7 +23654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23711,7 +23711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23762,7 +23762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23813,7 +23813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23864,7 +23864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23896,7 +23896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -23910,7 +23910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -23930,7 +23930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24108,7 +24108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24141,7 +24141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24156,7 +24156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24184,7 +24184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24224,7 +24224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24259,7 +24259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24320,7 +24320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24379,7 +24379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24408,7 +24408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24458,7 +24458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24492,7 +24492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24565,7 +24565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24779,7 +24779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24811,7 +24811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24849,7 +24849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24899,7 +24899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24931,7 +24931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25054,7 +25054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25099,7 +25099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25144,7 +25144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25189,7 +25189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25234,7 +25234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25286,7 +25286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25330,7 +25330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25344,7 +25344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25359,7 +25359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25399,7 +25399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25451,7 +25451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25465,7 +25465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25611,7 +25611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25690,7 +25690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25705,7 +25705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25720,7 +25720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25735,7 +25735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25750,7 +25750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25777,7 +25777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25810,7 +25810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25824,7 +25824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -25839,7 +25839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -25875,7 +25875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -25907,7 +25907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -25939,7 +25939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -25959,7 +25959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC MODE Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26089,7 +26089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC OCMS MODE Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -26127,7 +26127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC OCMS KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -26142,7 +26142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC OCMS KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -26157,7 +26157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26185,7 +26185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26225,7 +26225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26288,7 +26288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26344,7 +26344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26392,7 +26392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26449,7 +26449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26500,7 +26500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26551,7 +26551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26604,7 +26604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26708,7 +26708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26736,7 +26736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26784,7 +26784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -26823,7 +26823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -26837,7 +26837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26995,7 +26995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27097,7 +27097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27244,7 +27244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27352,7 +27352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27367,7 +27367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -27382,7 +27382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27397,7 +27397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -27411,7 +27411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27425,7 +27425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27439,7 +27439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27508,7 +27508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27565,7 +27565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27622,7 +27622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27679,7 +27679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27707,7 +27707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27747,7 +27747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27808,7 +27808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27894,7 +27894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27998,7 +27998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28208,7 +28208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28748,7 +28748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29227,7 +29227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29254,7 +29254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29497,7 +29497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29517,7 +29517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29532,7 +29532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -29547,7 +29547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -29561,7 +29561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -29575,7 +29575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -29589,7 +29589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -29664,7 +29664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -29721,7 +29721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -29778,7 +29778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -29835,7 +29835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -29888,7 +29888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29903,7 +29903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -30049,7 +30049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -30076,7 +30076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -30103,7 +30103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -30130,7 +30130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -30163,7 +30163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -30183,7 +30183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30278,7 +30278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30307,7 +30307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30322,7 +30322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30337,7 +30337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30352,7 +30352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30367,7 +30367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30401,7 +30401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30542,7 +30542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30591,7 +30591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30659,7 +30659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30673,7 +30673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30705,7 +30705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30828,7 +30828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30933,7 +30933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31038,7 +31038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31143,7 +31143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31158,7 +31158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31173,7 +31173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31205,7 +31205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31237,7 +31237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31269,7 +31269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31297,7 +31297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31353,7 +31353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -31410,7 +31410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -31519,7 +31519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -31570,7 +31570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -31621,7 +31621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -31672,7 +31672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -31723,7 +31723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -31738,7 +31738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -31753,7 +31753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -31767,7 +31767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -31812,7 +31812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -33395,7 +33395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -33476,7 +33476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -33641,7 +33641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -33692,7 +33692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -33785,7 +33785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33950,7 +33950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -34115,7 +34115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -34280,7 +34280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -34408,7 +34408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -34437,7 +34437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -34609,7 +34609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -34774,7 +34774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -34833,7 +34833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -34898,7 +34898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -34999,7 +34999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -35100,7 +35100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -35193,7 +35193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -35207,7 +35207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -35221,7 +35221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35283,7 +35283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35328,7 +35328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -35373,7 +35373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -35538,7 +35538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -35589,7 +35589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -35682,7 +35682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -35847,7 +35847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -36012,7 +36012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -36177,7 +36177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -36293,7 +36293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -36319,7 +36319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -36351,7 +36351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -36383,7 +36383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -36405,7 +36405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -36565,7 +36565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -36714,7 +36714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -36767,7 +36767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -36832,7 +36832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -36921,7 +36921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -37004,7 +37004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -37087,7 +37087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -37109,7 +37109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -37159,7 +37159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37173,7 +37173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37187,7 +37187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37249,7 +37249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37294,7 +37294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -37345,7 +37345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -37390,7 +37390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -37405,7 +37405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -37441,7 +37441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37472,7 +37472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -37518,7 +37518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37547,7 +37547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37597,7 +37597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -37637,7 +37637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37664,7 +37664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37702,7 +37702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -37734,7 +37734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37887,7 +37887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38040,7 +38040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38193,7 +38193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38346,7 +38346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38499,7 +38499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38652,7 +38652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38805,7 +38805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38957,7 +38957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39109,7 +39109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39262,7 +39262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39415,7 +39415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39568,7 +39568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -39721,7 +39721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -39880,7 +39880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39931,7 +39931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39982,7 +39982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40033,7 +40033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40084,7 +40084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -40098,7 +40098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -40112,7 +40112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -40132,7 +40132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -40226,7 +40226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -40240,7 +40240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -40254,7 +40254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -40584,7 +40584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -40604,7 +40604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -40618,7 +40618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -40646,7 +40646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -40846,7 +40846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMS70Q20B.svd
+++ b/data/Atmel/ATSAMS70Q20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6087,7 +6087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6206,7 +6206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6233,7 +6233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6284,7 +6284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6335,7 +6335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6386,7 +6386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6437,7 +6437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6480,7 +6480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6494,7 +6494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6510,7 +6510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6544,7 +6544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6642,7 +6642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6750,7 +6750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6770,7 +6770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6784,7 +6784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6816,7 +6816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6880,7 +6880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6912,7 +6912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6944,7 +6944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6977,7 +6977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7058,7 +7058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7121,7 +7121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7184,7 +7184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7247,7 +7247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7268,7 +7268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7310,7 +7310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7324,7 +7324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7356,7 +7356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7384,7 +7384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7416,7 +7416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7430,7 +7430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7458,7 +7458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7496,7 +7496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7555,7 +7555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7605,7 +7605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7655,7 +7655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7676,7 +7676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7866,7 +7866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7894,7 +7894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7934,7 +7934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -8336,7 +8336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -8537,7 +8537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8738,7 +8738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8939,7 +8939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -9140,7 +9140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -9341,7 +9341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -9542,7 +9542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9743,7 +9743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9944,7 +9944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -10145,7 +10145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -10345,7 +10345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -10546,7 +10546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10747,7 +10747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10948,7 +10948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -11149,7 +11149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -11350,7 +11350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -11551,7 +11551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11752,7 +11752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11953,7 +11953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -12154,7 +12154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -12355,7 +12355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -12558,7 +12558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12758,7 +12758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12959,7 +12959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -13160,7 +13160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -13361,7 +13361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -13375,7 +13375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -13576,7 +13576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13777,7 +13777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13978,7 +13978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -14179,7 +14179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -14380,7 +14380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -14581,7 +14581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14782,7 +14782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14983,7 +14983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -15184,7 +15184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -15385,7 +15385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -15586,7 +15586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15787,7 +15787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15988,7 +15988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -16189,7 +16189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -16390,7 +16390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -16591,7 +16591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16619,7 +16619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16640,7 +16640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16840,7 +16840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -17456,7 +17456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -17512,7 +17512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -17545,7 +17545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -17578,7 +17578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17611,7 +17611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17632,7 +17632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17698,7 +17698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17761,7 +17761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17824,7 +17824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17893,7 +17893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -18052,7 +18052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -18211,7 +18211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18561,7 +18561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18682,7 +18682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18704,7 +18704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18752,7 +18752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18857,7 +18857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18962,7 +18962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19085,7 +19085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -19190,7 +19190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -19348,7 +19348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -19452,7 +19452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -19467,7 +19467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19495,7 +19495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19516,7 +19516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19651,7 +19651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19786,7 +19786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19921,7 +19921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19993,7 +19993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -20037,7 +20037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -20196,7 +20196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20355,7 +20355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -20514,7 +20514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20673,7 +20673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20687,7 +20687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20822,7 +20822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20957,7 +20957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -21092,7 +21092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -21227,7 +21227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -21261,7 +21261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -21435,7 +21435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -21468,7 +21468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21501,7 +21501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21534,7 +21534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21591,7 +21591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21648,7 +21648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21705,7 +21705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21762,7 +21762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21830,7 +21830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21845,7 +21845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21859,7 +21859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21879,7 +21879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21894,7 +21894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -22011,7 +22011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -22128,7 +22128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -22245,7 +22245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22362,7 +22362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22418,7 +22418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -22474,7 +22474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22531,7 +22531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22588,7 +22588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22645,7 +22645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22702,7 +22702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22728,7 +22728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22749,7 +22749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22764,7 +22764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22820,7 +22820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22854,7 +22854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22910,7 +22910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22930,7 +22930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22945,7 +22945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22977,7 +22977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -23033,7 +23033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -23116,7 +23116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -23215,7 +23215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23248,7 +23248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23269,7 +23269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23313,7 +23313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23353,7 +23353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23547,7 +23547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23561,7 +23561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23576,7 +23576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23590,7 +23590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23605,7 +23605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23620,7 +23620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23640,7 +23640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23662,7 +23662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23683,7 +23683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23704,7 +23704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23784,7 +23784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23822,7 +23822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23843,7 +23843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23923,7 +23923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23961,7 +23961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -24009,7 +24009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24042,7 +24042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24162,7 +24162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24177,7 +24177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24192,7 +24192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24249,7 +24249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24300,7 +24300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24351,7 +24351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24402,7 +24402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24434,7 +24434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24448,7 +24448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24468,7 +24468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24646,7 +24646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24679,7 +24679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24694,7 +24694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24722,7 +24722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24762,7 +24762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24797,7 +24797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24858,7 +24858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24917,7 +24917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24946,7 +24946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24996,7 +24996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25030,7 +25030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25103,7 +25103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25317,7 +25317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25349,7 +25349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25387,7 +25387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25437,7 +25437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25469,7 +25469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25592,7 +25592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25637,7 +25637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25682,7 +25682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25727,7 +25727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25772,7 +25772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25824,7 +25824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25868,7 +25868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25882,7 +25882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25897,7 +25897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25937,7 +25937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25989,7 +25989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26003,7 +26003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26149,7 +26149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26228,7 +26228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26243,7 +26243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26258,7 +26258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26273,7 +26273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26288,7 +26288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26315,7 +26315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26348,7 +26348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26362,7 +26362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26377,7 +26377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26413,7 +26413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26445,7 +26445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26477,7 +26477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26497,7 +26497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26627,7 +26627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -26665,7 +26665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -26680,7 +26680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -26695,7 +26695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26723,7 +26723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26763,7 +26763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26802,7 +26802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26894,7 +26894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26915,7 +26915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26965,7 +26965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27022,7 +27022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27073,7 +27073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27124,7 +27124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27177,7 +27177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27210,12 +27210,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -27307,7 +27307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27335,7 +27335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27383,7 +27383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -27422,7 +27422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -27436,7 +27436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27594,7 +27594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27696,7 +27696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27843,7 +27843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27951,7 +27951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27966,7 +27966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -27981,7 +27981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27996,7 +27996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28010,7 +28010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28024,7 +28024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -28038,7 +28038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28107,7 +28107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28164,7 +28164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -28221,7 +28221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28278,7 +28278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28306,7 +28306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28337,7 +28337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -28346,7 +28346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28407,7 +28407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28493,7 +28493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28597,7 +28597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28807,7 +28807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29347,7 +29347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29792,6 +29792,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -29826,7 +29854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29853,7 +29881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30096,9 +30124,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -30532,7 +30560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30552,7 +30580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30567,7 +30595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30582,7 +30610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30596,7 +30624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30610,7 +30638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30624,7 +30652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -30699,7 +30727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -30756,7 +30784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -30813,7 +30841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -30870,7 +30898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -30923,7 +30951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30938,7 +30966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -31096,7 +31124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -31129,7 +31157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -31162,7 +31190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -31195,7 +31223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -31234,7 +31262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -31254,7 +31282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31349,7 +31377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31378,7 +31406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31393,7 +31421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31408,7 +31436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31423,7 +31451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31438,7 +31466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31472,7 +31500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31613,7 +31641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31662,7 +31690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31730,7 +31758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31744,7 +31772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31776,7 +31804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31899,7 +31927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32004,7 +32032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -32109,7 +32137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -32214,7 +32242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32229,7 +32257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32244,7 +32272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32276,7 +32304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32308,7 +32336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32340,7 +32368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32368,7 +32396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32424,7 +32452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -32481,7 +32509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -32590,7 +32618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -32641,7 +32669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -32692,7 +32720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -32743,7 +32771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -32794,7 +32822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -32809,7 +32837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -32824,7 +32852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -32838,7 +32866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -32883,7 +32911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -33709,6 +33737,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -33759,7 +33805,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -33800,80 +33892,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33971,12 +33989,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -33986,6 +33998,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34021,46 +34045,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -34089,6 +34073,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34142,7 +34144,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -34189,134 +34237,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34408,30 +34328,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -34441,6 +34337,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34476,64 +34384,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -34562,6 +34412,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34615,7 +34483,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -34662,134 +34576,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34881,30 +34667,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -34914,6 +34676,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34949,64 +34723,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -35035,6 +34751,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35112,7 +34846,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -35159,140 +34945,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35390,30 +35042,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -35423,6 +35051,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35453,64 +35093,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -36201,7 +35783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36292,7 +35874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36445,7 +36027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36496,7 +36078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36589,7 +36171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36742,7 +36324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36895,7 +36477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37048,7 +36630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37176,7 +36758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37205,7 +36787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -37377,7 +36959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -37542,9 +37124,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37708,9 +37290,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37874,9 +37456,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38040,7 +37622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -38099,9 +37681,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38159,9 +37741,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38219,9 +37801,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38279,7 +37861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -38344,9 +37926,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38410,9 +37992,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38476,9 +38058,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38542,7 +38124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -38643,9 +38225,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38751,9 +38333,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38853,9 +38435,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38955,7 +38537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -39056,9 +38638,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39164,9 +38746,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39266,9 +38848,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39368,7 +38950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -39457,9 +39039,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39547,9 +39129,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39637,9 +39219,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39731,7 +39313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39745,7 +39327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39759,7 +39341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39821,7 +39403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39866,7 +39448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -39921,7 +39503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -40030,43 +39612,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40074,7 +39656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -40125,7 +39707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -40174,43 +39756,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40218,7 +39800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -40327,43 +39909,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40371,7 +39953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -40480,43 +40062,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40524,7 +40106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -40633,43 +40215,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40677,7 +40259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -40793,7 +40375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -40819,7 +40401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -40851,7 +40433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -40883,7 +40465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -40905,7 +40487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -41065,9 +40647,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -41232,7 +40814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -41381,9 +40963,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41531,9 +41113,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41681,9 +41263,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41831,7 +41413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -41884,9 +41466,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41938,9 +41520,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41992,9 +41574,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42046,7 +41628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -42111,9 +41693,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42177,9 +41759,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42243,9 +41825,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42309,7 +41891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -42398,9 +41980,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42488,9 +42070,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42578,9 +42160,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42668,7 +42250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -42751,9 +42333,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42835,9 +42417,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42919,9 +42501,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43003,7 +42585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -43086,9 +42668,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43170,9 +42752,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43254,9 +42836,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43338,7 +42920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -43360,7 +42942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -43410,7 +42992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43424,7 +43006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43438,7 +43020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43500,7 +43082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43545,7 +43127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -43602,7 +43184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -43647,7 +43229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -43662,7 +43244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -43698,7 +43280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43729,7 +43311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43775,7 +43357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43804,7 +43386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43854,7 +43436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43894,7 +43476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43921,7 +43503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43959,7 +43541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43991,7 +43573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -44144,7 +43726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -44297,7 +43879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -44450,7 +44032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -44603,7 +44185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -44756,7 +44338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -44909,7 +44491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -45062,7 +44644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -45214,7 +44796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -45366,7 +44948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45519,7 +45101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -45672,7 +45254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -45825,7 +45407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -45978,7 +45560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -46137,7 +45719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46188,7 +45770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46239,7 +45821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46290,7 +45872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46341,7 +45923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -46355,7 +45937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -46369,7 +45951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -46389,7 +45971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -46483,7 +46065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -46497,7 +46079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -46511,7 +46093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -47104,7 +46686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -47124,7 +46706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -47138,7 +46720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -47166,7 +46748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -47366,7 +46948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -49255,6 +48837,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMS70Q21.svd
+++ b/data/Atmel/ATSAMS70Q21.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3167,7 +3167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3216,7 +3216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3312,7 +3312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3534,7 +3534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3555,7 +3555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3576,7 +3576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3611,7 +3611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3632,7 +3632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3665,7 +3665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3698,7 +3698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3731,7 +3731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3764,7 +3764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3784,7 +3784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3812,7 +3812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4177,7 +4177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4216,7 +4216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4266,7 +4266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4375,7 +4375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4389,7 +4389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4646,7 +4646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4666,7 +4666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4776,7 +4776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4929,7 +4929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5082,7 +5082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5235,7 +5235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5388,7 +5388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5436,7 +5436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5468,7 +5468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5496,7 +5496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5519,7 +5519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5552,7 +5552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5626,7 +5626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5671,7 +5671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5698,7 +5698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5749,7 +5749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5800,7 +5800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5902,7 +5902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5945,7 +5945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5959,7 +5959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5975,7 +5975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6009,7 +6009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6107,7 +6107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6215,7 +6215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6249,7 +6249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6281,7 +6281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6313,7 +6313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6345,7 +6345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6377,7 +6377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6409,7 +6409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6442,7 +6442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6523,7 +6523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6586,7 +6586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6649,7 +6649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6712,7 +6712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6733,7 +6733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6754,7 +6754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6775,7 +6775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6789,7 +6789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6821,7 +6821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6835,7 +6835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6849,7 +6849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6881,7 +6881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6961,7 +6961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7020,7 +7020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7070,7 +7070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7120,7 +7120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7135,7 +7135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7267,7 +7267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7295,7 +7295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7335,7 +7335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7536,7 +7536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -7737,7 +7737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8139,7 +8139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8340,7 +8340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -8541,7 +8541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -8742,7 +8742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -8943,7 +8943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9144,7 +9144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9345,7 +9345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -9546,7 +9546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -9746,7 +9746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -9947,7 +9947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10148,7 +10148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10349,7 +10349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -10550,7 +10550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -10751,7 +10751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -10952,7 +10952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11153,7 +11153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11354,7 +11354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -11555,7 +11555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -11756,7 +11756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -11959,7 +11959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12159,7 +12159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12360,7 +12360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -12561,7 +12561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -12762,7 +12762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -12776,7 +12776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -12977,7 +12977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13178,7 +13178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13379,7 +13379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -13580,7 +13580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -13781,7 +13781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -13982,7 +13982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14183,7 +14183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14384,7 +14384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -14585,7 +14585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -14786,7 +14786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -14987,7 +14987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15188,7 +15188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15389,7 +15389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -15590,7 +15590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -15791,7 +15791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -15992,7 +15992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16020,7 +16020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16041,7 +16041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16241,7 +16241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -16857,7 +16857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -16913,7 +16913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -16946,7 +16946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -16979,7 +16979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17012,7 +17012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17033,7 +17033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17099,7 +17099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17156,7 +17156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17213,7 +17213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17276,7 +17276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17435,7 +17435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17594,7 +17594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -17944,7 +17944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18065,7 +18065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18087,7 +18087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18135,7 +18135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18234,7 +18234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18333,7 +18333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -18450,7 +18450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -18549,7 +18549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -18707,7 +18707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -18811,7 +18811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -18826,7 +18826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -18854,7 +18854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -18875,7 +18875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19034,7 +19034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19193,7 +19193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19352,7 +19352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19424,7 +19424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -19468,7 +19468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -19627,7 +19627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -19786,7 +19786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -19945,7 +19945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20104,7 +20104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20118,7 +20118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20277,7 +20277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20436,7 +20436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -20595,7 +20595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -20754,7 +20754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -20788,7 +20788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -20962,7 +20962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -20995,7 +20995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21028,7 +21028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21061,7 +21061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21118,7 +21118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21175,7 +21175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21232,7 +21232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21289,7 +21289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21357,7 +21357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21372,7 +21372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21386,7 +21386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21406,7 +21406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21421,7 +21421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -21538,7 +21538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -21655,7 +21655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -21772,7 +21772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -21889,7 +21889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -21945,7 +21945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -22001,7 +22001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22058,7 +22058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22115,7 +22115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22172,7 +22172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22229,7 +22229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22255,7 +22255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22276,7 +22276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22291,7 +22291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22347,7 +22347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22381,7 +22381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22437,7 +22437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22457,7 +22457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22472,7 +22472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22504,7 +22504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -22560,7 +22560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -22643,7 +22643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -22742,7 +22742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -22762,7 +22762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -22783,7 +22783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -22827,7 +22827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -22867,7 +22867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23009,7 +23009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23023,7 +23023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23038,7 +23038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23052,7 +23052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23082,7 +23082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23102,7 +23102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23124,7 +23124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23145,7 +23145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23166,7 +23166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23246,7 +23246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23284,7 +23284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23305,7 +23305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23385,7 +23385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23423,7 +23423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -23471,7 +23471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23504,7 +23504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23624,7 +23624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23639,7 +23639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23654,7 +23654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23711,7 +23711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -23762,7 +23762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -23813,7 +23813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -23864,7 +23864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -23896,7 +23896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -23910,7 +23910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -23930,7 +23930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24108,7 +24108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24141,7 +24141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24156,7 +24156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24184,7 +24184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24224,7 +24224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24259,7 +24259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24320,7 +24320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24379,7 +24379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24408,7 +24408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24458,7 +24458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24492,7 +24492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24565,7 +24565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24779,7 +24779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24811,7 +24811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24849,7 +24849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24899,7 +24899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24931,7 +24931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25054,7 +25054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25099,7 +25099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25144,7 +25144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25189,7 +25189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25234,7 +25234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25286,7 +25286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25330,7 +25330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25344,7 +25344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25359,7 +25359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25399,7 +25399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25451,7 +25451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25465,7 +25465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25611,7 +25611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25690,7 +25690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25705,7 +25705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25720,7 +25720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25735,7 +25735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25750,7 +25750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25777,7 +25777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25810,7 +25810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25824,7 +25824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -25839,7 +25839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -25875,7 +25875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -25907,7 +25907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -25939,7 +25939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -25959,7 +25959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC MODE Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26089,7 +26089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC OCMS MODE Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -26127,7 +26127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC OCMS KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -26142,7 +26142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC OCMS KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -26157,7 +26157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26185,7 +26185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26225,7 +26225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26288,7 +26288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26344,7 +26344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26392,7 +26392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26449,7 +26449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26500,7 +26500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26551,7 +26551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26604,7 +26604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26708,7 +26708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26736,7 +26736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26784,7 +26784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -26823,7 +26823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -26837,7 +26837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26995,7 +26995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27097,7 +27097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27244,7 +27244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27352,7 +27352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27367,7 +27367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -27382,7 +27382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27397,7 +27397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -27411,7 +27411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27425,7 +27425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27439,7 +27439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27508,7 +27508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27565,7 +27565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27622,7 +27622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27679,7 +27679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27707,7 +27707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27747,7 +27747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27808,7 +27808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27894,7 +27894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27998,7 +27998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28208,7 +28208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28748,7 +28748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29227,7 +29227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29254,7 +29254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29497,7 +29497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29517,7 +29517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29532,7 +29532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -29547,7 +29547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -29561,7 +29561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -29575,7 +29575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -29589,7 +29589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -29664,7 +29664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -29721,7 +29721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -29778,7 +29778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -29835,7 +29835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -29888,7 +29888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -29903,7 +29903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -30049,7 +30049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -30076,7 +30076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -30103,7 +30103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -30130,7 +30130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -30163,7 +30163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -30183,7 +30183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30278,7 +30278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30307,7 +30307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30322,7 +30322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30337,7 +30337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30352,7 +30352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30367,7 +30367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30401,7 +30401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30542,7 +30542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30591,7 +30591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30659,7 +30659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30673,7 +30673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30705,7 +30705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30828,7 +30828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30933,7 +30933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31038,7 +31038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31143,7 +31143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31158,7 +31158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31173,7 +31173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31205,7 +31205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31237,7 +31237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31269,7 +31269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31297,7 +31297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31353,7 +31353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -31410,7 +31410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -31519,7 +31519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -31570,7 +31570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -31621,7 +31621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -31672,7 +31672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -31723,7 +31723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -31738,7 +31738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -31753,7 +31753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -31767,7 +31767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -31812,7 +31812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -33395,7 +33395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -33476,7 +33476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -33641,7 +33641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -33692,7 +33692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -33785,7 +33785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33950,7 +33950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -34115,7 +34115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -34280,7 +34280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -34408,7 +34408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -34437,7 +34437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -34609,7 +34609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -34774,7 +34774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -34833,7 +34833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -34898,7 +34898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -34999,7 +34999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -35100,7 +35100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -35193,7 +35193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -35207,7 +35207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -35221,7 +35221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35283,7 +35283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35328,7 +35328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -35373,7 +35373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -35538,7 +35538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -35589,7 +35589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -35682,7 +35682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -35847,7 +35847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -36012,7 +36012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -36177,7 +36177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -36293,7 +36293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -36319,7 +36319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -36351,7 +36351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -36383,7 +36383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -36405,7 +36405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -36565,7 +36565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -36714,7 +36714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -36767,7 +36767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -36832,7 +36832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -36921,7 +36921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -37004,7 +37004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -37087,7 +37087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -37109,7 +37109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -37159,7 +37159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37173,7 +37173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37187,7 +37187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37249,7 +37249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37294,7 +37294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -37345,7 +37345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -37390,7 +37390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -37405,7 +37405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -37441,7 +37441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37472,7 +37472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -37518,7 +37518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37547,7 +37547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37597,7 +37597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -37637,7 +37637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37664,7 +37664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37702,7 +37702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -37734,7 +37734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37887,7 +37887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38040,7 +38040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38193,7 +38193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38346,7 +38346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38499,7 +38499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38652,7 +38652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38805,7 +38805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38957,7 +38957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39109,7 +39109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39262,7 +39262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39415,7 +39415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39568,7 +39568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -39721,7 +39721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -39880,7 +39880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39931,7 +39931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39982,7 +39982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40033,7 +40033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40084,7 +40084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -40098,7 +40098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -40112,7 +40112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -40132,7 +40132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -40226,7 +40226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -40240,7 +40240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -40254,7 +40254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -40584,7 +40584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -40604,7 +40604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -40618,7 +40618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -40646,7 +40646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -40846,7 +40846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -41046,7 +41046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -41246,7 +41246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMS70Q21B.svd
+++ b/data/Atmel/ATSAMS70Q21B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6087,7 +6087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6206,7 +6206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6233,7 +6233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6284,7 +6284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6335,7 +6335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6386,7 +6386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6437,7 +6437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6480,7 +6480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6494,7 +6494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6510,7 +6510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6544,7 +6544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6642,7 +6642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6750,7 +6750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6770,7 +6770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6784,7 +6784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6816,7 +6816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6880,7 +6880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6912,7 +6912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6944,7 +6944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6977,7 +6977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7058,7 +7058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7121,7 +7121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7184,7 +7184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7247,7 +7247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7268,7 +7268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7310,7 +7310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7324,7 +7324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7356,7 +7356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7384,7 +7384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7416,7 +7416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7430,7 +7430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7458,7 +7458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7496,7 +7496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7555,7 +7555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7605,7 +7605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7655,7 +7655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7676,7 +7676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7866,7 +7866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7894,7 +7894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7934,7 +7934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -8336,7 +8336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -8537,7 +8537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -8738,7 +8738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -8939,7 +8939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -9140,7 +9140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -9341,7 +9341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -9542,7 +9542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -9743,7 +9743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -9944,7 +9944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -10145,7 +10145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -10345,7 +10345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -10546,7 +10546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -10747,7 +10747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -10948,7 +10948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -11149,7 +11149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -11350,7 +11350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -11551,7 +11551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -11752,7 +11752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -11953,7 +11953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -12154,7 +12154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -12355,7 +12355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -12558,7 +12558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -12758,7 +12758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -12959,7 +12959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -13160,7 +13160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -13361,7 +13361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -13375,7 +13375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -13576,7 +13576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -13777,7 +13777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -13978,7 +13978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -14179,7 +14179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -14380,7 +14380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -14581,7 +14581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -14782,7 +14782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -14983,7 +14983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -15184,7 +15184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -15385,7 +15385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -15586,7 +15586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -15787,7 +15787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -15988,7 +15988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -16189,7 +16189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -16390,7 +16390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -16591,7 +16591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -16619,7 +16619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -16640,7 +16640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -16840,7 +16840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -17456,7 +17456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -17512,7 +17512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -17545,7 +17545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -17578,7 +17578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -17611,7 +17611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -17632,7 +17632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -17698,7 +17698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17761,7 +17761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17824,7 +17824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17893,7 +17893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -18052,7 +18052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -18211,7 +18211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18561,7 +18561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18682,7 +18682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18704,7 +18704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -18752,7 +18752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -18857,7 +18857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18962,7 +18962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -19085,7 +19085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -19190,7 +19190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -19348,7 +19348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -19452,7 +19452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -19467,7 +19467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19495,7 +19495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19516,7 +19516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19651,7 +19651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -19786,7 +19786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -19921,7 +19921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -19993,7 +19993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -20037,7 +20037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -20196,7 +20196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20355,7 +20355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -20514,7 +20514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -20673,7 +20673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -20687,7 +20687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -20822,7 +20822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -20957,7 +20957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -21092,7 +21092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -21227,7 +21227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -21261,7 +21261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -21435,7 +21435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -21468,7 +21468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -21501,7 +21501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -21534,7 +21534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -21591,7 +21591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -21648,7 +21648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -21705,7 +21705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -21762,7 +21762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -21830,7 +21830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -21845,7 +21845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -21859,7 +21859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -21879,7 +21879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -21894,7 +21894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -22011,7 +22011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -22128,7 +22128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -22245,7 +22245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22362,7 +22362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -22418,7 +22418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -22474,7 +22474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -22531,7 +22531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -22588,7 +22588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -22645,7 +22645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -22702,7 +22702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -22728,7 +22728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -22749,7 +22749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -22764,7 +22764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -22820,7 +22820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -22854,7 +22854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -22910,7 +22910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -22930,7 +22930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -22945,7 +22945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -22977,7 +22977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -23033,7 +23033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -23116,7 +23116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -23215,7 +23215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23248,7 +23248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23269,7 +23269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23313,7 +23313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23353,7 +23353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -23547,7 +23547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -23561,7 +23561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -23576,7 +23576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -23590,7 +23590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -23605,7 +23605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -23620,7 +23620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -23640,7 +23640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -23662,7 +23662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -23683,7 +23683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -23704,7 +23704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -23784,7 +23784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -23822,7 +23822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -23843,7 +23843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -23923,7 +23923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -23961,7 +23961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -24009,7 +24009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24042,7 +24042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24162,7 +24162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24177,7 +24177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -24192,7 +24192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -24249,7 +24249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24300,7 +24300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24351,7 +24351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24402,7 +24402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24434,7 +24434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24448,7 +24448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24468,7 +24468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24646,7 +24646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24679,7 +24679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24694,7 +24694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -24722,7 +24722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -24762,7 +24762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24797,7 +24797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24858,7 +24858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24917,7 +24917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24946,7 +24946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24996,7 +24996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25030,7 +25030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25103,7 +25103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25317,7 +25317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25349,7 +25349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25387,7 +25387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25437,7 +25437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25469,7 +25469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25592,7 +25592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25637,7 +25637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25682,7 +25682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25727,7 +25727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25772,7 +25772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25824,7 +25824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25868,7 +25868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25882,7 +25882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25897,7 +25897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25937,7 +25937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25989,7 +25989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26003,7 +26003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26149,7 +26149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26228,7 +26228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26243,7 +26243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26258,7 +26258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26273,7 +26273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26288,7 +26288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26315,7 +26315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26348,7 +26348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26362,7 +26362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26377,7 +26377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26413,7 +26413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26445,7 +26445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26477,7 +26477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26497,7 +26497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26627,7 +26627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -26665,7 +26665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -26680,7 +26680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -26695,7 +26695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26723,7 +26723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26763,7 +26763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26802,7 +26802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26894,7 +26894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26915,7 +26915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26965,7 +26965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27022,7 +27022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27073,7 +27073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27124,7 +27124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27177,7 +27177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27210,12 +27210,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -27307,7 +27307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27335,7 +27335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27383,7 +27383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -27422,7 +27422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -27436,7 +27436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27594,7 +27594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27696,7 +27696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27843,7 +27843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27951,7 +27951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27966,7 +27966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -27981,7 +27981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27996,7 +27996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28010,7 +28010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28024,7 +28024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -28038,7 +28038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28107,7 +28107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28164,7 +28164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -28221,7 +28221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28278,7 +28278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28306,7 +28306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28337,7 +28337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -28346,7 +28346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28407,7 +28407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28493,7 +28493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28597,7 +28597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28807,7 +28807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29347,7 +29347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29792,6 +29792,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -29826,7 +29854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29853,7 +29881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30096,9 +30124,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -30532,7 +30560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30552,7 +30580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30567,7 +30595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -30582,7 +30610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -30596,7 +30624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -30610,7 +30638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -30624,7 +30652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -30699,7 +30727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -30756,7 +30784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -30813,7 +30841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -30870,7 +30898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -30923,7 +30951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30938,7 +30966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -31096,7 +31124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -31129,7 +31157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -31162,7 +31190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -31195,7 +31223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -31234,7 +31262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -31254,7 +31282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31349,7 +31377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31378,7 +31406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31393,7 +31421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31408,7 +31436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31423,7 +31451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31438,7 +31466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31472,7 +31500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31613,7 +31641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31662,7 +31690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31730,7 +31758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31744,7 +31772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31776,7 +31804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31899,7 +31927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32004,7 +32032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -32109,7 +32137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -32214,7 +32242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32229,7 +32257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32244,7 +32272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32276,7 +32304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32308,7 +32336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32340,7 +32368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32368,7 +32396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32424,7 +32452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -32481,7 +32509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -32590,7 +32618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -32641,7 +32669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -32692,7 +32720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -32743,7 +32771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -32794,7 +32822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -32809,7 +32837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -32824,7 +32852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -32838,7 +32866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -32883,7 +32911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -33709,6 +33737,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -33759,7 +33805,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -33800,80 +33892,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -33971,12 +33989,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -33986,6 +33998,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34021,46 +34045,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -34089,6 +34073,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34142,7 +34144,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -34189,134 +34237,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34408,30 +34328,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -34441,6 +34337,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34476,64 +34384,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -34562,6 +34412,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34615,7 +34483,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -34662,134 +34576,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34881,30 +34667,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -34914,6 +34676,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34949,64 +34723,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -35035,6 +34751,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35112,7 +34846,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -35159,140 +34945,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35390,30 +35042,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -35423,6 +35051,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35453,64 +35093,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -36201,7 +35783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36292,7 +35874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36445,7 +36027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36496,7 +36078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36589,7 +36171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36742,7 +36324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36895,7 +36477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37048,7 +36630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37176,7 +36758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37205,7 +36787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -37377,7 +36959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -37542,9 +37124,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37708,9 +37290,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -37874,9 +37456,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38040,7 +37622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -38099,9 +37681,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38159,9 +37741,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38219,9 +37801,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38279,7 +37861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -38344,9 +37926,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38410,9 +37992,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38476,9 +38058,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -38542,7 +38124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -38643,9 +38225,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38751,9 +38333,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38853,9 +38435,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38955,7 +38537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -39056,9 +38638,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39164,9 +38746,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39266,9 +38848,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39368,7 +38950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -39457,9 +39039,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39547,9 +39129,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39637,9 +39219,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39731,7 +39313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39745,7 +39327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39759,7 +39341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39821,7 +39403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39866,7 +39448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -39921,7 +39503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -40030,43 +39612,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40074,7 +39656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -40125,7 +39707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -40174,43 +39756,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40218,7 +39800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -40327,43 +39909,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40371,7 +39953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -40480,43 +40062,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40524,7 +40106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -40633,43 +40215,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40677,7 +40259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -40793,7 +40375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -40819,7 +40401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -40851,7 +40433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -40883,7 +40465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -40905,7 +40487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -41065,9 +40647,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -41232,7 +40814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -41381,9 +40963,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41531,9 +41113,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41681,9 +41263,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41831,7 +41413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -41884,9 +41466,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41938,9 +41520,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41992,9 +41574,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42046,7 +41628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -42111,9 +41693,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42177,9 +41759,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42243,9 +41825,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42309,7 +41891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -42398,9 +41980,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42488,9 +42070,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42578,9 +42160,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42668,7 +42250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -42751,9 +42333,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42835,9 +42417,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42919,9 +42501,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43003,7 +42585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -43086,9 +42668,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43170,9 +42752,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43254,9 +42836,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43338,7 +42920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -43360,7 +42942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -43410,7 +42992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43424,7 +43006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43438,7 +43020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43500,7 +43082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43545,7 +43127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -43602,7 +43184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -43647,7 +43229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -43662,7 +43244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -43698,7 +43280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43729,7 +43311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43775,7 +43357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43804,7 +43386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43854,7 +43436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43894,7 +43476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43921,7 +43503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43959,7 +43541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43991,7 +43573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -44144,7 +43726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -44297,7 +43879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -44450,7 +44032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -44603,7 +44185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -44756,7 +44338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -44909,7 +44491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -45062,7 +44644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -45214,7 +44796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -45366,7 +44948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45519,7 +45101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -45672,7 +45254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -45825,7 +45407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -45978,7 +45560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -46137,7 +45719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46188,7 +45770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46239,7 +45821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46290,7 +45872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46341,7 +45923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -46355,7 +45937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -46369,7 +45951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -46389,7 +45971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -46483,7 +46065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -46497,7 +46079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -46511,7 +46093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -47104,7 +46686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -47124,7 +46706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -47138,7 +46720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -47166,7 +46748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -47366,7 +46948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -47566,7 +47148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -47766,7 +47348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>
@@ -49655,6 +49237,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV70J19.svd
+++ b/data/Atmel/ATSAMV70J19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3152,7 +3152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3511,7 +3511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3550,7 +3550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3600,7 +3600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3663,7 +3663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -3709,7 +3709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3723,7 +3723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3980,7 +3980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4000,7 +4000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4065,7 +4065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4080,7 +4080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4095,7 +4095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4110,7 +4110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4263,7 +4263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -4416,7 +4416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -4569,7 +4569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -4722,7 +4722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -4770,7 +4770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -4802,7 +4802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -4830,7 +4830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4853,7 +4853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -4886,7 +4886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4960,7 +4960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5005,7 +5005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5032,7 +5032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5083,7 +5083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5134,7 +5134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5185,7 +5185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5236,7 +5236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5279,7 +5279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5293,7 +5293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5309,7 +5309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5343,7 +5343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5441,7 +5441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5569,7 +5569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5583,7 +5583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5615,7 +5615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5647,7 +5647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5679,7 +5679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5711,7 +5711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5776,7 +5776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5857,7 +5857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5920,7 +5920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6067,7 +6067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6109,7 +6109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6123,7 +6123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6155,7 +6155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6169,7 +6169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6183,7 +6183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6215,7 +6215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6229,7 +6229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6257,7 +6257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6295,7 +6295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -6354,7 +6354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6404,7 +6404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -6460,7 +6460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -6487,7 +6487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -6657,7 +6657,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -6685,7 +6685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -6729,7 +6729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6774,7 +6774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6789,7 +6789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6803,7 +6803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6860,7 +6860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6928,7 +6928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6948,7 +6948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7161,7 +7161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7193,7 +7193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7231,7 +7231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -7245,7 +7245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7307,7 +7307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7321,7 +7321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7354,7 +7354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7483,7 +7483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7671,7 +7671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7859,7 +7859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8047,7 +8047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -8067,7 +8067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -8151,7 +8151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -8171,7 +8171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -8191,7 +8191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -8205,7 +8205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -8261,7 +8261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -8461,7 +8461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -8661,7 +8661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -8693,7 +8693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -8732,7 +8732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -8746,7 +8746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -8760,7 +8760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -8792,7 +8792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -8860,7 +8860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -8874,7 +8874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -9029,7 +9029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -9061,7 +9061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -9094,7 +9094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -9151,7 +9151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -9352,7 +9352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -9552,7 +9552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -9752,7 +9752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -9953,7 +9953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -10154,7 +10154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -10354,7 +10354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10554,7 +10554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -10580,7 +10580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -10619,7 +10619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -10664,7 +10664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -10770,7 +10770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -10784,7 +10784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -10798,7 +10798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -10842,7 +10842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -10875,7 +10875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -10973,7 +10973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -10999,7 +10999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -11027,7 +11027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -11043,7 +11043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -11060,7 +11060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -11077,7 +11077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11093,7 +11093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -11107,7 +11107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -11121,7 +11121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -11160,7 +11160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -11207,7 +11207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -11223,7 +11223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -11256,7 +11256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -11457,7 +11457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -11658,7 +11658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -11859,7 +11859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -12060,7 +12060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -12261,7 +12261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -12462,7 +12462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -12663,7 +12663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -12864,7 +12864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -13065,7 +13065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -13266,7 +13266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -13467,7 +13467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -13667,7 +13667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -13868,7 +13868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -14069,7 +14069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -14270,7 +14270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -14471,7 +14471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -14672,7 +14672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -14873,7 +14873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -15074,7 +15074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -15275,7 +15275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -15476,7 +15476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -15677,7 +15677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -15880,7 +15880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -16080,7 +16080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -16281,7 +16281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -16482,7 +16482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -16683,7 +16683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -16697,7 +16697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -16898,7 +16898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -17099,7 +17099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -17300,7 +17300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -17501,7 +17501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -17702,7 +17702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -17903,7 +17903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -18104,7 +18104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -18305,7 +18305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -18506,7 +18506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -18707,7 +18707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -18908,7 +18908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -19109,7 +19109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -19310,7 +19310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -19511,7 +19511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -19712,7 +19712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -19913,7 +19913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19941,7 +19941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19962,7 +19962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -20162,7 +20162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20778,7 +20778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -20834,7 +20834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -20867,7 +20867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -20900,7 +20900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -20933,7 +20933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -20954,7 +20954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -21004,7 +21004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -21061,7 +21061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -21118,7 +21118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -21181,7 +21181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -21340,7 +21340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -21499,7 +21499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -21849,7 +21849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -21970,7 +21970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -21992,7 +21992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22040,7 +22040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -22139,7 +22139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -22238,7 +22238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -22355,7 +22355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -22454,7 +22454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -22612,7 +22612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -22716,7 +22716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -22731,7 +22731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -22759,7 +22759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -22780,7 +22780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22939,7 +22939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -23098,7 +23098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -23257,7 +23257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -23329,7 +23329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -23373,7 +23373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -23532,7 +23532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -23691,7 +23691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -23850,7 +23850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -24009,7 +24009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -24023,7 +24023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -24182,7 +24182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -24341,7 +24341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -24500,7 +24500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -24659,7 +24659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -24674,7 +24674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24700,7 +24700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24747,7 +24747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24921,7 +24921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24954,7 +24954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24987,7 +24987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25020,7 +25020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25077,7 +25077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25134,7 +25134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25191,7 +25191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25248,7 +25248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25316,7 +25316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25331,7 +25331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25345,7 +25345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25365,7 +25365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -25380,7 +25380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -25497,7 +25497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -25614,7 +25614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -25731,7 +25731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25848,7 +25848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -25904,7 +25904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -25960,7 +25960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -26017,7 +26017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -26074,7 +26074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -26131,7 +26131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -26188,7 +26188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -26214,7 +26214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -26235,7 +26235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -26250,7 +26250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -26306,7 +26306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -26340,7 +26340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -26396,7 +26396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -26416,7 +26416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -26431,7 +26431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -26463,7 +26463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -26519,7 +26519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26602,7 +26602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26701,7 +26701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26721,7 +26721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26742,7 +26742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26786,7 +26786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26826,7 +26826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26968,7 +26968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26982,7 +26982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26997,7 +26997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27011,7 +27011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -27026,7 +27026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -27041,7 +27041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -27061,7 +27061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -27083,7 +27083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -27104,7 +27104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -27125,7 +27125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -27205,7 +27205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -27243,7 +27243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -27264,7 +27264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -27344,7 +27344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -27382,7 +27382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -27430,7 +27430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27463,7 +27463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27583,7 +27583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27598,7 +27598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27613,7 +27613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27670,7 +27670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27721,7 +27721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27772,7 +27772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27823,7 +27823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27855,7 +27855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27869,7 +27869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -27889,7 +27889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28067,7 +28067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28100,7 +28100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28115,7 +28115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28143,7 +28143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28183,7 +28183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28218,7 +28218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28279,7 +28279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28338,7 +28338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28367,7 +28367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28417,7 +28417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28451,7 +28451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28524,7 +28524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28738,7 +28738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28770,7 +28770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28808,7 +28808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28858,7 +28858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28890,7 +28890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29013,7 +29013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29058,7 +29058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29103,7 +29103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29148,7 +29148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29193,7 +29193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29245,7 +29245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29289,7 +29289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29303,7 +29303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29318,7 +29318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29358,7 +29358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -29397,7 +29397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -29411,7 +29411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29569,7 +29569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29671,7 +29671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29818,7 +29818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29926,7 +29926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29941,7 +29941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29956,7 +29956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29971,7 +29971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29985,7 +29985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29999,7 +29999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30013,7 +30013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30082,7 +30082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30139,7 +30139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30196,7 +30196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30253,7 +30253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30281,7 +30281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30321,7 +30321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30382,7 +30382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30468,7 +30468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30572,7 +30572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30782,7 +30782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31322,7 +31322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31801,7 +31801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31828,7 +31828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32071,7 +32071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32091,7 +32091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32106,7 +32106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -32121,7 +32121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -32135,7 +32135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32149,7 +32149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32163,7 +32163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -32238,7 +32238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -32295,7 +32295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -32352,7 +32352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -32409,7 +32409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -32462,7 +32462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -32477,7 +32477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -32623,7 +32623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -32650,7 +32650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -32677,7 +32677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -32704,7 +32704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -32737,7 +32737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -32757,7 +32757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32785,7 +32785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -32873,7 +32873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32902,7 +32902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32917,7 +32917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32932,7 +32932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32947,7 +32947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32962,7 +32962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -32996,7 +32996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33137,7 +33137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33186,7 +33186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33254,7 +33254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33268,7 +33268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33300,7 +33300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33423,7 +33423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33528,7 +33528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33633,7 +33633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33738,7 +33738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33753,7 +33753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33768,7 +33768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33800,7 +33800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33832,7 +33832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -33864,7 +33864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33892,7 +33892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33940,7 +33940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -34003,7 +34003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -34112,7 +34112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -34163,7 +34163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -34214,7 +34214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -34265,7 +34265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -34334,7 +34334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -34349,7 +34349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -34364,7 +34364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -34378,7 +34378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -34423,7 +34423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -35982,7 +35982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36073,7 +36073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36226,7 +36226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36277,7 +36277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36370,7 +36370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36523,7 +36523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36676,7 +36676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36829,7 +36829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36957,7 +36957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36986,7 +36986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -37158,7 +37158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -37323,7 +37323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -37382,7 +37382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -37447,7 +37447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -37548,7 +37548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -37649,7 +37649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -37742,7 +37742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37756,7 +37756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37770,7 +37770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37832,7 +37832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37877,7 +37877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -37932,7 +37932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -38085,7 +38085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -38136,7 +38136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -38229,7 +38229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -38382,7 +38382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -38535,7 +38535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -38688,7 +38688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -38804,7 +38804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -38830,7 +38830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -38862,7 +38862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -38894,7 +38894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -38916,7 +38916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -39076,7 +39076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -39225,7 +39225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -39278,7 +39278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -39343,7 +39343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -39432,7 +39432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -39515,7 +39515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -39598,7 +39598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -39620,7 +39620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -39670,7 +39670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39684,7 +39684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39698,7 +39698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39760,7 +39760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39805,7 +39805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -39862,7 +39862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -39907,7 +39907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -39922,7 +39922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -39958,7 +39958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39989,7 +39989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40035,7 +40035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40064,7 +40064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40114,7 +40114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40154,7 +40154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40181,7 +40181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40219,7 +40219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40251,7 +40251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -40404,7 +40404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40557,7 +40557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -40710,7 +40710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -40863,7 +40863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -41016,7 +41016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -41169,7 +41169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -41322,7 +41322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -41474,7 +41474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -41626,7 +41626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -41779,7 +41779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -41932,7 +41932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -42085,7 +42085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -42238,7 +42238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -42397,7 +42397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42448,7 +42448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42499,7 +42499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42550,7 +42550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -42601,7 +42601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -42615,7 +42615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -42629,7 +42629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -42649,7 +42649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -42743,7 +42743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -42757,7 +42757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -42771,7 +42771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -43101,7 +43101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -43121,7 +43121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -43135,7 +43135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -43382,7 +43382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -43397,7 +43397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -43493,7 +43493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -43715,7 +43715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -43736,7 +43736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -43757,7 +43757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -43792,7 +43792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -43813,7 +43813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -43846,7 +43846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -43879,7 +43879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -43912,7 +43912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43945,7 +43945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -43965,7 +43965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -43993,7 +43993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV70J19B.svd
+++ b/data/Atmel/ATSAMV70J19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4257,7 +4257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4302,7 +4302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4380,7 +4380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4431,7 +4431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4482,7 +4482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4533,7 +4533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4576,7 +4576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4590,7 +4590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4606,7 +4606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -4640,7 +4640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4738,7 +4738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4846,7 +4846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4866,7 +4866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4880,7 +4880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4912,7 +4912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4944,7 +4944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4976,7 +4976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5008,7 +5008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5040,7 +5040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5073,7 +5073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5154,7 +5154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5217,7 +5217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5280,7 +5280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5343,7 +5343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5364,7 +5364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -5385,7 +5385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5406,7 +5406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5420,7 +5420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5452,7 +5452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5480,7 +5480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5512,7 +5512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5554,7 +5554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5592,7 +5592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -5651,7 +5651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5701,7 +5701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5757,7 +5757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5784,7 +5784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -6000,7 +6000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -6072,7 +6072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6117,7 +6117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6132,7 +6132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6146,7 +6146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6197,7 +6197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6259,7 +6259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6279,7 +6279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6488,7 +6488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6520,7 +6520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6558,7 +6558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6572,7 +6572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6648,7 +6648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6681,7 +6681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6822,7 +6822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6842,7 +6842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7018,7 +7018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7194,7 +7194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -7390,7 +7390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -7474,7 +7474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -7494,7 +7494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -7514,7 +7514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -7528,7 +7528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -7584,7 +7584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -7784,7 +7784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -7984,7 +7984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -8016,7 +8016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -8055,7 +8055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -8069,7 +8069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -8083,7 +8083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -8115,7 +8115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -8183,7 +8183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -8197,7 +8197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -8352,7 +8352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -8384,7 +8384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -8417,7 +8417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -8474,7 +8474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -8675,7 +8675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -8875,7 +8875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -9075,7 +9075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -9276,7 +9276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -9477,7 +9477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -9677,7 +9677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -9877,7 +9877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -9903,7 +9903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -9942,7 +9942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -9975,7 +9975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -10081,7 +10081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -10095,7 +10095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -10109,7 +10109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -10153,7 +10153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -10186,7 +10186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -10284,7 +10284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -10310,7 +10310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -10338,7 +10338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -10354,7 +10354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -10371,7 +10371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -10388,7 +10388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -10404,7 +10404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10418,7 +10418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -10432,7 +10432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -10471,7 +10471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -10518,7 +10518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -10534,7 +10534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -10567,7 +10567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -10768,7 +10768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -10969,7 +10969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -11170,7 +11170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -11371,7 +11371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -11572,7 +11572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -11773,7 +11773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -11974,7 +11974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -12175,7 +12175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -12376,7 +12376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -12577,7 +12577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -12778,7 +12778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -12978,7 +12978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -13179,7 +13179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -13380,7 +13380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -13581,7 +13581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -13782,7 +13782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -13983,7 +13983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -14184,7 +14184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -14385,7 +14385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -14586,7 +14586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -14787,7 +14787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -14988,7 +14988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -15191,7 +15191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -15391,7 +15391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -15592,7 +15592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -15793,7 +15793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -15994,7 +15994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -16008,7 +16008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -16209,7 +16209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -16410,7 +16410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -16611,7 +16611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -16812,7 +16812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -17013,7 +17013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -17214,7 +17214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -17415,7 +17415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -17616,7 +17616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -17817,7 +17817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -18018,7 +18018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -18219,7 +18219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -18420,7 +18420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -18621,7 +18621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -18822,7 +18822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -19023,7 +19023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -19224,7 +19224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19252,7 +19252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19273,7 +19273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19473,7 +19473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20089,7 +20089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -20145,7 +20145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -20178,7 +20178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -20211,7 +20211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -20244,7 +20244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -20265,7 +20265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -20315,7 +20315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -20378,7 +20378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -20441,7 +20441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -20510,7 +20510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -20633,7 +20633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -20756,7 +20756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -21070,7 +21070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -21191,7 +21191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -21213,7 +21213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -21261,7 +21261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -21366,7 +21366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -21471,7 +21471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -21594,7 +21594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -21699,7 +21699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -21857,7 +21857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -21961,7 +21961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -21976,7 +21976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -22004,7 +22004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -22025,7 +22025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22160,7 +22160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -22295,7 +22295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -22430,7 +22430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -22502,7 +22502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -22546,7 +22546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -22669,7 +22669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -22792,7 +22792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -22915,7 +22915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -23038,7 +23038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -23052,7 +23052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -23187,7 +23187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -23322,7 +23322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -23457,7 +23457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -23592,7 +23592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -23626,7 +23626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23800,7 +23800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23833,7 +23833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23866,7 +23866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23899,7 +23899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23956,7 +23956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24013,7 +24013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24070,7 +24070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24127,7 +24127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24195,7 +24195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -24210,7 +24210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -24224,7 +24224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -24244,7 +24244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24259,7 +24259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24376,7 +24376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24493,7 +24493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -24610,7 +24610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24727,7 +24727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24783,7 +24783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -24839,7 +24839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -24896,7 +24896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -24953,7 +24953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -25010,7 +25010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -25067,7 +25067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -25093,7 +25093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -25114,7 +25114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -25129,7 +25129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -25185,7 +25185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -25219,7 +25219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -25275,7 +25275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -25295,7 +25295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -25310,7 +25310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -25342,7 +25342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -25398,7 +25398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -25481,7 +25481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -25580,7 +25580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -25613,7 +25613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -25634,7 +25634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -25678,7 +25678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -25718,7 +25718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -25912,7 +25912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -25926,7 +25926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -25941,7 +25941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -25955,7 +25955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -25970,7 +25970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -25985,7 +25985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -26005,7 +26005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -26027,7 +26027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -26048,7 +26048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -26069,7 +26069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -26149,7 +26149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -26187,7 +26187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -26208,7 +26208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -26288,7 +26288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -26326,7 +26326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -26374,7 +26374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26407,7 +26407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26527,7 +26527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26542,7 +26542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26557,7 +26557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26614,7 +26614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26665,7 +26665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26716,7 +26716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26767,7 +26767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26799,7 +26799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26813,7 +26813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26833,7 +26833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27011,7 +27011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27044,7 +27044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27059,7 +27059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27087,7 +27087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27127,7 +27127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27162,7 +27162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27223,7 +27223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27282,7 +27282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27311,7 +27311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27361,7 +27361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27395,7 +27395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27468,7 +27468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27682,7 +27682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27714,7 +27714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27752,7 +27752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27802,7 +27802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27834,7 +27834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27957,7 +27957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28002,7 +28002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28047,7 +28047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28092,7 +28092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28137,7 +28137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28189,7 +28189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28233,7 +28233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28247,7 +28247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28262,7 +28262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28302,7 +28302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -28341,7 +28341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -28355,7 +28355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28513,7 +28513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28615,7 +28615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28762,7 +28762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28870,7 +28870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28885,7 +28885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28900,7 +28900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28915,7 +28915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28929,7 +28929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28943,7 +28943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -28957,7 +28957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29026,7 +29026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29083,7 +29083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29140,7 +29140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29197,7 +29197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29225,7 +29225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29256,7 +29256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -29265,7 +29265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29326,7 +29326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29412,7 +29412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29516,7 +29516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29726,7 +29726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30266,7 +30266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30711,6 +30711,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -30745,7 +30773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30772,7 +30800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31015,9 +31043,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -31451,7 +31479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31471,7 +31499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31486,7 +31514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31501,7 +31529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31515,7 +31543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31529,7 +31557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31543,7 +31571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -31618,7 +31646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -31675,7 +31703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -31732,7 +31760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -31789,7 +31817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -31842,7 +31870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -31857,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -32015,7 +32043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -32048,7 +32076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -32081,7 +32109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -32114,7 +32142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -32153,7 +32181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -32173,7 +32201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32268,7 +32296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32297,7 +32325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32312,7 +32340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32327,7 +32355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32342,7 +32370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32357,7 +32385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -32391,7 +32419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32532,7 +32560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32581,7 +32609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32649,7 +32677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32663,7 +32691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32695,7 +32723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32818,7 +32846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32923,7 +32951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33028,7 +33056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33133,7 +33161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33148,7 +33176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33163,7 +33191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33195,7 +33223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33227,7 +33255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -33259,7 +33287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33287,7 +33315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33335,7 +33363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -33392,7 +33420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -33501,7 +33529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -33552,7 +33580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -33603,7 +33631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33654,7 +33682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -33705,7 +33733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -33720,7 +33748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -33735,7 +33763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -33749,7 +33777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -33794,7 +33822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -34604,6 +34632,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -34654,7 +34700,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -34695,80 +34787,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34866,12 +34884,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -34881,6 +34893,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34916,46 +34940,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -34984,6 +34968,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35037,7 +35039,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -35084,134 +35132,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35303,30 +35223,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -35336,6 +35232,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35371,64 +35279,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -35457,6 +35307,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35510,7 +35378,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -35557,134 +35471,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35776,30 +35562,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -35809,6 +35571,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35844,64 +35618,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -35930,6 +35646,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -36007,7 +35741,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -36054,140 +35840,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -36285,30 +35937,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -36318,6 +35946,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -36348,64 +35988,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -37088,7 +36670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -37179,7 +36761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -37332,7 +36914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -37383,7 +36965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -37476,7 +37058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37629,7 +37211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37782,7 +37364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37935,7 +37517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -38063,7 +37645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -38092,7 +37674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -38264,7 +37846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -38429,9 +38011,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38595,9 +38177,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38761,9 +38343,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38927,7 +38509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -38986,9 +38568,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39046,9 +38628,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39106,9 +38688,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39166,7 +38748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -39231,9 +38813,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39297,9 +38879,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39363,9 +38945,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39429,7 +39011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -39530,9 +39112,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -39638,9 +39220,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -39740,9 +39322,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -39842,7 +39424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -39943,9 +39525,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40051,9 +39633,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40153,9 +39735,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40255,7 +39837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -40344,9 +39926,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40434,9 +40016,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40524,9 +40106,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40618,7 +40200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -40632,7 +40214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -40646,7 +40228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40708,7 +40290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40753,7 +40335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -40808,7 +40390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -40917,43 +40499,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40961,7 +40543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -41012,7 +40594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -41061,43 +40643,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -41105,7 +40687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -41214,43 +40796,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -41258,7 +40840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -41367,43 +40949,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -41411,7 +40993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -41520,43 +41102,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -41564,7 +41146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -41680,7 +41262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -41706,7 +41288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -41738,7 +41320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -41770,7 +41352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -41792,7 +41374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -41952,9 +41534,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -42119,7 +41701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -42268,9 +41850,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42418,9 +42000,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42568,9 +42150,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42718,7 +42300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -42771,9 +42353,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42825,9 +42407,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42879,9 +42461,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42933,7 +42515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -42998,9 +42580,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43064,9 +42646,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43130,9 +42712,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43196,7 +42778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -43285,9 +42867,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43375,9 +42957,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43465,9 +43047,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43555,7 +43137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -43638,9 +43220,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43722,9 +43304,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43806,9 +43388,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43890,7 +43472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -43973,9 +43555,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44057,9 +43639,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44141,9 +43723,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44225,7 +43807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -44247,7 +43829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -44297,7 +43879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44311,7 +43893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44325,7 +43907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44387,7 +43969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44432,7 +44014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -44489,7 +44071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -44534,7 +44116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -44549,7 +44131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -44585,7 +44167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -44616,7 +44198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -44662,7 +44244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -44691,7 +44273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -44741,7 +44323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -44781,7 +44363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -44808,7 +44390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -44846,7 +44428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -44878,7 +44460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -45031,7 +44613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45184,7 +44766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -45337,7 +44919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -45490,7 +45072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -45643,7 +45225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -45796,7 +45378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -45949,7 +45531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -46101,7 +45683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -46253,7 +45835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -46406,7 +45988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -46559,7 +46141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -46712,7 +46294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -46865,7 +46447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -47024,7 +46606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47075,7 +46657,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47126,7 +46708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47177,7 +46759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47228,7 +46810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -47242,7 +46824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -47256,7 +46838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -47276,7 +46858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -47370,7 +46952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -47384,7 +46966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -47398,7 +46980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -47881,7 +47463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -47901,7 +47483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -47915,7 +47497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -47943,7 +47525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -49832,6 +49414,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV70J20.svd
+++ b/data/Atmel/ATSAMV70J20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3152,7 +3152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3186,7 +3186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3297,7 +3297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3519,7 +3519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3596,7 +3596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3650,7 +3650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3683,7 +3683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3716,7 +3716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3749,7 +3749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3769,7 +3769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3797,7 +3797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4162,7 +4162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4201,7 +4201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4251,7 +4251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4314,7 +4314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4360,7 +4360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4374,7 +4374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4631,7 +4631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4651,7 +4651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4716,7 +4716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4914,7 +4914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5067,7 +5067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5220,7 +5220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5373,7 +5373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5421,7 +5421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5453,7 +5453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5481,7 +5481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5504,7 +5504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5537,7 +5537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5611,7 +5611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5656,7 +5656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5683,7 +5683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5734,7 +5734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5785,7 +5785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5887,7 +5887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5930,7 +5930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5944,7 +5944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5994,7 +5994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6092,7 +6092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6200,7 +6200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6234,7 +6234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6266,7 +6266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6330,7 +6330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6362,7 +6362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6394,7 +6394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6427,7 +6427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6508,7 +6508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6571,7 +6571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6697,7 +6697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6718,7 +6718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6739,7 +6739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6760,7 +6760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6774,7 +6774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6806,7 +6806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6820,7 +6820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6834,7 +6834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6866,7 +6866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6880,7 +6880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6946,7 +6946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7005,7 +7005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7055,7 +7055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7138,7 +7138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7308,7 +7308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7336,7 +7336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7380,7 +7380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7425,7 +7425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7454,7 +7454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7511,7 +7511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7579,7 +7579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7599,7 +7599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7812,7 +7812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7844,7 +7844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7882,7 +7882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7958,7 +7958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7972,7 +7972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8005,7 +8005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8134,7 +8134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8510,7 +8510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8698,7 +8698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -8718,7 +8718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -8802,7 +8802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -8822,7 +8822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -8842,7 +8842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -8856,7 +8856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -8912,7 +8912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -9112,7 +9112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -9312,7 +9312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -9383,7 +9383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -9397,7 +9397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -9411,7 +9411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -9511,7 +9511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -9525,7 +9525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -9712,7 +9712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -9802,7 +9802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -10003,7 +10003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10203,7 +10203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -10403,7 +10403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -10604,7 +10604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -11005,7 +11005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11205,7 +11205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -11231,7 +11231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -11270,7 +11270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -11303,7 +11303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -11409,7 +11409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -11423,7 +11423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -11437,7 +11437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -11481,7 +11481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -11514,7 +11514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -11612,7 +11612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -11638,7 +11638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -11666,7 +11666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -11682,7 +11682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -11699,7 +11699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -11716,7 +11716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11732,7 +11732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -11746,7 +11746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -11760,7 +11760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -11799,7 +11799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -11846,7 +11846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -11862,7 +11862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -11895,7 +11895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -12096,7 +12096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -12297,7 +12297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -12498,7 +12498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -12699,7 +12699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -12900,7 +12900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -13101,7 +13101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -13302,7 +13302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -13503,7 +13503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -13704,7 +13704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -13905,7 +13905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -14106,7 +14106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -14306,7 +14306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -14507,7 +14507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -14708,7 +14708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -14909,7 +14909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -15110,7 +15110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -15311,7 +15311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -15512,7 +15512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -15713,7 +15713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -15914,7 +15914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16115,7 +16115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16316,7 +16316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -16519,7 +16519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -16719,7 +16719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -16920,7 +16920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -17121,7 +17121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -17322,7 +17322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -17336,7 +17336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -17537,7 +17537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -17738,7 +17738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -17939,7 +17939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -18140,7 +18140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -18341,7 +18341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -18542,7 +18542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -18743,7 +18743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -18944,7 +18944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -19145,7 +19145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -19346,7 +19346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -19547,7 +19547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -19748,7 +19748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -19949,7 +19949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -20150,7 +20150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -20351,7 +20351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -20552,7 +20552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -20580,7 +20580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -20601,7 +20601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -20801,7 +20801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -21417,7 +21417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -21473,7 +21473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -21506,7 +21506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -21539,7 +21539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -21572,7 +21572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -21593,7 +21593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -21643,7 +21643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -21700,7 +21700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -21757,7 +21757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -21820,7 +21820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -21979,7 +21979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -22138,7 +22138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -22488,7 +22488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -22609,7 +22609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -22631,7 +22631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22679,7 +22679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -22778,7 +22778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -22877,7 +22877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -22994,7 +22994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -23093,7 +23093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -23251,7 +23251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -23355,7 +23355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -23370,7 +23370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23398,7 +23398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23419,7 +23419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -23578,7 +23578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -23737,7 +23737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -23896,7 +23896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -24012,7 +24012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -24171,7 +24171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24330,7 +24330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -24489,7 +24489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -24648,7 +24648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -24662,7 +24662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -24821,7 +24821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -24980,7 +24980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -25139,7 +25139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -25298,7 +25298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -25313,7 +25313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25339,7 +25339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25386,7 +25386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25560,7 +25560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25593,7 +25593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25626,7 +25626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25659,7 +25659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25716,7 +25716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25773,7 +25773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25830,7 +25830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25887,7 +25887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25955,7 +25955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25970,7 +25970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25984,7 +25984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26004,7 +26004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26019,7 +26019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26136,7 +26136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26253,7 +26253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26370,7 +26370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26487,7 +26487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -26543,7 +26543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -26599,7 +26599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -26656,7 +26656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -26713,7 +26713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -26770,7 +26770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -26827,7 +26827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -26853,7 +26853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -26874,7 +26874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -26889,7 +26889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -26945,7 +26945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -26979,7 +26979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27035,7 +27035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27055,7 +27055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27070,7 +27070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27102,7 +27102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27158,7 +27158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27241,7 +27241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27340,7 +27340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27360,7 +27360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27381,7 +27381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27425,7 +27425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27465,7 +27465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27607,7 +27607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27621,7 +27621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27636,7 +27636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27650,7 +27650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -27665,7 +27665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -27680,7 +27680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -27700,7 +27700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -27722,7 +27722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -27743,7 +27743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -27764,7 +27764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -27844,7 +27844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -27882,7 +27882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -27903,7 +27903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -27983,7 +27983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28021,7 +28021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28069,7 +28069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28102,7 +28102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28222,7 +28222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28237,7 +28237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28252,7 +28252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28309,7 +28309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28360,7 +28360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28411,7 +28411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28462,7 +28462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28494,7 +28494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28508,7 +28508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28528,7 +28528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28706,7 +28706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28739,7 +28739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28754,7 +28754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28782,7 +28782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28822,7 +28822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28857,7 +28857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28918,7 +28918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28977,7 +28977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29006,7 +29006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29056,7 +29056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29090,7 +29090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29163,7 +29163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29377,7 +29377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29409,7 +29409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29447,7 +29447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29497,7 +29497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29529,7 +29529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29652,7 +29652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29697,7 +29697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29742,7 +29742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29787,7 +29787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29832,7 +29832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29884,7 +29884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29928,7 +29928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29942,7 +29942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29957,7 +29957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29997,7 +29997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -30036,7 +30036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -30050,7 +30050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30208,7 +30208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30310,7 +30310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30457,7 +30457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30565,7 +30565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30580,7 +30580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30595,7 +30595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30610,7 +30610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30624,7 +30624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30638,7 +30638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30652,7 +30652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30721,7 +30721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30778,7 +30778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30835,7 +30835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30892,7 +30892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30920,7 +30920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30960,7 +30960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31021,7 +31021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31107,7 +31107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31211,7 +31211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31421,7 +31421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31961,7 +31961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32440,7 +32440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32467,7 +32467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32710,7 +32710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32730,7 +32730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32745,7 +32745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -32760,7 +32760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -32774,7 +32774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32788,7 +32788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32802,7 +32802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -32877,7 +32877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -32934,7 +32934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -32991,7 +32991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -33048,7 +33048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -33101,7 +33101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -33116,7 +33116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -33262,7 +33262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -33289,7 +33289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -33316,7 +33316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -33343,7 +33343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -33376,7 +33376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -33396,7 +33396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33424,7 +33424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -33512,7 +33512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33541,7 +33541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33556,7 +33556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33571,7 +33571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33586,7 +33586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33601,7 +33601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -33635,7 +33635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33776,7 +33776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33825,7 +33825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33893,7 +33893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33907,7 +33907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33939,7 +33939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34062,7 +34062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34167,7 +34167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34272,7 +34272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34377,7 +34377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34392,7 +34392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34407,7 +34407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34439,7 +34439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -34471,7 +34471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -34503,7 +34503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34531,7 +34531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34579,7 +34579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -34642,7 +34642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -34751,7 +34751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -34802,7 +34802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -34853,7 +34853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -34904,7 +34904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -34973,7 +34973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -34988,7 +34988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -35003,7 +35003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -35017,7 +35017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -35062,7 +35062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -36621,7 +36621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36712,7 +36712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36865,7 +36865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36916,7 +36916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -37009,7 +37009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37162,7 +37162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37315,7 +37315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37468,7 +37468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37596,7 +37596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37625,7 +37625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -37797,7 +37797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -37962,7 +37962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -38021,7 +38021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -38086,7 +38086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -38187,7 +38187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -38288,7 +38288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -38381,7 +38381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -38395,7 +38395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38409,7 +38409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -38471,7 +38471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -38516,7 +38516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -38571,7 +38571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -38724,7 +38724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -38775,7 +38775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -38868,7 +38868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -39021,7 +39021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -39174,7 +39174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -39327,7 +39327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -39443,7 +39443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -39469,7 +39469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -39501,7 +39501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -39533,7 +39533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -39555,7 +39555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -39715,7 +39715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -39864,7 +39864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -39917,7 +39917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -39982,7 +39982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -40071,7 +40071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -40154,7 +40154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -40237,7 +40237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -40259,7 +40259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -40309,7 +40309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -40323,7 +40323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -40337,7 +40337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40399,7 +40399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40444,7 +40444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -40501,7 +40501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -40546,7 +40546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -40561,7 +40561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -40597,7 +40597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40628,7 +40628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40674,7 +40674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40703,7 +40703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40753,7 +40753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40793,7 +40793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40820,7 +40820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40858,7 +40858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40890,7 +40890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -41043,7 +41043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -41196,7 +41196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -41349,7 +41349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -41502,7 +41502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -41655,7 +41655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -41808,7 +41808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -41961,7 +41961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -42113,7 +42113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -42265,7 +42265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -42418,7 +42418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -42571,7 +42571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -42724,7 +42724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -42877,7 +42877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -43036,7 +43036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43087,7 +43087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43138,7 +43138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43189,7 +43189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43240,7 +43240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -43254,7 +43254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -43268,7 +43268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -43288,7 +43288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -43382,7 +43382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -43396,7 +43396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -43410,7 +43410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -43740,7 +43740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -43760,7 +43760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -43774,7 +43774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -43802,7 +43802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -44002,7 +44002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV70J20B.svd
+++ b/data/Atmel/ATSAMV70J20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4257,7 +4257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4302,7 +4302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4329,7 +4329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4380,7 +4380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4431,7 +4431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4482,7 +4482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4533,7 +4533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4576,7 +4576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4590,7 +4590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4606,7 +4606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -4640,7 +4640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4738,7 +4738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4846,7 +4846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4866,7 +4866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4880,7 +4880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4912,7 +4912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4944,7 +4944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4976,7 +4976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5008,7 +5008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5040,7 +5040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5073,7 +5073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5154,7 +5154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5217,7 +5217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5280,7 +5280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5343,7 +5343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5364,7 +5364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -5385,7 +5385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5406,7 +5406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5420,7 +5420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5452,7 +5452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5480,7 +5480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5512,7 +5512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -5526,7 +5526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5554,7 +5554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5592,7 +5592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -5651,7 +5651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -5701,7 +5701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5757,7 +5757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5784,7 +5784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -6000,7 +6000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -6072,7 +6072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6117,7 +6117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6132,7 +6132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6146,7 +6146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6197,7 +6197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6259,7 +6259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6279,7 +6279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6488,7 +6488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6520,7 +6520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6558,7 +6558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6572,7 +6572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6648,7 +6648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6681,7 +6681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6822,7 +6822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6842,7 +6842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7018,7 +7018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7194,7 +7194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -7390,7 +7390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -7474,7 +7474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -7494,7 +7494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -7514,7 +7514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -7528,7 +7528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -7584,7 +7584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -7784,7 +7784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -7984,7 +7984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -8016,7 +8016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -8055,7 +8055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -8069,7 +8069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -8083,7 +8083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -8115,7 +8115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -8183,7 +8183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -8197,7 +8197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -8352,7 +8352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -8384,7 +8384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -8417,7 +8417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -8474,7 +8474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -8675,7 +8675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -8875,7 +8875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -9075,7 +9075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -9276,7 +9276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -9477,7 +9477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -9677,7 +9677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -9877,7 +9877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -9903,7 +9903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -9942,7 +9942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -9975,7 +9975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -10081,7 +10081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -10095,7 +10095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -10109,7 +10109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -10153,7 +10153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -10186,7 +10186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -10284,7 +10284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -10310,7 +10310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -10338,7 +10338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -10354,7 +10354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -10371,7 +10371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -10388,7 +10388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -10404,7 +10404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10418,7 +10418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -10432,7 +10432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -10471,7 +10471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -10518,7 +10518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -10534,7 +10534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -10567,7 +10567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -10768,7 +10768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -10969,7 +10969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -11170,7 +11170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -11371,7 +11371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -11572,7 +11572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -11773,7 +11773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -11974,7 +11974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -12175,7 +12175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -12376,7 +12376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -12577,7 +12577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -12778,7 +12778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -12978,7 +12978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -13179,7 +13179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -13380,7 +13380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -13581,7 +13581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -13782,7 +13782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -13983,7 +13983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -14184,7 +14184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -14385,7 +14385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -14586,7 +14586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -14787,7 +14787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -14988,7 +14988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -15191,7 +15191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -15391,7 +15391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -15592,7 +15592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -15793,7 +15793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -15994,7 +15994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -16008,7 +16008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -16209,7 +16209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -16410,7 +16410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -16611,7 +16611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -16812,7 +16812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -17013,7 +17013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -17214,7 +17214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -17415,7 +17415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -17616,7 +17616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -17817,7 +17817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -18018,7 +18018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -18219,7 +18219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -18420,7 +18420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -18621,7 +18621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -18822,7 +18822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -19023,7 +19023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -19224,7 +19224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19252,7 +19252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19273,7 +19273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -19473,7 +19473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20089,7 +20089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -20145,7 +20145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -20178,7 +20178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -20211,7 +20211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -20244,7 +20244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -20265,7 +20265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -20315,7 +20315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -20378,7 +20378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -20441,7 +20441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -20510,7 +20510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -20633,7 +20633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -20756,7 +20756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -21070,7 +21070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -21191,7 +21191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -21213,7 +21213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -21261,7 +21261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -21366,7 +21366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -21471,7 +21471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -21594,7 +21594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -21699,7 +21699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -21857,7 +21857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -21961,7 +21961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -21976,7 +21976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -22004,7 +22004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -22025,7 +22025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22160,7 +22160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -22295,7 +22295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -22430,7 +22430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -22502,7 +22502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -22546,7 +22546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -22669,7 +22669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -22792,7 +22792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -22915,7 +22915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -23038,7 +23038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -23052,7 +23052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -23187,7 +23187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -23322,7 +23322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -23457,7 +23457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -23592,7 +23592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -23626,7 +23626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -23800,7 +23800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -23833,7 +23833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -23866,7 +23866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -23899,7 +23899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -23956,7 +23956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -24013,7 +24013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -24070,7 +24070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -24127,7 +24127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -24195,7 +24195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -24210,7 +24210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -24224,7 +24224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -24244,7 +24244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -24259,7 +24259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -24376,7 +24376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -24493,7 +24493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -24610,7 +24610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24727,7 +24727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -24783,7 +24783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -24839,7 +24839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -24896,7 +24896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -24953,7 +24953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -25010,7 +25010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -25067,7 +25067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -25093,7 +25093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -25114,7 +25114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -25129,7 +25129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -25185,7 +25185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -25219,7 +25219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -25275,7 +25275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -25295,7 +25295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -25310,7 +25310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -25342,7 +25342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -25398,7 +25398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -25481,7 +25481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -25580,7 +25580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -25613,7 +25613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -25634,7 +25634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -25678,7 +25678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -25718,7 +25718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -25912,7 +25912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -25926,7 +25926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -25941,7 +25941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -25955,7 +25955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -25970,7 +25970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -25985,7 +25985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -26005,7 +26005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -26027,7 +26027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -26048,7 +26048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -26069,7 +26069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -26149,7 +26149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -26187,7 +26187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -26208,7 +26208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -26288,7 +26288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -26326,7 +26326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -26374,7 +26374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26407,7 +26407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26527,7 +26527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26542,7 +26542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26557,7 +26557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26614,7 +26614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26665,7 +26665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26716,7 +26716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26767,7 +26767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26799,7 +26799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26813,7 +26813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26833,7 +26833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27011,7 +27011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27044,7 +27044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27059,7 +27059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27087,7 +27087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27127,7 +27127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27162,7 +27162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27223,7 +27223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27282,7 +27282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27311,7 +27311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27361,7 +27361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27395,7 +27395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27468,7 +27468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27682,7 +27682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27714,7 +27714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27752,7 +27752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27802,7 +27802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27834,7 +27834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27957,7 +27957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28002,7 +28002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28047,7 +28047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28092,7 +28092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -28137,7 +28137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -28189,7 +28189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28233,7 +28233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28247,7 +28247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28262,7 +28262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28302,7 +28302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -28341,7 +28341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -28355,7 +28355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28513,7 +28513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28615,7 +28615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28762,7 +28762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28870,7 +28870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28885,7 +28885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -28900,7 +28900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28915,7 +28915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28929,7 +28929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28943,7 +28943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -28957,7 +28957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29026,7 +29026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29083,7 +29083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -29140,7 +29140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -29197,7 +29197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29225,7 +29225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29256,7 +29256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -29265,7 +29265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29326,7 +29326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29412,7 +29412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29516,7 +29516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29726,7 +29726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30266,7 +30266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30711,6 +30711,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -30745,7 +30773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30772,7 +30800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31015,9 +31043,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -31451,7 +31479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31471,7 +31499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31486,7 +31514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31501,7 +31529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31515,7 +31543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31529,7 +31557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31543,7 +31571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -31618,7 +31646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -31675,7 +31703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -31732,7 +31760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -31789,7 +31817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -31842,7 +31870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -31857,7 +31885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -32015,7 +32043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -32048,7 +32076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -32081,7 +32109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -32114,7 +32142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -32153,7 +32181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -32173,7 +32201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32268,7 +32296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32297,7 +32325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32312,7 +32340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32327,7 +32355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32342,7 +32370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32357,7 +32385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -32391,7 +32419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32532,7 +32560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32581,7 +32609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32649,7 +32677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32663,7 +32691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32695,7 +32723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32818,7 +32846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32923,7 +32951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33028,7 +33056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33133,7 +33161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33148,7 +33176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33163,7 +33191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33195,7 +33223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33227,7 +33255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -33259,7 +33287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33287,7 +33315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33335,7 +33363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -33392,7 +33420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -33501,7 +33529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -33552,7 +33580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -33603,7 +33631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -33654,7 +33682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -33705,7 +33733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -33720,7 +33748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -33735,7 +33763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -33749,7 +33777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -33794,7 +33822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -34604,6 +34632,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -34654,7 +34700,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -34695,80 +34787,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34866,12 +34884,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -34881,6 +34893,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -34916,46 +34940,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -34984,6 +34968,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35037,7 +35039,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -35084,134 +35132,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35303,30 +35223,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -35336,6 +35232,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35371,64 +35279,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -35457,6 +35307,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35510,7 +35378,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -35557,134 +35471,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35776,30 +35562,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -35809,6 +35571,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -35844,64 +35618,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -35930,6 +35646,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -36007,7 +35741,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -36054,140 +35840,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -36285,30 +35937,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -36318,6 +35946,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -36348,64 +35988,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -37088,7 +36670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -37179,7 +36761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -37332,7 +36914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -37383,7 +36965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -37476,7 +37058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37629,7 +37211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37782,7 +37364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37935,7 +37517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -38063,7 +37645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -38092,7 +37674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -38264,7 +37846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -38429,9 +38011,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38595,9 +38177,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38761,9 +38343,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -38927,7 +38509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -38986,9 +38568,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39046,9 +38628,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39106,9 +38688,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39166,7 +38748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -39231,9 +38813,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39297,9 +38879,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39363,9 +38945,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -39429,7 +39011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -39530,9 +39112,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -39638,9 +39220,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -39740,9 +39322,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -39842,7 +39424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -39943,9 +39525,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40051,9 +39633,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40153,9 +39735,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40255,7 +39837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -40344,9 +39926,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40434,9 +40016,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40524,9 +40106,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -40618,7 +40200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -40632,7 +40214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -40646,7 +40228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40708,7 +40290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40753,7 +40335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -40808,7 +40390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -40917,43 +40499,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -40961,7 +40543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -41012,7 +40594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -41061,43 +40643,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -41105,7 +40687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -41214,43 +40796,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -41258,7 +40840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -41367,43 +40949,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -41411,7 +40993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -41520,43 +41102,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -41564,7 +41146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -41680,7 +41262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -41706,7 +41288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -41738,7 +41320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -41770,7 +41352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -41792,7 +41374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -41952,9 +41534,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -42119,7 +41701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -42268,9 +41850,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42418,9 +42000,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42568,9 +42150,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42718,7 +42300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -42771,9 +42353,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42825,9 +42407,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42879,9 +42461,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42933,7 +42515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -42998,9 +42580,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43064,9 +42646,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43130,9 +42712,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43196,7 +42778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -43285,9 +42867,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43375,9 +42957,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43465,9 +43047,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43555,7 +43137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -43638,9 +43220,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43722,9 +43304,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43806,9 +43388,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43890,7 +43472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -43973,9 +43555,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44057,9 +43639,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44141,9 +43723,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44225,7 +43807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -44247,7 +43829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -44297,7 +43879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44311,7 +43893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44325,7 +43907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44387,7 +43969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44432,7 +44014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -44489,7 +44071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -44534,7 +44116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -44549,7 +44131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -44585,7 +44167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -44616,7 +44198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -44662,7 +44244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -44691,7 +44273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -44741,7 +44323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -44781,7 +44363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -44808,7 +44390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -44846,7 +44428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -44878,7 +44460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -45031,7 +44613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45184,7 +44766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -45337,7 +44919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -45490,7 +45072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -45643,7 +45225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -45796,7 +45378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -45949,7 +45531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -46101,7 +45683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -46253,7 +45835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -46406,7 +45988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -46559,7 +46141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -46712,7 +46294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -46865,7 +46447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -47024,7 +46606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47075,7 +46657,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47126,7 +46708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47177,7 +46759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47228,7 +46810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -47242,7 +46824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -47256,7 +46838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -47276,7 +46858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -47370,7 +46952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -47384,7 +46966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -47398,7 +46980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -47881,7 +47463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -47901,7 +47483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -47915,7 +47497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -47943,7 +47525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -48143,7 +47725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -50032,6 +49614,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV70N19.svd
+++ b/data/Atmel/ATSAMV70N19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3152,7 +3152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3186,7 +3186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3297,7 +3297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3519,7 +3519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3596,7 +3596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3650,7 +3650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3683,7 +3683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3716,7 +3716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3749,7 +3749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3769,7 +3769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3797,7 +3797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4162,7 +4162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4201,7 +4201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4251,7 +4251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4314,7 +4314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4360,7 +4360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4374,7 +4374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4631,7 +4631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4651,7 +4651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4716,7 +4716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4914,7 +4914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5067,7 +5067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5220,7 +5220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5373,7 +5373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5421,7 +5421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5453,7 +5453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5481,7 +5481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5504,7 +5504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5537,7 +5537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5611,7 +5611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5656,7 +5656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5683,7 +5683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5734,7 +5734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5785,7 +5785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5887,7 +5887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5930,7 +5930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5944,7 +5944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5994,7 +5994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6092,7 +6092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6200,7 +6200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6234,7 +6234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6266,7 +6266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6330,7 +6330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6362,7 +6362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6394,7 +6394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6427,7 +6427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6508,7 +6508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6571,7 +6571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6697,7 +6697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6718,7 +6718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6739,7 +6739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6760,7 +6760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6774,7 +6774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6806,7 +6806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6820,7 +6820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6834,7 +6834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6866,7 +6866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6880,7 +6880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6946,7 +6946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7005,7 +7005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7055,7 +7055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7138,7 +7138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7308,7 +7308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7336,7 +7336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7380,7 +7380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7425,7 +7425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7454,7 +7454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7511,7 +7511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7579,7 +7579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7599,7 +7599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7812,7 +7812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7844,7 +7844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7882,7 +7882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7958,7 +7958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7972,7 +7972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8005,7 +8005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8134,7 +8134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8510,7 +8510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8698,7 +8698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -8718,7 +8718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -8802,7 +8802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -8822,7 +8822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -8842,7 +8842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -8856,7 +8856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -8912,7 +8912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -9112,7 +9112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -9312,7 +9312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -9383,7 +9383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -9397,7 +9397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -9411,7 +9411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -9511,7 +9511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -9525,7 +9525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -9712,7 +9712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -9802,7 +9802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -10003,7 +10003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10203,7 +10203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -10403,7 +10403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -10604,7 +10604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -11005,7 +11005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11205,7 +11205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -11231,7 +11231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -11270,7 +11270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -11303,7 +11303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -11409,7 +11409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -11423,7 +11423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -11437,7 +11437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -11481,7 +11481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -11514,7 +11514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -11612,7 +11612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -11638,7 +11638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -11666,7 +11666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -11682,7 +11682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -11699,7 +11699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -11716,7 +11716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11732,7 +11732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -11746,7 +11746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -11760,7 +11760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -11799,7 +11799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -11846,7 +11846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -11862,7 +11862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -11895,7 +11895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -12096,7 +12096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -12297,7 +12297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -12498,7 +12498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -12699,7 +12699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -12900,7 +12900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -13101,7 +13101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -13302,7 +13302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -13503,7 +13503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -13704,7 +13704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -13905,7 +13905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -14106,7 +14106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -14306,7 +14306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -14507,7 +14507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -14708,7 +14708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -14909,7 +14909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -15110,7 +15110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -15311,7 +15311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -15512,7 +15512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -15713,7 +15713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -15914,7 +15914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16115,7 +16115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16316,7 +16316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -16519,7 +16519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -16719,7 +16719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -16920,7 +16920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -17121,7 +17121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -17322,7 +17322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -17336,7 +17336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -17537,7 +17537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -17738,7 +17738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -17939,7 +17939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -18140,7 +18140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -18341,7 +18341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -18542,7 +18542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -18743,7 +18743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -18944,7 +18944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -19145,7 +19145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -19346,7 +19346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -19547,7 +19547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -19748,7 +19748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -19949,7 +19949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -20150,7 +20150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -20351,7 +20351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -20552,7 +20552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -20580,7 +20580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -20601,7 +20601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -20801,7 +20801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -21417,7 +21417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -21473,7 +21473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -21506,7 +21506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -21539,7 +21539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -21572,7 +21572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -21593,7 +21593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -21643,7 +21643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -21700,7 +21700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -21757,7 +21757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -21820,7 +21820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -21979,7 +21979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -22138,7 +22138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -22488,7 +22488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -22609,7 +22609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -22631,7 +22631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22679,7 +22679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -22778,7 +22778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -22877,7 +22877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -22994,7 +22994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -23093,7 +23093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -23251,7 +23251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -23355,7 +23355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -23370,7 +23370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23398,7 +23398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23419,7 +23419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -23578,7 +23578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -23737,7 +23737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -23896,7 +23896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -24012,7 +24012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -24171,7 +24171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24330,7 +24330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -24489,7 +24489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -24648,7 +24648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -24662,7 +24662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -24821,7 +24821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -24980,7 +24980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -25139,7 +25139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -25298,7 +25298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -25313,7 +25313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25339,7 +25339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25386,7 +25386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25560,7 +25560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25593,7 +25593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25626,7 +25626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25659,7 +25659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25716,7 +25716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25773,7 +25773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25830,7 +25830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25887,7 +25887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25955,7 +25955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25970,7 +25970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25984,7 +25984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26004,7 +26004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26019,7 +26019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26136,7 +26136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26253,7 +26253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26370,7 +26370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26487,7 +26487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -26543,7 +26543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -26599,7 +26599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -26656,7 +26656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -26713,7 +26713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -26770,7 +26770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -26827,7 +26827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -26853,7 +26853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -26874,7 +26874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -26889,7 +26889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -26945,7 +26945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -26979,7 +26979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27035,7 +27035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27055,7 +27055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27070,7 +27070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27102,7 +27102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27158,7 +27158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27241,7 +27241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27340,7 +27340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27360,7 +27360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27381,7 +27381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27425,7 +27425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27465,7 +27465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27607,7 +27607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27621,7 +27621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27636,7 +27636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27650,7 +27650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -27665,7 +27665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -27680,7 +27680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -27700,7 +27700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -27722,7 +27722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -27743,7 +27743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -27764,7 +27764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -27844,7 +27844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -27882,7 +27882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -27903,7 +27903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -27983,7 +27983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28021,7 +28021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28069,7 +28069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28102,7 +28102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28222,7 +28222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28237,7 +28237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28252,7 +28252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28309,7 +28309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28360,7 +28360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28411,7 +28411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28462,7 +28462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28494,7 +28494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28508,7 +28508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28528,7 +28528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28706,7 +28706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28739,7 +28739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28754,7 +28754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28782,7 +28782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28822,7 +28822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28857,7 +28857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28918,7 +28918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28977,7 +28977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29006,7 +29006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29056,7 +29056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29090,7 +29090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29163,7 +29163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29377,7 +29377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29409,7 +29409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29447,7 +29447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29497,7 +29497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29529,7 +29529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29652,7 +29652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29697,7 +29697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29742,7 +29742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29787,7 +29787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29832,7 +29832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29884,7 +29884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29928,7 +29928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29942,7 +29942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29957,7 +29957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29997,7 +29997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30060,7 +30060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30116,7 +30116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30137,7 +30137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30164,7 +30164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30221,7 +30221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30272,7 +30272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30323,7 +30323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30376,7 +30376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30480,7 +30480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30508,7 +30508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30548,7 +30548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -30587,7 +30587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -30601,7 +30601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30759,7 +30759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30861,7 +30861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31008,7 +31008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31116,7 +31116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31131,7 +31131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31146,7 +31146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31161,7 +31161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31175,7 +31175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31189,7 +31189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31203,7 +31203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31272,7 +31272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31329,7 +31329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31386,7 +31386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31443,7 +31443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31471,7 +31471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31511,7 +31511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31572,7 +31572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31658,7 +31658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31762,7 +31762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31972,7 +31972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32512,7 +32512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32991,7 +32991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33018,7 +33018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -33261,7 +33261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -33281,7 +33281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -33296,7 +33296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -33311,7 +33311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -33325,7 +33325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -33339,7 +33339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -33353,7 +33353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -33428,7 +33428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -33485,7 +33485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -33542,7 +33542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -33599,7 +33599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -33652,7 +33652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -33667,7 +33667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -33813,7 +33813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -33840,7 +33840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -33867,7 +33867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -33894,7 +33894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -33927,7 +33927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -33947,7 +33947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33975,7 +33975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34063,7 +34063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34092,7 +34092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34107,7 +34107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34122,7 +34122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34137,7 +34137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34152,7 +34152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -34186,7 +34186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34327,7 +34327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34376,7 +34376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34444,7 +34444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34458,7 +34458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34490,7 +34490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34613,7 +34613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34718,7 +34718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34823,7 +34823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34928,7 +34928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34943,7 +34943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34958,7 +34958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34990,7 +34990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35022,7 +35022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35054,7 +35054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35082,7 +35082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35138,7 +35138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -35201,7 +35201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -35310,7 +35310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -35361,7 +35361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -35412,7 +35412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -35463,7 +35463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -35532,7 +35532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -35547,7 +35547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -35562,7 +35562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -35576,7 +35576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -35621,7 +35621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -37204,7 +37204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -37295,7 +37295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -37448,7 +37448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -37499,7 +37499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -37592,7 +37592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37745,7 +37745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37898,7 +37898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -38051,7 +38051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -38179,7 +38179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -38208,7 +38208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -38380,7 +38380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -38545,7 +38545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -38604,7 +38604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -38669,7 +38669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -38770,7 +38770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -38871,7 +38871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -38964,7 +38964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -38978,7 +38978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38992,7 +38992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39054,7 +39054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39099,7 +39099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -39154,7 +39154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -39307,7 +39307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -39358,7 +39358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -39451,7 +39451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -39604,7 +39604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -39757,7 +39757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -39910,7 +39910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -40026,7 +40026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -40052,7 +40052,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -40084,7 +40084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -40116,7 +40116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -40138,7 +40138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -40298,7 +40298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -40447,7 +40447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -40500,7 +40500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -40565,7 +40565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -40654,7 +40654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -40737,7 +40737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -40820,7 +40820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -40842,7 +40842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -40892,7 +40892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -40906,7 +40906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -40920,7 +40920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40982,7 +40982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -41027,7 +41027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -41084,7 +41084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -41129,7 +41129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -41144,7 +41144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -41180,7 +41180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -41211,7 +41211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -41257,7 +41257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -41286,7 +41286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -41336,7 +41336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -41376,7 +41376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -41403,7 +41403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -41441,7 +41441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -41473,7 +41473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -41626,7 +41626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -41779,7 +41779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -41932,7 +41932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -42085,7 +42085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -42238,7 +42238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -42391,7 +42391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -42544,7 +42544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -42696,7 +42696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -42848,7 +42848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43001,7 +43001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -43154,7 +43154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -43307,7 +43307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -43460,7 +43460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -43619,7 +43619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43670,7 +43670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43721,7 +43721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43772,7 +43772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43823,7 +43823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -43837,7 +43837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -43851,7 +43851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -43871,7 +43871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -43965,7 +43965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -43979,7 +43979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -43993,7 +43993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -44323,7 +44323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -44343,7 +44343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -44357,7 +44357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>

--- a/data/Atmel/ATSAMV70N19B.svd
+++ b/data/Atmel/ATSAMV70N19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6079,7 +6079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6153,7 +6153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6198,7 +6198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6225,7 +6225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6276,7 +6276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6327,7 +6327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6378,7 +6378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6429,7 +6429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6472,7 +6472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6486,7 +6486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6502,7 +6502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6536,7 +6536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6742,7 +6742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6762,7 +6762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6776,7 +6776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6808,7 +6808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6840,7 +6840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6872,7 +6872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6904,7 +6904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6936,7 +6936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6969,7 +6969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7050,7 +7050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7113,7 +7113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7176,7 +7176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7239,7 +7239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7260,7 +7260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7281,7 +7281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7302,7 +7302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7316,7 +7316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7348,7 +7348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7362,7 +7362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7376,7 +7376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7408,7 +7408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7450,7 +7450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7488,7 +7488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7547,7 +7547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7597,7 +7597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7653,7 +7653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7686,7 +7686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7914,7 +7914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7942,7 +7942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7986,7 +7986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8031,7 +8031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8046,7 +8046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8060,7 +8060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8111,7 +8111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8173,7 +8173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8193,7 +8193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8402,7 +8402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8434,7 +8434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8472,7 +8472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8486,7 +8486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8548,7 +8548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8562,7 +8562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8595,7 +8595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8736,7 +8736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8756,7 +8756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8932,7 +8932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9108,7 +9108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -9284,7 +9284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -9304,7 +9304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -9388,7 +9388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -9408,7 +9408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -9428,7 +9428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -9442,7 +9442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -9498,7 +9498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -9698,7 +9698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -9898,7 +9898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -9930,7 +9930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -9969,7 +9969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -9983,7 +9983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -9997,7 +9997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -10029,7 +10029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -10097,7 +10097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -10111,7 +10111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -10266,7 +10266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -10298,7 +10298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -10331,7 +10331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -10388,7 +10388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -10589,7 +10589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10789,7 +10789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -10989,7 +10989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -11190,7 +11190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -11391,7 +11391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -11591,7 +11591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11791,7 +11791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -11817,7 +11817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -11856,7 +11856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -11901,7 +11901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -12007,7 +12007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -12021,7 +12021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -12035,7 +12035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -12079,7 +12079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -12112,7 +12112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -12210,7 +12210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -12236,7 +12236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -12264,7 +12264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12280,7 +12280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12297,7 +12297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12314,7 +12314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -12330,7 +12330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12344,7 +12344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -12358,7 +12358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -12397,7 +12397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -12444,7 +12444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -12460,7 +12460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -12493,7 +12493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -12694,7 +12694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -12895,7 +12895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -13096,7 +13096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -13297,7 +13297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -13498,7 +13498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -13699,7 +13699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -13900,7 +13900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -14101,7 +14101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -14302,7 +14302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -14503,7 +14503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -14704,7 +14704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -14904,7 +14904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -15105,7 +15105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -15306,7 +15306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -15507,7 +15507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -15708,7 +15708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -15909,7 +15909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -16110,7 +16110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -16311,7 +16311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -16512,7 +16512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16713,7 +16713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16914,7 +16914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17117,7 +17117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -17317,7 +17317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -17518,7 +17518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -17719,7 +17719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -17920,7 +17920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -17934,7 +17934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -18135,7 +18135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -18336,7 +18336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -18537,7 +18537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -18738,7 +18738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -18939,7 +18939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -19140,7 +19140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -19341,7 +19341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -19542,7 +19542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -19743,7 +19743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -19944,7 +19944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -20145,7 +20145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -20346,7 +20346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -20547,7 +20547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -20748,7 +20748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -20949,7 +20949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -21150,7 +21150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -21178,7 +21178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -21199,7 +21199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -21399,7 +21399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -22015,7 +22015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -22071,7 +22071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -22104,7 +22104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -22137,7 +22137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -22170,7 +22170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -22191,7 +22191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -22241,7 +22241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -22304,7 +22304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -22367,7 +22367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -22436,7 +22436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -22577,7 +22577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -22718,7 +22718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -23050,7 +23050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -23171,7 +23171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -23193,7 +23193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -23241,7 +23241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -23346,7 +23346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -23451,7 +23451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -23574,7 +23574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -23679,7 +23679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -23837,7 +23837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -23941,7 +23941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -23956,7 +23956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23984,7 +23984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24005,7 +24005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24152,7 +24152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -24299,7 +24299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -24446,7 +24446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -24518,7 +24518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -24562,7 +24562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -24703,7 +24703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24844,7 +24844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -24985,7 +24985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -25126,7 +25126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -25140,7 +25140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -25287,7 +25287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -25434,7 +25434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -25581,7 +25581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -25728,7 +25728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -25762,7 +25762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25936,7 +25936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25969,7 +25969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26002,7 +26002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26035,7 +26035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26092,7 +26092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26149,7 +26149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26206,7 +26206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26263,7 +26263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26331,7 +26331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26346,7 +26346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26360,7 +26360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26380,7 +26380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26395,7 +26395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26512,7 +26512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26629,7 +26629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26746,7 +26746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26863,7 +26863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -26919,7 +26919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -26975,7 +26975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27032,7 +27032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27089,7 +27089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -27146,7 +27146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -27203,7 +27203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -27229,7 +27229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -27250,7 +27250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -27265,7 +27265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -27321,7 +27321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -27355,7 +27355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27411,7 +27411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27431,7 +27431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27446,7 +27446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27478,7 +27478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27534,7 +27534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27617,7 +27617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27716,7 +27716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27749,7 +27749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27770,7 +27770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27814,7 +27814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27854,7 +27854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28048,7 +28048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28062,7 +28062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28077,7 +28077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28091,7 +28091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28106,7 +28106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28121,7 +28121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28141,7 +28141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28163,7 +28163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -28184,7 +28184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -28205,7 +28205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -28285,7 +28285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -28323,7 +28323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -28344,7 +28344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -28424,7 +28424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28462,7 +28462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28510,7 +28510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28543,7 +28543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28663,7 +28663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28678,7 +28678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28693,7 +28693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28750,7 +28750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28801,7 +28801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28852,7 +28852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28903,7 +28903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28935,7 +28935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28949,7 +28949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28969,7 +28969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29147,7 +29147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29180,7 +29180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29195,7 +29195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29223,7 +29223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29263,7 +29263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29298,7 +29298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29359,7 +29359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29418,7 +29418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29447,7 +29447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29497,7 +29497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29531,7 +29531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29604,7 +29604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29818,7 +29818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29850,7 +29850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29888,7 +29888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29938,7 +29938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29970,7 +29970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30093,7 +30093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30138,7 +30138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30183,7 +30183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30228,7 +30228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30273,7 +30273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30325,7 +30325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30369,7 +30369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30383,7 +30383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30398,7 +30398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30438,7 +30438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30477,7 +30477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30569,7 +30569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30590,7 +30590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30640,7 +30640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30697,7 +30697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30748,7 +30748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30799,7 +30799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30852,7 +30852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30885,12 +30885,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -30982,7 +30982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31010,7 +31010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31050,7 +31050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -31089,7 +31089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -31103,7 +31103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31261,7 +31261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31363,7 +31363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31510,7 +31510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31618,7 +31618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31633,7 +31633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31648,7 +31648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31663,7 +31663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31677,7 +31677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31691,7 +31691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31705,7 +31705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31774,7 +31774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31831,7 +31831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31888,7 +31888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31945,7 +31945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31973,7 +31973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32004,7 +32004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -32013,7 +32013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32074,7 +32074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32160,7 +32160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32264,7 +32264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32474,7 +32474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33014,7 +33014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33459,6 +33459,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -33493,7 +33521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33520,7 +33548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -33763,9 +33791,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -34199,7 +34227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34219,7 +34247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34234,7 +34262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34249,7 +34277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34263,7 +34291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34277,7 +34305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34291,7 +34319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34366,7 +34394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34423,7 +34451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34480,7 +34508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -34537,7 +34565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -34590,7 +34618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -34605,7 +34633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -34763,7 +34791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -34796,7 +34824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -34829,7 +34857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -34862,7 +34890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -34901,7 +34929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -34921,7 +34949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35016,7 +35044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35045,7 +35073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35060,7 +35088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35075,7 +35103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35090,7 +35118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35105,7 +35133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35139,7 +35167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35280,7 +35308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35329,7 +35357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35397,7 +35425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35411,7 +35439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35443,7 +35471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35566,7 +35594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35671,7 +35699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35776,7 +35804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35881,7 +35909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35896,7 +35924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35911,7 +35939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35943,7 +35971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35975,7 +36003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36007,7 +36035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36035,7 +36063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36091,7 +36119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36148,7 +36176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36257,7 +36285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36308,7 +36336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36359,7 +36387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36410,7 +36438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36461,7 +36489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36476,7 +36504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36491,7 +36519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36505,7 +36533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -36550,7 +36578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -37376,6 +37404,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -37426,7 +37472,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -37467,80 +37559,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37638,12 +37656,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -37653,6 +37665,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37688,46 +37712,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -37756,6 +37740,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37809,7 +37811,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -37856,134 +37904,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38075,30 +37995,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -38108,6 +38004,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38143,64 +38051,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -38229,6 +38079,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38282,7 +38150,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -38329,134 +38243,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38548,30 +38334,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -38581,6 +38343,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38616,64 +38390,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -38702,6 +38418,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38779,7 +38513,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -38826,140 +38612,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39057,30 +38709,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -39090,6 +38718,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39120,64 +38760,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -39868,7 +39450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39959,7 +39541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -40112,7 +39694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40163,7 +39745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40256,7 +39838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40409,7 +39991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40562,7 +40144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40715,7 +40297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40843,7 +40425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40872,7 +40454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -41044,7 +40626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -41209,9 +40791,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41375,9 +40957,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41541,9 +41123,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41707,7 +41289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -41766,9 +41348,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41826,9 +41408,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41886,9 +41468,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41946,7 +41528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -42011,9 +41593,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42077,9 +41659,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42143,9 +41725,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42209,7 +41791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42310,9 +41892,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42418,9 +42000,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42520,9 +42102,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42622,7 +42204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -42723,9 +42305,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42831,9 +42413,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42933,9 +42515,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43035,7 +42617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43124,9 +42706,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43214,9 +42796,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43304,9 +42886,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43398,7 +42980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43412,7 +42994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43426,7 +43008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43488,7 +43070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43533,7 +43115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43588,7 +43170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43697,43 +43279,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43741,7 +43323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43792,7 +43374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43841,43 +43423,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43885,7 +43467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -43994,43 +43576,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44038,7 +43620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44147,43 +43729,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44191,7 +43773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44300,43 +43882,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44344,7 +43926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44460,7 +44042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44486,7 +44068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44518,7 +44100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44550,7 +44132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44572,7 +44154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44732,9 +44314,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -44899,7 +44481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45048,9 +44630,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45198,9 +44780,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45348,9 +44930,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45498,7 +45080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45551,9 +45133,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45605,9 +45187,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45659,9 +45241,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45713,7 +45295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45778,9 +45360,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45844,9 +45426,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45910,9 +45492,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45976,7 +45558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -46065,9 +45647,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46155,9 +45737,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46245,9 +45827,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46335,7 +45917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46418,9 +46000,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46502,9 +46084,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46586,9 +46168,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46670,7 +46252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -46753,9 +46335,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46837,9 +46419,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46921,9 +46503,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47005,7 +46587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -47027,7 +46609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -47077,7 +46659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47091,7 +46673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47105,7 +46687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47167,7 +46749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47212,7 +46794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47269,7 +46851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47314,7 +46896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47329,7 +46911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47365,7 +46947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47396,7 +46978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47442,7 +47024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47471,7 +47053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47521,7 +47103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47561,7 +47143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47588,7 +47170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47626,7 +47208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47658,7 +47240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -47811,7 +47393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47964,7 +47546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -48117,7 +47699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48270,7 +47852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48423,7 +48005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -48576,7 +48158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -48729,7 +48311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -48881,7 +48463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -49033,7 +48615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49186,7 +48768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49339,7 +48921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49492,7 +49074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -49645,7 +49227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -49804,7 +49386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49855,7 +49437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -49906,7 +49488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -49957,7 +49539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50008,7 +49590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -50022,7 +49604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -50036,7 +49618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -50056,7 +49638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -50150,7 +49732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50164,7 +49746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50178,7 +49760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -50741,7 +50323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -50761,7 +50343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -50775,7 +50357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -50803,7 +50385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -52692,6 +52274,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV70N20.svd
+++ b/data/Atmel/ATSAMV70N20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3152,7 +3152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3511,7 +3511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3550,7 +3550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3600,7 +3600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3663,7 +3663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -3709,7 +3709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3723,7 +3723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3980,7 +3980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4000,7 +4000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4065,7 +4065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4080,7 +4080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4095,7 +4095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4110,7 +4110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4263,7 +4263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -4416,7 +4416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -4569,7 +4569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -4722,7 +4722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -4770,7 +4770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -4802,7 +4802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -4830,7 +4830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4853,7 +4853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -4886,7 +4886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4960,7 +4960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5005,7 +5005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5032,7 +5032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5083,7 +5083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5134,7 +5134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5185,7 +5185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5236,7 +5236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5279,7 +5279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5293,7 +5293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5309,7 +5309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5343,7 +5343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5441,7 +5441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5569,7 +5569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5583,7 +5583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5615,7 +5615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5647,7 +5647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5679,7 +5679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5711,7 +5711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -5776,7 +5776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -5857,7 +5857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -5920,7 +5920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6067,7 +6067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6088,7 +6088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6109,7 +6109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6123,7 +6123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6155,7 +6155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6169,7 +6169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6183,7 +6183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6215,7 +6215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6229,7 +6229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6257,7 +6257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6295,7 +6295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -6354,7 +6354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6404,7 +6404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -6460,7 +6460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -6487,7 +6487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -6657,7 +6657,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -6685,7 +6685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -6729,7 +6729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6774,7 +6774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6789,7 +6789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6803,7 +6803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6860,7 +6860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6928,7 +6928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6948,7 +6948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7161,7 +7161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7193,7 +7193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7231,7 +7231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -7245,7 +7245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7307,7 +7307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7321,7 +7321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7354,7 +7354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7483,7 +7483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7671,7 +7671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7859,7 +7859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8047,7 +8047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -8067,7 +8067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -8151,7 +8151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -8171,7 +8171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -8191,7 +8191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -8205,7 +8205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -8261,7 +8261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -8461,7 +8461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -8661,7 +8661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -8693,7 +8693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -8732,7 +8732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -8746,7 +8746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -8760,7 +8760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -8792,7 +8792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -8860,7 +8860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -8874,7 +8874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -9029,7 +9029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -9061,7 +9061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -9094,7 +9094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -9151,7 +9151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -9352,7 +9352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -9552,7 +9552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -9752,7 +9752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -9953,7 +9953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -10154,7 +10154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -10354,7 +10354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10554,7 +10554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -10580,7 +10580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -10619,7 +10619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -10664,7 +10664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -10770,7 +10770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -10784,7 +10784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -10798,7 +10798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -10842,7 +10842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -10875,7 +10875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -10973,7 +10973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -10999,7 +10999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -11027,7 +11027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -11043,7 +11043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -11060,7 +11060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -11077,7 +11077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11093,7 +11093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -11107,7 +11107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -11121,7 +11121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -11160,7 +11160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -11207,7 +11207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -11223,7 +11223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -11256,7 +11256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -11457,7 +11457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -11658,7 +11658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -11859,7 +11859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -12060,7 +12060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -12261,7 +12261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -12462,7 +12462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -12663,7 +12663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -12864,7 +12864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -13065,7 +13065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -13266,7 +13266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -13467,7 +13467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -13667,7 +13667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -13868,7 +13868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -14069,7 +14069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -14270,7 +14270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -14471,7 +14471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -14672,7 +14672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -14873,7 +14873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -15074,7 +15074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -15275,7 +15275,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -15476,7 +15476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -15677,7 +15677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -15880,7 +15880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -16080,7 +16080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -16281,7 +16281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -16482,7 +16482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -16683,7 +16683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -16697,7 +16697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -16898,7 +16898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -17099,7 +17099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -17300,7 +17300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -17501,7 +17501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -17702,7 +17702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -17903,7 +17903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -18104,7 +18104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -18305,7 +18305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -18506,7 +18506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -18707,7 +18707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -18908,7 +18908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -19109,7 +19109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -19310,7 +19310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -19511,7 +19511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -19712,7 +19712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -19913,7 +19913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -19941,7 +19941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -19962,7 +19962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -20162,7 +20162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -20778,7 +20778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -20834,7 +20834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -20867,7 +20867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -20900,7 +20900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -20933,7 +20933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -20954,7 +20954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -21004,7 +21004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -21061,7 +21061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -21118,7 +21118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -21181,7 +21181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -21340,7 +21340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -21499,7 +21499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -21849,7 +21849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -21970,7 +21970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -21992,7 +21992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22040,7 +22040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -22139,7 +22139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -22238,7 +22238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -22355,7 +22355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -22454,7 +22454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -22612,7 +22612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -22716,7 +22716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -22731,7 +22731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -22759,7 +22759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -22780,7 +22780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22939,7 +22939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -23098,7 +23098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -23257,7 +23257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -23329,7 +23329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -23373,7 +23373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -23532,7 +23532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -23691,7 +23691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -23850,7 +23850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -24009,7 +24009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -24023,7 +24023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -24182,7 +24182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -24341,7 +24341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -24500,7 +24500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -24659,7 +24659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -24674,7 +24674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -24700,7 +24700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -24747,7 +24747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -24921,7 +24921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -24954,7 +24954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -24987,7 +24987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25020,7 +25020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25077,7 +25077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25134,7 +25134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25191,7 +25191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25248,7 +25248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25316,7 +25316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25331,7 +25331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -25345,7 +25345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -25365,7 +25365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -25380,7 +25380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -25497,7 +25497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -25614,7 +25614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -25731,7 +25731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -25848,7 +25848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -25904,7 +25904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -25960,7 +25960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -26017,7 +26017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -26074,7 +26074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -26131,7 +26131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -26188,7 +26188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -26214,7 +26214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -26235,7 +26235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -26250,7 +26250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -26306,7 +26306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -26340,7 +26340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -26396,7 +26396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -26416,7 +26416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -26431,7 +26431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -26463,7 +26463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -26519,7 +26519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -26602,7 +26602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -26701,7 +26701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26721,7 +26721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26742,7 +26742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26786,7 +26786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -26826,7 +26826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -26968,7 +26968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -26982,7 +26982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -26997,7 +26997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27011,7 +27011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -27026,7 +27026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -27041,7 +27041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -27061,7 +27061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -27083,7 +27083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -27104,7 +27104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -27125,7 +27125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -27205,7 +27205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -27243,7 +27243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -27264,7 +27264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -27344,7 +27344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -27382,7 +27382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -27430,7 +27430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27463,7 +27463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27583,7 +27583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27598,7 +27598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27613,7 +27613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27670,7 +27670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27721,7 +27721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27772,7 +27772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27823,7 +27823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27855,7 +27855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27869,7 +27869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -27889,7 +27889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28067,7 +28067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28100,7 +28100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28115,7 +28115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28143,7 +28143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28183,7 +28183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28218,7 +28218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28279,7 +28279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28338,7 +28338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28367,7 +28367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28417,7 +28417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28451,7 +28451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28524,7 +28524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28738,7 +28738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28770,7 +28770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28808,7 +28808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28858,7 +28858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28890,7 +28890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29013,7 +29013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29058,7 +29058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29103,7 +29103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29148,7 +29148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29193,7 +29193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29245,7 +29245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29289,7 +29289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29303,7 +29303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29318,7 +29318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29358,7 +29358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29421,7 +29421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29477,7 +29477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29498,7 +29498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29525,7 +29525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29582,7 +29582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29633,7 +29633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29684,7 +29684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29737,7 +29737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29841,7 +29841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29869,7 +29869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29909,7 +29909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -29948,7 +29948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -29962,7 +29962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30120,7 +30120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30222,7 +30222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30369,7 +30369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30477,7 +30477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30492,7 +30492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30507,7 +30507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30522,7 +30522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30536,7 +30536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30550,7 +30550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30564,7 +30564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30633,7 +30633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30690,7 +30690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30747,7 +30747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30804,7 +30804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30832,7 +30832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30872,7 +30872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30933,7 +30933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31019,7 +31019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31123,7 +31123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31333,7 +31333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31873,7 +31873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32352,7 +32352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32379,7 +32379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32622,7 +32622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32642,7 +32642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32657,7 +32657,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -32672,7 +32672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -32686,7 +32686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32700,7 +32700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32714,7 +32714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -32789,7 +32789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -32846,7 +32846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -32903,7 +32903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -32960,7 +32960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -33013,7 +33013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -33028,7 +33028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -33174,7 +33174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -33201,7 +33201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -33228,7 +33228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -33255,7 +33255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -33288,7 +33288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -33308,7 +33308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33336,7 +33336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -33424,7 +33424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33453,7 +33453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33468,7 +33468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33483,7 +33483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33498,7 +33498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33513,7 +33513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -33547,7 +33547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33688,7 +33688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33737,7 +33737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33805,7 +33805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33819,7 +33819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33851,7 +33851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33974,7 +33974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34079,7 +34079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34184,7 +34184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34289,7 +34289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34304,7 +34304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34319,7 +34319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34351,7 +34351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -34383,7 +34383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -34415,7 +34415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34443,7 +34443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34499,7 +34499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -34562,7 +34562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -34671,7 +34671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -34722,7 +34722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -34773,7 +34773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -34824,7 +34824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -34893,7 +34893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -34908,7 +34908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -34923,7 +34923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -34937,7 +34937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -34982,7 +34982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -36565,7 +36565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36656,7 +36656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36809,7 +36809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36860,7 +36860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36953,7 +36953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37106,7 +37106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37259,7 +37259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37412,7 +37412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37540,7 +37540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37569,7 +37569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -37741,7 +37741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -37906,7 +37906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -37965,7 +37965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -38030,7 +38030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -38131,7 +38131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -38232,7 +38232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -38325,7 +38325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -38339,7 +38339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38353,7 +38353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -38415,7 +38415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -38460,7 +38460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -38515,7 +38515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -38668,7 +38668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -38719,7 +38719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -38812,7 +38812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -38965,7 +38965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -39118,7 +39118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -39271,7 +39271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -39387,7 +39387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -39413,7 +39413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -39445,7 +39445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -39477,7 +39477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -39499,7 +39499,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -39659,7 +39659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -39808,7 +39808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -39861,7 +39861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -39926,7 +39926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -40015,7 +40015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -40098,7 +40098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -40181,7 +40181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -40203,7 +40203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -40253,7 +40253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -40267,7 +40267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -40281,7 +40281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -40343,7 +40343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -40388,7 +40388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -40445,7 +40445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -40490,7 +40490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -40505,7 +40505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -40541,7 +40541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40572,7 +40572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40618,7 +40618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40647,7 +40647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40697,7 +40697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40737,7 +40737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40764,7 +40764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40802,7 +40802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40834,7 +40834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -40987,7 +40987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -41140,7 +41140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -41293,7 +41293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -41446,7 +41446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -41599,7 +41599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -41752,7 +41752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -41905,7 +41905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -42057,7 +42057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -42209,7 +42209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -42362,7 +42362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -42515,7 +42515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -42668,7 +42668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -42821,7 +42821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -42980,7 +42980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43031,7 +43031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43082,7 +43082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43133,7 +43133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43184,7 +43184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -43198,7 +43198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -43212,7 +43212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -43232,7 +43232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -43326,7 +43326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -43340,7 +43340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -43354,7 +43354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -43684,7 +43684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -43704,7 +43704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -43718,7 +43718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -43746,7 +43746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -43946,7 +43946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -44165,7 +44165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -44180,7 +44180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -44276,7 +44276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -44498,7 +44498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -44519,7 +44519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -44540,7 +44540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -44575,7 +44575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -44596,7 +44596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -44629,7 +44629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -44662,7 +44662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -44695,7 +44695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -44728,7 +44728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -44748,7 +44748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -44776,7 +44776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV70N20B.svd
+++ b/data/Atmel/ATSAMV70N20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6079,7 +6079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6153,7 +6153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6198,7 +6198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6225,7 +6225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6276,7 +6276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6327,7 +6327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6378,7 +6378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6429,7 +6429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6472,7 +6472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6486,7 +6486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6502,7 +6502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6536,7 +6536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6742,7 +6742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6762,7 +6762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6776,7 +6776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6808,7 +6808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6840,7 +6840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6872,7 +6872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6904,7 +6904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6936,7 +6936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6969,7 +6969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7050,7 +7050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7113,7 +7113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7176,7 +7176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7239,7 +7239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7260,7 +7260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7281,7 +7281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7302,7 +7302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7316,7 +7316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7348,7 +7348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7362,7 +7362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7376,7 +7376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7408,7 +7408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7450,7 +7450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7488,7 +7488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7547,7 +7547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7597,7 +7597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7653,7 +7653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7686,7 +7686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7914,7 +7914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7942,7 +7942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7986,7 +7986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8031,7 +8031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8046,7 +8046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8060,7 +8060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8111,7 +8111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8173,7 +8173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8193,7 +8193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8402,7 +8402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8434,7 +8434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8472,7 +8472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8486,7 +8486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8548,7 +8548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8562,7 +8562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8595,7 +8595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8736,7 +8736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8756,7 +8756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8932,7 +8932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9108,7 +9108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -9284,7 +9284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -9304,7 +9304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -9388,7 +9388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -9408,7 +9408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -9428,7 +9428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -9442,7 +9442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -9498,7 +9498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -9698,7 +9698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -9898,7 +9898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -9930,7 +9930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -9969,7 +9969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -9983,7 +9983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -9997,7 +9997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -10029,7 +10029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -10097,7 +10097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -10111,7 +10111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -10266,7 +10266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -10298,7 +10298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -10331,7 +10331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -10388,7 +10388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -10589,7 +10589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10789,7 +10789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -10989,7 +10989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -11190,7 +11190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -11391,7 +11391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -11591,7 +11591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11791,7 +11791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -11817,7 +11817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -11856,7 +11856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -11901,7 +11901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -12007,7 +12007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -12021,7 +12021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -12035,7 +12035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -12079,7 +12079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -12112,7 +12112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -12210,7 +12210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -12236,7 +12236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -12264,7 +12264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12280,7 +12280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12297,7 +12297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12314,7 +12314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -12330,7 +12330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12344,7 +12344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -12358,7 +12358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -12397,7 +12397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -12444,7 +12444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -12460,7 +12460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -12493,7 +12493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -12694,7 +12694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -12895,7 +12895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -13096,7 +13096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -13297,7 +13297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -13498,7 +13498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -13699,7 +13699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -13900,7 +13900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -14101,7 +14101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -14302,7 +14302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -14503,7 +14503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -14704,7 +14704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -14904,7 +14904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -15105,7 +15105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -15306,7 +15306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -15507,7 +15507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -15708,7 +15708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -15909,7 +15909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -16110,7 +16110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -16311,7 +16311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -16512,7 +16512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16713,7 +16713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16914,7 +16914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17117,7 +17117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -17317,7 +17317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -17518,7 +17518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -17719,7 +17719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -17920,7 +17920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -17934,7 +17934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -18135,7 +18135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -18336,7 +18336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -18537,7 +18537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -18738,7 +18738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -18939,7 +18939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -19140,7 +19140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -19341,7 +19341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -19542,7 +19542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -19743,7 +19743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -19944,7 +19944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -20145,7 +20145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -20346,7 +20346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -20547,7 +20547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -20748,7 +20748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -20949,7 +20949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -21150,7 +21150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -21178,7 +21178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -21199,7 +21199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -21399,7 +21399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -22015,7 +22015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -22071,7 +22071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -22104,7 +22104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -22137,7 +22137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -22170,7 +22170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -22191,7 +22191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -22241,7 +22241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -22304,7 +22304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -22367,7 +22367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -22436,7 +22436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -22577,7 +22577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -22718,7 +22718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -23050,7 +23050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -23171,7 +23171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -23193,7 +23193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -23241,7 +23241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -23346,7 +23346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -23451,7 +23451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -23574,7 +23574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -23679,7 +23679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -23837,7 +23837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -23941,7 +23941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -23956,7 +23956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23984,7 +23984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24005,7 +24005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24152,7 +24152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -24299,7 +24299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -24446,7 +24446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -24518,7 +24518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -24562,7 +24562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -24703,7 +24703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24844,7 +24844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -24985,7 +24985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -25126,7 +25126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -25140,7 +25140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -25287,7 +25287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -25434,7 +25434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -25581,7 +25581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -25728,7 +25728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -25762,7 +25762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25936,7 +25936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25969,7 +25969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26002,7 +26002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26035,7 +26035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26092,7 +26092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26149,7 +26149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26206,7 +26206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26263,7 +26263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26331,7 +26331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26346,7 +26346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26360,7 +26360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26380,7 +26380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26395,7 +26395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26512,7 +26512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26629,7 +26629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26746,7 +26746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26863,7 +26863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -26919,7 +26919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -26975,7 +26975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27032,7 +27032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27089,7 +27089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -27146,7 +27146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -27203,7 +27203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -27229,7 +27229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -27250,7 +27250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -27265,7 +27265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -27321,7 +27321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -27355,7 +27355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27411,7 +27411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27431,7 +27431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27446,7 +27446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27478,7 +27478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27534,7 +27534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27617,7 +27617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27716,7 +27716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27749,7 +27749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27770,7 +27770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27814,7 +27814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27854,7 +27854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28048,7 +28048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28062,7 +28062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28077,7 +28077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28091,7 +28091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28106,7 +28106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28121,7 +28121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28141,7 +28141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28163,7 +28163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -28184,7 +28184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -28205,7 +28205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -28285,7 +28285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -28323,7 +28323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -28344,7 +28344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -28424,7 +28424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28462,7 +28462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28510,7 +28510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28543,7 +28543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28663,7 +28663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28678,7 +28678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28693,7 +28693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28750,7 +28750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28801,7 +28801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28852,7 +28852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28903,7 +28903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28935,7 +28935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28949,7 +28949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28969,7 +28969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29147,7 +29147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29180,7 +29180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29195,7 +29195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29223,7 +29223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29263,7 +29263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29298,7 +29298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29359,7 +29359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29418,7 +29418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29447,7 +29447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29497,7 +29497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29531,7 +29531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29604,7 +29604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29818,7 +29818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29850,7 +29850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29888,7 +29888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29938,7 +29938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29970,7 +29970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30093,7 +30093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30138,7 +30138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30183,7 +30183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30228,7 +30228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30273,7 +30273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30325,7 +30325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30369,7 +30369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30383,7 +30383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30398,7 +30398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30438,7 +30438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30477,7 +30477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30569,7 +30569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30590,7 +30590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30640,7 +30640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30697,7 +30697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30748,7 +30748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30799,7 +30799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30852,7 +30852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30885,12 +30885,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -30982,7 +30982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31010,7 +31010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31050,7 +31050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -31089,7 +31089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -31103,7 +31103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31261,7 +31261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31363,7 +31363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31510,7 +31510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31618,7 +31618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31633,7 +31633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31648,7 +31648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31663,7 +31663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31677,7 +31677,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31691,7 +31691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31705,7 +31705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31774,7 +31774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31831,7 +31831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31888,7 +31888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31945,7 +31945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31973,7 +31973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32004,7 +32004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -32013,7 +32013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32074,7 +32074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32160,7 +32160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32264,7 +32264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32474,7 +32474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33014,7 +33014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33459,6 +33459,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -33493,7 +33521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33520,7 +33548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -33763,9 +33791,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -34199,7 +34227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34219,7 +34247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34234,7 +34262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34249,7 +34277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34263,7 +34291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34277,7 +34305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34291,7 +34319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34366,7 +34394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34423,7 +34451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34480,7 +34508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -34537,7 +34565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -34590,7 +34618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -34605,7 +34633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -34763,7 +34791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -34796,7 +34824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -34829,7 +34857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -34862,7 +34890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -34901,7 +34929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -34921,7 +34949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35016,7 +35044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35045,7 +35073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35060,7 +35088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35075,7 +35103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35090,7 +35118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35105,7 +35133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35139,7 +35167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35280,7 +35308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35329,7 +35357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35397,7 +35425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35411,7 +35439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35443,7 +35471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35566,7 +35594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35671,7 +35699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35776,7 +35804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35881,7 +35909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35896,7 +35924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35911,7 +35939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35943,7 +35971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35975,7 +36003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36007,7 +36035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36035,7 +36063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36091,7 +36119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36148,7 +36176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36257,7 +36285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36308,7 +36336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36359,7 +36387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36410,7 +36438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36461,7 +36489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36476,7 +36504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36491,7 +36519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36505,7 +36533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -36550,7 +36578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -37376,6 +37404,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -37426,7 +37472,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -37467,80 +37559,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37638,12 +37656,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -37653,6 +37665,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37688,46 +37712,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -37756,6 +37740,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -37809,7 +37811,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -37856,134 +37904,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38075,30 +37995,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -38108,6 +38004,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38143,64 +38051,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -38229,6 +38079,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38282,7 +38150,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -38329,134 +38243,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38548,30 +38334,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -38581,6 +38343,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38616,64 +38390,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -38702,6 +38418,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38779,7 +38513,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -38826,140 +38612,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39057,30 +38709,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -39090,6 +38718,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39120,64 +38760,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -39868,7 +39450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39959,7 +39541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -40112,7 +39694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40163,7 +39745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40256,7 +39838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40409,7 +39991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40562,7 +40144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40715,7 +40297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40843,7 +40425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40872,7 +40454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -41044,7 +40626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -41209,9 +40791,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41375,9 +40957,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41541,9 +41123,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41707,7 +41289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -41766,9 +41348,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41826,9 +41408,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41886,9 +41468,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -41946,7 +41528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -42011,9 +41593,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42077,9 +41659,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42143,9 +41725,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42209,7 +41791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42310,9 +41892,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42418,9 +42000,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42520,9 +42102,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42622,7 +42204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -42723,9 +42305,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42831,9 +42413,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42933,9 +42515,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43035,7 +42617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43124,9 +42706,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43214,9 +42796,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43304,9 +42886,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43398,7 +42980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43412,7 +42994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43426,7 +43008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43488,7 +43070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43533,7 +43115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43588,7 +43170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43697,43 +43279,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43741,7 +43323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43792,7 +43374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43841,43 +43423,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -43885,7 +43467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -43994,43 +43576,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44038,7 +43620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44147,43 +43729,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44191,7 +43773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44300,43 +43882,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44344,7 +43926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44460,7 +44042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44486,7 +44068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44518,7 +44100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44550,7 +44132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44572,7 +44154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44732,9 +44314,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -44899,7 +44481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45048,9 +44630,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45198,9 +44780,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45348,9 +44930,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45498,7 +45080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45551,9 +45133,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45605,9 +45187,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45659,9 +45241,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45713,7 +45295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45778,9 +45360,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45844,9 +45426,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45910,9 +45492,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45976,7 +45558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -46065,9 +45647,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46155,9 +45737,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46245,9 +45827,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46335,7 +45917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46418,9 +46000,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46502,9 +46084,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46586,9 +46168,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46670,7 +46252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -46753,9 +46335,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46837,9 +46419,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46921,9 +46503,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47005,7 +46587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -47027,7 +46609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -47077,7 +46659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47091,7 +46673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47105,7 +46687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47167,7 +46749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47212,7 +46794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47269,7 +46851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47314,7 +46896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47329,7 +46911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47365,7 +46947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47396,7 +46978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47442,7 +47024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47471,7 +47053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47521,7 +47103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47561,7 +47143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47588,7 +47170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47626,7 +47208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47658,7 +47240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -47811,7 +47393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47964,7 +47546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -48117,7 +47699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48270,7 +47852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48423,7 +48005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -48576,7 +48158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -48729,7 +48311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -48881,7 +48463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -49033,7 +48615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49186,7 +48768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49339,7 +48921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49492,7 +49074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -49645,7 +49227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -49804,7 +49386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49855,7 +49437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -49906,7 +49488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -49957,7 +49539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50008,7 +49590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -50022,7 +49604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -50036,7 +49618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -50056,7 +49638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -50150,7 +49732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50164,7 +49746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50178,7 +49760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -50741,7 +50323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -50761,7 +50343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -50775,7 +50357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -50803,7 +50385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -51003,7 +50585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -52892,6 +52474,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV70Q19.svd
+++ b/data/Atmel/ATSAMV70Q19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3152,7 +3152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3186,7 +3186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3297,7 +3297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3519,7 +3519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3596,7 +3596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3650,7 +3650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3683,7 +3683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3716,7 +3716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3749,7 +3749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3769,7 +3769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3797,7 +3797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4162,7 +4162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4201,7 +4201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4251,7 +4251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4314,7 +4314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4360,7 +4360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4374,7 +4374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4631,7 +4631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4651,7 +4651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4716,7 +4716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4914,7 +4914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5067,7 +5067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5220,7 +5220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5373,7 +5373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5421,7 +5421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5453,7 +5453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5481,7 +5481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5504,7 +5504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5537,7 +5537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5611,7 +5611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5656,7 +5656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5683,7 +5683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5734,7 +5734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5785,7 +5785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5887,7 +5887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5930,7 +5930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5944,7 +5944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5994,7 +5994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6092,7 +6092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6200,7 +6200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6234,7 +6234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6266,7 +6266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6330,7 +6330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6362,7 +6362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6394,7 +6394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6427,7 +6427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6508,7 +6508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6571,7 +6571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6697,7 +6697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6718,7 +6718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6739,7 +6739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6760,7 +6760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6774,7 +6774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6806,7 +6806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6820,7 +6820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6834,7 +6834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6866,7 +6866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6880,7 +6880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6946,7 +6946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7005,7 +7005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7055,7 +7055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7138,7 +7138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7308,7 +7308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7336,7 +7336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7380,7 +7380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7425,7 +7425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7454,7 +7454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7511,7 +7511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7579,7 +7579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7599,7 +7599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7812,7 +7812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7844,7 +7844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7882,7 +7882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7958,7 +7958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7972,7 +7972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8005,7 +8005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8134,7 +8134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8510,7 +8510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8698,7 +8698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -8718,7 +8718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -8802,7 +8802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -8822,7 +8822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -8842,7 +8842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -8856,7 +8856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -8912,7 +8912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -9112,7 +9112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -9312,7 +9312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -9383,7 +9383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -9397,7 +9397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -9411,7 +9411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -9511,7 +9511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -9525,7 +9525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -9712,7 +9712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -9802,7 +9802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -10003,7 +10003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10203,7 +10203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -10403,7 +10403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -10604,7 +10604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -11005,7 +11005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11205,7 +11205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -11231,7 +11231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -11270,7 +11270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -11315,7 +11315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -11421,7 +11421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -11435,7 +11435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -11449,7 +11449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -11493,7 +11493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -11526,7 +11526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -11624,7 +11624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -11650,7 +11650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -11678,7 +11678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -11694,7 +11694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -11711,7 +11711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -11728,7 +11728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11744,7 +11744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -11758,7 +11758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -11772,7 +11772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -11811,7 +11811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -11858,7 +11858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -11874,7 +11874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -11907,7 +11907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -12108,7 +12108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -12309,7 +12309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -12510,7 +12510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -12711,7 +12711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -12912,7 +12912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -13113,7 +13113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -13314,7 +13314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -13515,7 +13515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -13716,7 +13716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -13917,7 +13917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -14118,7 +14118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -14318,7 +14318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -14519,7 +14519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -14720,7 +14720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -14921,7 +14921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -15122,7 +15122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -15323,7 +15323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -15524,7 +15524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -15725,7 +15725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -15926,7 +15926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16127,7 +16127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16328,7 +16328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -16531,7 +16531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -16731,7 +16731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -16932,7 +16932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -17133,7 +17133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -17334,7 +17334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -17348,7 +17348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -17549,7 +17549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -17750,7 +17750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -17951,7 +17951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -18152,7 +18152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -18353,7 +18353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -18554,7 +18554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -18755,7 +18755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -18956,7 +18956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -19157,7 +19157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -19358,7 +19358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -19559,7 +19559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -19760,7 +19760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -19961,7 +19961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -20162,7 +20162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -20363,7 +20363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -20564,7 +20564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -20592,7 +20592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -20613,7 +20613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -20813,7 +20813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -21429,7 +21429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -21485,7 +21485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -21518,7 +21518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -21551,7 +21551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -21584,7 +21584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -21605,7 +21605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -21671,7 +21671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -21728,7 +21728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -21785,7 +21785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -21848,7 +21848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -22007,7 +22007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -22166,7 +22166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -22516,7 +22516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -22637,7 +22637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -22659,7 +22659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22707,7 +22707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -22806,7 +22806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -22905,7 +22905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -23022,7 +23022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -23121,7 +23121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -23279,7 +23279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -23383,7 +23383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -23398,7 +23398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23426,7 +23426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23447,7 +23447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -23606,7 +23606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -23765,7 +23765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -23924,7 +23924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -23996,7 +23996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -24040,7 +24040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -24199,7 +24199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24358,7 +24358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -24517,7 +24517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -24676,7 +24676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -24690,7 +24690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -24849,7 +24849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -25008,7 +25008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -25167,7 +25167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -25326,7 +25326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -25341,7 +25341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25367,7 +25367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25414,7 +25414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25588,7 +25588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25621,7 +25621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25654,7 +25654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25687,7 +25687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25744,7 +25744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25801,7 +25801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25858,7 +25858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25915,7 +25915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25983,7 +25983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25998,7 +25998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26012,7 +26012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26032,7 +26032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26047,7 +26047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26164,7 +26164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26281,7 +26281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26398,7 +26398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26515,7 +26515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -26571,7 +26571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -26627,7 +26627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -26684,7 +26684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -26741,7 +26741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -26798,7 +26798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -26855,7 +26855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -26881,7 +26881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -26902,7 +26902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -26917,7 +26917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -26973,7 +26973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -27007,7 +27007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27063,7 +27063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27083,7 +27083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27098,7 +27098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27130,7 +27130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27186,7 +27186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27269,7 +27269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27368,7 +27368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27388,7 +27388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27409,7 +27409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27453,7 +27453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27493,7 +27493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27635,7 +27635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27649,7 +27649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27664,7 +27664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27678,7 +27678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -27693,7 +27693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -27708,7 +27708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -27728,7 +27728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -27750,7 +27750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -27771,7 +27771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -27792,7 +27792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -27872,7 +27872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -27910,7 +27910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -27931,7 +27931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -28011,7 +28011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28049,7 +28049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28097,7 +28097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28130,7 +28130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28250,7 +28250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28265,7 +28265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28280,7 +28280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28337,7 +28337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28388,7 +28388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28439,7 +28439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28490,7 +28490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28522,7 +28522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28536,7 +28536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28556,7 +28556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28734,7 +28734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28767,7 +28767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28782,7 +28782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28810,7 +28810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28850,7 +28850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28885,7 +28885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28946,7 +28946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29005,7 +29005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29034,7 +29034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29084,7 +29084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29118,7 +29118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29191,7 +29191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29405,7 +29405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29437,7 +29437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29475,7 +29475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29525,7 +29525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29557,7 +29557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29680,7 +29680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29725,7 +29725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29770,7 +29770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29815,7 +29815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29860,7 +29860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29912,7 +29912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29956,7 +29956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29970,7 +29970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29985,7 +29985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30025,7 +30025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30077,7 +30077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30091,7 +30091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30237,7 +30237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30316,7 +30316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30331,7 +30331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30346,7 +30346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30361,7 +30361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30376,7 +30376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30403,7 +30403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30436,7 +30436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30450,7 +30450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30465,7 +30465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30501,7 +30501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30533,7 +30533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30565,7 +30565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30585,7 +30585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30715,7 +30715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -30753,7 +30753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -30768,7 +30768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -30783,7 +30783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30811,7 +30811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30851,7 +30851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30914,7 +30914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30970,7 +30970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30991,7 +30991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31018,7 +31018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31075,7 +31075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31126,7 +31126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31177,7 +31177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31230,7 +31230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31334,7 +31334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31362,7 +31362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31410,7 +31410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -31449,7 +31449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -31463,7 +31463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31621,7 +31621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31723,7 +31723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31870,7 +31870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31978,7 +31978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31993,7 +31993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32008,7 +32008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32023,7 +32023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32037,7 +32037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32051,7 +32051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -32065,7 +32065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32134,7 +32134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32191,7 +32191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -32248,7 +32248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32305,7 +32305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32333,7 +32333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32373,7 +32373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32434,7 +32434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32520,7 +32520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32624,7 +32624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32834,7 +32834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33374,7 +33374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33853,7 +33853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33880,7 +33880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34123,7 +34123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34143,7 +34143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34158,7 +34158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34173,7 +34173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34187,7 +34187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34201,7 +34201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34215,7 +34215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34290,7 +34290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34347,7 +34347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34404,7 +34404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -34461,7 +34461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -34514,7 +34514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -34529,7 +34529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -34675,7 +34675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -34702,7 +34702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -34729,7 +34729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -34756,7 +34756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -34789,7 +34789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -34809,7 +34809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34837,7 +34837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34925,7 +34925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34954,7 +34954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34969,7 +34969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34984,7 +34984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34999,7 +34999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35014,7 +35014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35048,7 +35048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35189,7 +35189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35238,7 +35238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35306,7 +35306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35320,7 +35320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35352,7 +35352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35475,7 +35475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35580,7 +35580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35685,7 +35685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35790,7 +35790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35805,7 +35805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35820,7 +35820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35852,7 +35852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35884,7 +35884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35916,7 +35916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35944,7 +35944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36000,7 +36000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36063,7 +36063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36172,7 +36172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36223,7 +36223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36274,7 +36274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36325,7 +36325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36394,7 +36394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36409,7 +36409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36424,7 +36424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36438,7 +36438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -36483,7 +36483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -38066,7 +38066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -38157,7 +38157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -38310,7 +38310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -38361,7 +38361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -38454,7 +38454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -38607,7 +38607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -38760,7 +38760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -38913,7 +38913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39041,7 +39041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39070,7 +39070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -39242,7 +39242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -39407,7 +39407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -39466,7 +39466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -39531,7 +39531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -39632,7 +39632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -39733,7 +39733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -39826,7 +39826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39840,7 +39840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39854,7 +39854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39916,7 +39916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39961,7 +39961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -40016,7 +40016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -40169,7 +40169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -40220,7 +40220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -40313,7 +40313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -40466,7 +40466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -40619,7 +40619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -40772,7 +40772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -40888,7 +40888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -40914,7 +40914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -40946,7 +40946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -40978,7 +40978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -41000,7 +41000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -41160,7 +41160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -41309,7 +41309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -41362,7 +41362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -41427,7 +41427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -41516,7 +41516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -41599,7 +41599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -41682,7 +41682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -41704,7 +41704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -41754,7 +41754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -41768,7 +41768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -41782,7 +41782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -41844,7 +41844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -41889,7 +41889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -41946,7 +41946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -41991,7 +41991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -42006,7 +42006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -42042,7 +42042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -42073,7 +42073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -42119,7 +42119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42148,7 +42148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42198,7 +42198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42238,7 +42238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42265,7 +42265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42303,7 +42303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42335,7 +42335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -42488,7 +42488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -42641,7 +42641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -42794,7 +42794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -42947,7 +42947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -43100,7 +43100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -43253,7 +43253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -43406,7 +43406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -43558,7 +43558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -43710,7 +43710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43863,7 +43863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -44016,7 +44016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -44169,7 +44169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -44322,7 +44322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -44481,7 +44481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44532,7 +44532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44583,7 +44583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44634,7 +44634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44685,7 +44685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -44699,7 +44699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -44713,7 +44713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -44733,7 +44733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -44827,7 +44827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -44841,7 +44841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -44855,7 +44855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -45185,7 +45185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -45205,7 +45205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -45219,7 +45219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>

--- a/data/Atmel/ATSAMV70Q19B.svd
+++ b/data/Atmel/ATSAMV70Q19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6087,7 +6087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6206,7 +6206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6233,7 +6233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6284,7 +6284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6335,7 +6335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6386,7 +6386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6437,7 +6437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6480,7 +6480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6494,7 +6494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6510,7 +6510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6544,7 +6544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6642,7 +6642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6750,7 +6750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6770,7 +6770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6784,7 +6784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6816,7 +6816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6880,7 +6880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6912,7 +6912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6944,7 +6944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6977,7 +6977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7058,7 +7058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7121,7 +7121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7184,7 +7184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7247,7 +7247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7268,7 +7268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7310,7 +7310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7324,7 +7324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7356,7 +7356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7384,7 +7384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7416,7 +7416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7430,7 +7430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7458,7 +7458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7496,7 +7496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7555,7 +7555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7605,7 +7605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7661,7 +7661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7694,7 +7694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7922,7 +7922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7950,7 +7950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7994,7 +7994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8039,7 +8039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8054,7 +8054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8068,7 +8068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8119,7 +8119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8181,7 +8181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8201,7 +8201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8410,7 +8410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8442,7 +8442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8494,7 +8494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8556,7 +8556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8570,7 +8570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8603,7 +8603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8744,7 +8744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8764,7 +8764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8940,7 +8940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9116,7 +9116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -9292,7 +9292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -9312,7 +9312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -9396,7 +9396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -9416,7 +9416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -9436,7 +9436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -9450,7 +9450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -9506,7 +9506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -9706,7 +9706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -9906,7 +9906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -9938,7 +9938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -9977,7 +9977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -9991,7 +9991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -10005,7 +10005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -10037,7 +10037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -10105,7 +10105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -10119,7 +10119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -10274,7 +10274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -10306,7 +10306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -10339,7 +10339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -10396,7 +10396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -10597,7 +10597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10797,7 +10797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -10997,7 +10997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -11198,7 +11198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -11399,7 +11399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -11599,7 +11599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11799,7 +11799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -11825,7 +11825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -11864,7 +11864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -11909,7 +11909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -12015,7 +12015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -12029,7 +12029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -12043,7 +12043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -12087,7 +12087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -12120,7 +12120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -12218,7 +12218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -12244,7 +12244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -12272,7 +12272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12288,7 +12288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12305,7 +12305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12322,7 +12322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -12338,7 +12338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12352,7 +12352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -12366,7 +12366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -12405,7 +12405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -12452,7 +12452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -12468,7 +12468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -12501,7 +12501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -12702,7 +12702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -12903,7 +12903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -13104,7 +13104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -13305,7 +13305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -13506,7 +13506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -13707,7 +13707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -13908,7 +13908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -14109,7 +14109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -14310,7 +14310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -14511,7 +14511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -14712,7 +14712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -14912,7 +14912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -15113,7 +15113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -15314,7 +15314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -15515,7 +15515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -15716,7 +15716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -15917,7 +15917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -16118,7 +16118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -16319,7 +16319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -16520,7 +16520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16721,7 +16721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16922,7 +16922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17125,7 +17125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -17325,7 +17325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -17526,7 +17526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -17727,7 +17727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -17928,7 +17928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -17942,7 +17942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -18143,7 +18143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -18344,7 +18344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -18545,7 +18545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -18746,7 +18746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -18947,7 +18947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -19148,7 +19148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -19349,7 +19349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -19550,7 +19550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -19751,7 +19751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -19952,7 +19952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -20153,7 +20153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -20354,7 +20354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -20555,7 +20555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -20756,7 +20756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -20957,7 +20957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -21158,7 +21158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -21186,7 +21186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -21207,7 +21207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -21407,7 +21407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -22023,7 +22023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -22079,7 +22079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -22112,7 +22112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -22145,7 +22145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -22178,7 +22178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -22199,7 +22199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -22265,7 +22265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -22328,7 +22328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -22391,7 +22391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -22460,7 +22460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -22619,7 +22619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -22778,7 +22778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -23128,7 +23128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -23249,7 +23249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -23271,7 +23271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -23319,7 +23319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -23424,7 +23424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -23529,7 +23529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -23652,7 +23652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -23757,7 +23757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -23915,7 +23915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -24019,7 +24019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -24034,7 +24034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24062,7 +24062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24083,7 +24083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24236,7 +24236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -24389,7 +24389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -24542,7 +24542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -24614,7 +24614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -24658,7 +24658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -24817,7 +24817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24976,7 +24976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -25135,7 +25135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -25294,7 +25294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -25308,7 +25308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -25461,7 +25461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -25614,7 +25614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -25767,7 +25767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -25920,7 +25920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -25954,7 +25954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26128,7 +26128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26161,7 +26161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26194,7 +26194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26227,7 +26227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26284,7 +26284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26341,7 +26341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26398,7 +26398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26455,7 +26455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26523,7 +26523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26538,7 +26538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26552,7 +26552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26572,7 +26572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26587,7 +26587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26704,7 +26704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26821,7 +26821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26938,7 +26938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27055,7 +27055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27111,7 +27111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27167,7 +27167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27224,7 +27224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27281,7 +27281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -27338,7 +27338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -27395,7 +27395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -27421,7 +27421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -27442,7 +27442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -27457,7 +27457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -27513,7 +27513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -27547,7 +27547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27603,7 +27603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27623,7 +27623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27638,7 +27638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27670,7 +27670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27726,7 +27726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27809,7 +27809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27908,7 +27908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27941,7 +27941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27962,7 +27962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28006,7 +28006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28046,7 +28046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28240,7 +28240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28254,7 +28254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28269,7 +28269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28283,7 +28283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28298,7 +28298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28313,7 +28313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28333,7 +28333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28355,7 +28355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -28376,7 +28376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -28397,7 +28397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -28477,7 +28477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -28515,7 +28515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -28536,7 +28536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -28616,7 +28616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28654,7 +28654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28702,7 +28702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28735,7 +28735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28855,7 +28855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28870,7 +28870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28885,7 +28885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28942,7 +28942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28993,7 +28993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29044,7 +29044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29095,7 +29095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29127,7 +29127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29141,7 +29141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29161,7 +29161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29339,7 +29339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29372,7 +29372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29387,7 +29387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29415,7 +29415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29455,7 +29455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29490,7 +29490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29551,7 +29551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29610,7 +29610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29639,7 +29639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29689,7 +29689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29723,7 +29723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29796,7 +29796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30010,7 +30010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30042,7 +30042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30080,7 +30080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30130,7 +30130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30162,7 +30162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30285,7 +30285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30330,7 +30330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30375,7 +30375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30420,7 +30420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30465,7 +30465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30517,7 +30517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30561,7 +30561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30575,7 +30575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30590,7 +30590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30630,7 +30630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30682,7 +30682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30696,7 +30696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30842,7 +30842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30921,7 +30921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30936,7 +30936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30951,7 +30951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30966,7 +30966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30981,7 +30981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31008,7 +31008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31041,7 +31041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31055,7 +31055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31070,7 +31070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31106,7 +31106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31138,7 +31138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31170,7 +31170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31190,7 +31190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31320,7 +31320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -31358,7 +31358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -31373,7 +31373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -31388,7 +31388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31416,7 +31416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31456,7 +31456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31495,7 +31495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31587,7 +31587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31608,7 +31608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31658,7 +31658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31715,7 +31715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31766,7 +31766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31817,7 +31817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31870,7 +31870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31903,12 +31903,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -32000,7 +32000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32028,7 +32028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32076,7 +32076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -32115,7 +32115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -32129,7 +32129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32287,7 +32287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32389,7 +32389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32536,7 +32536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32644,7 +32644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32659,7 +32659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32674,7 +32674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32689,7 +32689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32703,7 +32703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32717,7 +32717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -32731,7 +32731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32800,7 +32800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32857,7 +32857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -32914,7 +32914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32971,7 +32971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32999,7 +32999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33030,7 +33030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -33039,7 +33039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33100,7 +33100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33186,7 +33186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33290,7 +33290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33500,7 +33500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34040,7 +34040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34485,6 +34485,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -34519,7 +34547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34546,7 +34574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34789,9 +34817,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -35225,7 +35253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35245,7 +35273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35260,7 +35288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -35275,7 +35303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -35289,7 +35317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -35303,7 +35331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -35317,7 +35345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -35392,7 +35420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -35449,7 +35477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -35506,7 +35534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -35563,7 +35591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -35616,7 +35644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -35631,7 +35659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -35789,7 +35817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -35822,7 +35850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -35855,7 +35883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -35888,7 +35916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -35927,7 +35955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -35947,7 +35975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36042,7 +36070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36071,7 +36099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36086,7 +36114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36101,7 +36129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36116,7 +36144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -36131,7 +36159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -36165,7 +36193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36306,7 +36334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36355,7 +36383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36423,7 +36451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36437,7 +36465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36469,7 +36497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -36592,7 +36620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -36697,7 +36725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36802,7 +36830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36907,7 +36935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36922,7 +36950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36937,7 +36965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36969,7 +36997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -37001,7 +37029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -37033,7 +37061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37061,7 +37089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -37117,7 +37145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -37174,7 +37202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -37283,7 +37311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -37334,7 +37362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -37385,7 +37413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37436,7 +37464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37487,7 +37515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37502,7 +37530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37517,7 +37545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37531,7 +37559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -37576,7 +37604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -38402,6 +38430,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -38452,7 +38498,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -38493,80 +38585,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38664,12 +38682,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -38679,6 +38691,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38714,46 +38738,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -38782,6 +38766,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38835,7 +38837,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -38882,134 +38930,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39101,30 +39021,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -39134,6 +39030,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39169,64 +39077,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -39255,6 +39105,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39308,7 +39176,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -39355,134 +39269,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39574,30 +39360,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -39607,6 +39369,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39642,64 +39416,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -39728,6 +39444,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39805,7 +39539,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -39852,140 +39638,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40083,30 +39735,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -40116,6 +39744,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40146,64 +39786,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -40894,7 +40476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -40985,7 +40567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41138,7 +40720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -41189,7 +40771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -41282,7 +40864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -41435,7 +41017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41588,7 +41170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41741,7 +41323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -41869,7 +41451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -41898,7 +41480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42070,7 +41652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -42235,9 +41817,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42401,9 +41983,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42567,9 +42149,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42733,7 +42315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -42792,9 +42374,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42852,9 +42434,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42912,9 +42494,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42972,7 +42554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43037,9 +42619,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43103,9 +42685,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43169,9 +42751,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43235,7 +42817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43336,9 +42918,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43444,9 +43026,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43546,9 +43128,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43648,7 +43230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43749,9 +43331,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43857,9 +43439,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43959,9 +43541,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44061,7 +43643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -44150,9 +43732,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44240,9 +43822,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44330,9 +43912,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44424,7 +44006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44438,7 +44020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44452,7 +44034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44514,7 +44096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44559,7 +44141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -44614,7 +44196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -44723,43 +44305,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44767,7 +44349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -44818,7 +44400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44867,43 +44449,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44911,7 +44493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -45020,43 +44602,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -45064,7 +44646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -45173,43 +44755,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -45217,7 +44799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -45326,43 +44908,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -45370,7 +44952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -45486,7 +45068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -45512,7 +45094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -45544,7 +45126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -45576,7 +45158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -45598,7 +45180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -45758,9 +45340,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -45925,7 +45507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -46074,9 +45656,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46224,9 +45806,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46374,9 +45956,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46524,7 +46106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -46577,9 +46159,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46631,9 +46213,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46685,9 +46267,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46739,7 +46321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -46804,9 +46386,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46870,9 +46452,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46936,9 +46518,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47002,7 +46584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -47091,9 +46673,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47181,9 +46763,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47271,9 +46853,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47361,7 +46943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -47444,9 +47026,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47528,9 +47110,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47612,9 +47194,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47696,7 +47278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -47779,9 +47361,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47863,9 +47445,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47947,9 +47529,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48031,7 +47613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -48053,7 +47635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -48103,7 +47685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -48117,7 +47699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -48131,7 +47713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -48193,7 +47775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -48238,7 +47820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -48295,7 +47877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -48340,7 +47922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -48355,7 +47937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -48391,7 +47973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48422,7 +48004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -48468,7 +48050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -48497,7 +48079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -48547,7 +48129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48587,7 +48169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -48614,7 +48196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -48652,7 +48234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48684,7 +48266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -48837,7 +48419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48990,7 +48572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -49143,7 +48725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -49296,7 +48878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -49449,7 +49031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -49602,7 +49184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -49755,7 +49337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -49907,7 +49489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -50059,7 +49641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -50212,7 +49794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -50365,7 +49947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -50518,7 +50100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -50671,7 +50253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -50830,7 +50412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50881,7 +50463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50932,7 +50514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50983,7 +50565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -51034,7 +50616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -51048,7 +50630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -51062,7 +50644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -51082,7 +50664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -51176,7 +50758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -51190,7 +50772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -51204,7 +50786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -51797,7 +51379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -51817,7 +51399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -51831,7 +51413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -51859,7 +51441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -53748,6 +53330,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV70Q20.svd
+++ b/data/Atmel/ATSAMV70Q20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -654,7 +654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -681,7 +681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -708,7 +708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -735,7 +735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -803,7 +803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -820,7 +820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -837,7 +837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -854,7 +854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -869,7 +869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -883,7 +883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -899,7 +899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -915,7 +915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -930,7 +930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -947,7 +947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -980,7 +980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1001,7 +1001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1261,7 +1261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1391,7 +1391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1447,7 +1447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1479,7 +1479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1560,7 +1560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1743,7 +1743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1848,7 +1848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1953,7 +1953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2058,7 +2058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2163,7 +2163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2244,7 +2244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2264,7 +2264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2344,7 +2344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2424,7 +2424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2438,7 +2438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2453,7 +2453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2467,7 +2467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2510,7 +2510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2530,7 +2530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2556,7 +2556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2636,7 +2636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2650,7 +2650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2670,7 +2670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2750,7 +2750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2778,7 +2778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2822,7 +2822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3152,7 +3152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3186,7 +3186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3201,7 +3201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3297,7 +3297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3519,7 +3519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3596,7 +3596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3650,7 +3650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3683,7 +3683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3716,7 +3716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3749,7 +3749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3769,7 +3769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3797,7 +3797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4162,7 +4162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4201,7 +4201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4251,7 +4251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4314,7 +4314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4360,7 +4360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4374,7 +4374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4631,7 +4631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4651,7 +4651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4716,7 +4716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4731,7 +4731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4746,7 +4746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4761,7 +4761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4914,7 +4914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5067,7 +5067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5220,7 +5220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5373,7 +5373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5421,7 +5421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5453,7 +5453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5481,7 +5481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5504,7 +5504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5537,7 +5537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5611,7 +5611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5656,7 +5656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5683,7 +5683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5734,7 +5734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5785,7 +5785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -5887,7 +5887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -5930,7 +5930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -5944,7 +5944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -5994,7 +5994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6092,7 +6092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6200,7 +6200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6234,7 +6234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6266,7 +6266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6298,7 +6298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6330,7 +6330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6362,7 +6362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6394,7 +6394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6427,7 +6427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -6508,7 +6508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -6571,7 +6571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6634,7 +6634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6697,7 +6697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6718,7 +6718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -6739,7 +6739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -6760,7 +6760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -6774,7 +6774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -6806,7 +6806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -6820,7 +6820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -6834,7 +6834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -6866,7 +6866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -6880,7 +6880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -6946,7 +6946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -7005,7 +7005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7055,7 +7055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7111,7 +7111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7138,7 +7138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7308,7 +7308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7336,7 +7336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7380,7 +7380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7425,7 +7425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7440,7 +7440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7454,7 +7454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7511,7 +7511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7579,7 +7579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7599,7 +7599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7812,7 +7812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7844,7 +7844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7882,7 +7882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7958,7 +7958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7972,7 +7972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8005,7 +8005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8134,7 +8134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8322,7 +8322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8510,7 +8510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8698,7 +8698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -8718,7 +8718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -8802,7 +8802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -8822,7 +8822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -8842,7 +8842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -8856,7 +8856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -8912,7 +8912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -9112,7 +9112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -9312,7 +9312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -9383,7 +9383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -9397,7 +9397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -9411,7 +9411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -9511,7 +9511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -9525,7 +9525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -9712,7 +9712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -9745,7 +9745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -9802,7 +9802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -10003,7 +10003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10203,7 +10203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -10403,7 +10403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -10604,7 +10604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -11005,7 +11005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11205,7 +11205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -11231,7 +11231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -11270,7 +11270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -11315,7 +11315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -11421,7 +11421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -11435,7 +11435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -11449,7 +11449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -11493,7 +11493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -11526,7 +11526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -11624,7 +11624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -11650,7 +11650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -11678,7 +11678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -11694,7 +11694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -11711,7 +11711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -11728,7 +11728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11744,7 +11744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -11758,7 +11758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -11772,7 +11772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -11811,7 +11811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -11858,7 +11858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -11874,7 +11874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -11907,7 +11907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -12108,7 +12108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -12309,7 +12309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -12510,7 +12510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -12711,7 +12711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -12912,7 +12912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -13113,7 +13113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -13314,7 +13314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -13515,7 +13515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -13716,7 +13716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -13917,7 +13917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -14118,7 +14118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -14318,7 +14318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -14519,7 +14519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -14720,7 +14720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -14921,7 +14921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -15122,7 +15122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -15323,7 +15323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -15524,7 +15524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -15725,7 +15725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -15926,7 +15926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16127,7 +16127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16328,7 +16328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -16531,7 +16531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -16731,7 +16731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -16932,7 +16932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -17133,7 +17133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -17334,7 +17334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -17348,7 +17348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -17549,7 +17549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -17750,7 +17750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -17951,7 +17951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -18152,7 +18152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -18353,7 +18353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -18554,7 +18554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -18755,7 +18755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -18956,7 +18956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -19157,7 +19157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -19358,7 +19358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -19559,7 +19559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -19760,7 +19760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -19961,7 +19961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -20162,7 +20162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -20363,7 +20363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -20564,7 +20564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -20592,7 +20592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -20613,7 +20613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -20813,7 +20813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -21429,7 +21429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -21485,7 +21485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -21518,7 +21518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -21551,7 +21551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -21584,7 +21584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -21605,7 +21605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -21671,7 +21671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -21728,7 +21728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -21785,7 +21785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -21848,7 +21848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -22007,7 +22007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -22166,7 +22166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -22516,7 +22516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -22637,7 +22637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -22659,7 +22659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -22707,7 +22707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -22806,7 +22806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -22905,7 +22905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -23022,7 +23022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -23121,7 +23121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -23279,7 +23279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -23383,7 +23383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -23398,7 +23398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -23426,7 +23426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -23447,7 +23447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -23606,7 +23606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -23765,7 +23765,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -23924,7 +23924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -23996,7 +23996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -24040,7 +24040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -24199,7 +24199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24358,7 +24358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -24517,7 +24517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -24676,7 +24676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -24690,7 +24690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -24849,7 +24849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -25008,7 +25008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -25167,7 +25167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -25326,7 +25326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -25341,7 +25341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25367,7 +25367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25414,7 +25414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -25588,7 +25588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -25621,7 +25621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -25654,7 +25654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -25687,7 +25687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -25744,7 +25744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -25801,7 +25801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -25858,7 +25858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -25915,7 +25915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -25983,7 +25983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -25998,7 +25998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26012,7 +26012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26032,7 +26032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26047,7 +26047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26164,7 +26164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26281,7 +26281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26398,7 +26398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26515,7 +26515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -26571,7 +26571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -26627,7 +26627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -26684,7 +26684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -26741,7 +26741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -26798,7 +26798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -26855,7 +26855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -26881,7 +26881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -26902,7 +26902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -26917,7 +26917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -26973,7 +26973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -27007,7 +27007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27063,7 +27063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27083,7 +27083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27098,7 +27098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27130,7 +27130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27186,7 +27186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27269,7 +27269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27368,7 +27368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27388,7 +27388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27409,7 +27409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27453,7 +27453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27493,7 +27493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27635,7 +27635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27649,7 +27649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -27664,7 +27664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -27678,7 +27678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -27693,7 +27693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -27708,7 +27708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -27728,7 +27728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -27750,7 +27750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -27771,7 +27771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -27792,7 +27792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -27872,7 +27872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -27910,7 +27910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -27931,7 +27931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -28011,7 +28011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28049,7 +28049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28097,7 +28097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28130,7 +28130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28250,7 +28250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28265,7 +28265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28280,7 +28280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28337,7 +28337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28388,7 +28388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -28439,7 +28439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -28490,7 +28490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -28522,7 +28522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -28536,7 +28536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -28556,7 +28556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -28734,7 +28734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -28767,7 +28767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28782,7 +28782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28810,7 +28810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28850,7 +28850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28885,7 +28885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28946,7 +28946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29005,7 +29005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29034,7 +29034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29084,7 +29084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29118,7 +29118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29191,7 +29191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29405,7 +29405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29437,7 +29437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29475,7 +29475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29525,7 +29525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29557,7 +29557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29680,7 +29680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29725,7 +29725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29770,7 +29770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29815,7 +29815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29860,7 +29860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29912,7 +29912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29956,7 +29956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29970,7 +29970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29985,7 +29985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30025,7 +30025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30077,7 +30077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30091,7 +30091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30237,7 +30237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30316,7 +30316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30331,7 +30331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30346,7 +30346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30361,7 +30361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30376,7 +30376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30403,7 +30403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30436,7 +30436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30450,7 +30450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30465,7 +30465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30501,7 +30501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -30533,7 +30533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -30565,7 +30565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -30585,7 +30585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -30715,7 +30715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -30753,7 +30753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -30768,7 +30768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -30783,7 +30783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30811,7 +30811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30851,7 +30851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30914,7 +30914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30970,7 +30970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30991,7 +30991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31018,7 +31018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31075,7 +31075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31126,7 +31126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31177,7 +31177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31230,7 +31230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31334,7 +31334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31362,7 +31362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31410,7 +31410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -31449,7 +31449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -31463,7 +31463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31621,7 +31621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31723,7 +31723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31870,7 +31870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31978,7 +31978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31993,7 +31993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32008,7 +32008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32023,7 +32023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32037,7 +32037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32051,7 +32051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -32065,7 +32065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32134,7 +32134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32191,7 +32191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -32248,7 +32248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32305,7 +32305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32333,7 +32333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32373,7 +32373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32434,7 +32434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32520,7 +32520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32624,7 +32624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32834,7 +32834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33374,7 +33374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33853,7 +33853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -33880,7 +33880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34123,7 +34123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34143,7 +34143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34158,7 +34158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34173,7 +34173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34187,7 +34187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34201,7 +34201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34215,7 +34215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34290,7 +34290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34347,7 +34347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34404,7 +34404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -34461,7 +34461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -34514,7 +34514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -34529,7 +34529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -34675,7 +34675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -34702,7 +34702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -34729,7 +34729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -34756,7 +34756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -34789,7 +34789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -34809,7 +34809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34837,7 +34837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34925,7 +34925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34954,7 +34954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34969,7 +34969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34984,7 +34984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34999,7 +34999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35014,7 +35014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35048,7 +35048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35189,7 +35189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35238,7 +35238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35306,7 +35306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35320,7 +35320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35352,7 +35352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35475,7 +35475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35580,7 +35580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35685,7 +35685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35790,7 +35790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35805,7 +35805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35820,7 +35820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35852,7 +35852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35884,7 +35884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35916,7 +35916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35944,7 +35944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36000,7 +36000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36063,7 +36063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36172,7 +36172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36223,7 +36223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36274,7 +36274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36325,7 +36325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36394,7 +36394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36409,7 +36409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36424,7 +36424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -36438,7 +36438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -36483,7 +36483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -38066,7 +38066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -38157,7 +38157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -38310,7 +38310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -38361,7 +38361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -38454,7 +38454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -38607,7 +38607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -38760,7 +38760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -38913,7 +38913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39041,7 +39041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39070,7 +39070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -39242,7 +39242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -39407,7 +39407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -39466,7 +39466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -39531,7 +39531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -39632,7 +39632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -39733,7 +39733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -39826,7 +39826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39840,7 +39840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39854,7 +39854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39916,7 +39916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39961,7 +39961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -40016,7 +40016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -40169,7 +40169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -40220,7 +40220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -40313,7 +40313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -40466,7 +40466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -40619,7 +40619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -40772,7 +40772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -40888,7 +40888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -40914,7 +40914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -40946,7 +40946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -40978,7 +40978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -41000,7 +41000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -41160,7 +41160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -41309,7 +41309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -41362,7 +41362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -41427,7 +41427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -41516,7 +41516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -41599,7 +41599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -41682,7 +41682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -41704,7 +41704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -41754,7 +41754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -41768,7 +41768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -41782,7 +41782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -41844,7 +41844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -41889,7 +41889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -41946,7 +41946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -41991,7 +41991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -42006,7 +42006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -42042,7 +42042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -42073,7 +42073,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -42119,7 +42119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42154,7 +42154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42204,7 +42204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42244,7 +42244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -42271,7 +42271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -42309,7 +42309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -42341,7 +42341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -42494,7 +42494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -42647,7 +42647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -42800,7 +42800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -42953,7 +42953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -43106,7 +43106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -43259,7 +43259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -43412,7 +43412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -43564,7 +43564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -43716,7 +43716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -43869,7 +43869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -44022,7 +44022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -44175,7 +44175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -44328,7 +44328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -44487,7 +44487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44538,7 +44538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44589,7 +44589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44640,7 +44640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44691,7 +44691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -44705,7 +44705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -44719,7 +44719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -44739,7 +44739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -44833,7 +44833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -44847,7 +44847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -44861,7 +44861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -45191,7 +45191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -45211,7 +45211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -45225,7 +45225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -45253,7 +45253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -45453,7 +45453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV70Q20B.svd
+++ b/data/Atmel/ATSAMV70Q20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4183,7 +4183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -4272,7 +4272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -4335,7 +4335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -4381,7 +4381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -4395,7 +4395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -4652,7 +4652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -4672,7 +4672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -4737,7 +4737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -4752,7 +4752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -4767,7 +4767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -4782,7 +4782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -4935,7 +4935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -5088,7 +5088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -5241,7 +5241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -5394,7 +5394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -5442,7 +5442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -5474,7 +5474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -5502,7 +5502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -5525,7 +5525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -5558,7 +5558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -5609,7 +5609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -5808,7 +5808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -5865,7 +5865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -5898,7 +5898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -5931,7 +5931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -5964,7 +5964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -5997,7 +5997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6030,7 +6030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6045,7 +6045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6087,7 +6087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6206,7 +6206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6233,7 +6233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6284,7 +6284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6335,7 +6335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6386,7 +6386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6437,7 +6437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6480,7 +6480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -6494,7 +6494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -6510,7 +6510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -6544,7 +6544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -6642,7 +6642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -6750,7 +6750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -6770,7 +6770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -6784,7 +6784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -6816,7 +6816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -6880,7 +6880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -6912,7 +6912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -6944,7 +6944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -6977,7 +6977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -7058,7 +7058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -7121,7 +7121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7184,7 +7184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7247,7 +7247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7268,7 +7268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7310,7 +7310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -7324,7 +7324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -7356,7 +7356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -7384,7 +7384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -7416,7 +7416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -7430,7 +7430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -7458,7 +7458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -7496,7 +7496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -7555,7 +7555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -7605,7 +7605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7661,7 +7661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7694,7 +7694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -7922,7 +7922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -7950,7 +7950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -7994,7 +7994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8039,7 +8039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8054,7 +8054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8068,7 +8068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8119,7 +8119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8181,7 +8181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8201,7 +8201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8410,7 +8410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8442,7 +8442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8494,7 +8494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8556,7 +8556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8570,7 +8570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8603,7 +8603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8744,7 +8744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8764,7 +8764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8940,7 +8940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9116,7 +9116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -9292,7 +9292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -9312,7 +9312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -9396,7 +9396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -9416,7 +9416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -9436,7 +9436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -9450,7 +9450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -9506,7 +9506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -9706,7 +9706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -9906,7 +9906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -9938,7 +9938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -9977,7 +9977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -9991,7 +9991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -10005,7 +10005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -10037,7 +10037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -10105,7 +10105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -10119,7 +10119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -10274,7 +10274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -10306,7 +10306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -10339,7 +10339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -10396,7 +10396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -10597,7 +10597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -10797,7 +10797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -10997,7 +10997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -11198,7 +11198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -11399,7 +11399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -11599,7 +11599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11799,7 +11799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -11825,7 +11825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -11864,7 +11864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -11909,7 +11909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -12015,7 +12015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -12029,7 +12029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -12043,7 +12043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -12087,7 +12087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -12120,7 +12120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -12218,7 +12218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -12244,7 +12244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -12272,7 +12272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12288,7 +12288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12305,7 +12305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12322,7 +12322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -12338,7 +12338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12352,7 +12352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -12366,7 +12366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -12405,7 +12405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -12452,7 +12452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -12468,7 +12468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -12501,7 +12501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -12702,7 +12702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -12903,7 +12903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -13104,7 +13104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -13305,7 +13305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -13506,7 +13506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -13707,7 +13707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -13908,7 +13908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -14109,7 +14109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -14310,7 +14310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -14511,7 +14511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -14712,7 +14712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -14912,7 +14912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -15113,7 +15113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -15314,7 +15314,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -15515,7 +15515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -15716,7 +15716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -15917,7 +15917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -16118,7 +16118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -16319,7 +16319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -16520,7 +16520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -16721,7 +16721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -16922,7 +16922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -17125,7 +17125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -17325,7 +17325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -17526,7 +17526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -17727,7 +17727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -17928,7 +17928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -17942,7 +17942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -18143,7 +18143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -18344,7 +18344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -18545,7 +18545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -18746,7 +18746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -18947,7 +18947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -19148,7 +19148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -19349,7 +19349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -19550,7 +19550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -19751,7 +19751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -19952,7 +19952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -20153,7 +20153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -20354,7 +20354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -20555,7 +20555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -20756,7 +20756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -20957,7 +20957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -21158,7 +21158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -21186,7 +21186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -21207,7 +21207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -21407,7 +21407,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -22023,7 +22023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -22079,7 +22079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -22112,7 +22112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -22145,7 +22145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -22178,7 +22178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -22199,7 +22199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -22265,7 +22265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -22328,7 +22328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -22391,7 +22391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -22460,7 +22460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -22619,7 +22619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -22778,7 +22778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -23128,7 +23128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -23249,7 +23249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -23271,7 +23271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -23319,7 +23319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -23424,7 +23424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -23529,7 +23529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -23652,7 +23652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -23757,7 +23757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -23915,7 +23915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -24019,7 +24019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -24034,7 +24034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24062,7 +24062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24083,7 +24083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24236,7 +24236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -24389,7 +24389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -24542,7 +24542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -24614,7 +24614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -24658,7 +24658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -24817,7 +24817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -24976,7 +24976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -25135,7 +25135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -25294,7 +25294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -25308,7 +25308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -25461,7 +25461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -25614,7 +25614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -25767,7 +25767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -25920,7 +25920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -25954,7 +25954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -26128,7 +26128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -26161,7 +26161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -26194,7 +26194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -26227,7 +26227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -26284,7 +26284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -26341,7 +26341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -26398,7 +26398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -26455,7 +26455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -26523,7 +26523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -26538,7 +26538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -26552,7 +26552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -26572,7 +26572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -26587,7 +26587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -26704,7 +26704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -26821,7 +26821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -26938,7 +26938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27055,7 +27055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -27111,7 +27111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -27167,7 +27167,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -27224,7 +27224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -27281,7 +27281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -27338,7 +27338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -27395,7 +27395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -27421,7 +27421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -27442,7 +27442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -27457,7 +27457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -27513,7 +27513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -27547,7 +27547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -27603,7 +27603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -27623,7 +27623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -27638,7 +27638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -27670,7 +27670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -27726,7 +27726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -27809,7 +27809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -27908,7 +27908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -27941,7 +27941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -27962,7 +27962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28006,7 +28006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28046,7 +28046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28240,7 +28240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28254,7 +28254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28269,7 +28269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28283,7 +28283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -28298,7 +28298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -28313,7 +28313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -28333,7 +28333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -28355,7 +28355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -28376,7 +28376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -28397,7 +28397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -28477,7 +28477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -28515,7 +28515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -28536,7 +28536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -28616,7 +28616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -28654,7 +28654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -28702,7 +28702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -28735,7 +28735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -28855,7 +28855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -28870,7 +28870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -28885,7 +28885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -28942,7 +28942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -28993,7 +28993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29044,7 +29044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29095,7 +29095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29127,7 +29127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29141,7 +29141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29161,7 +29161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29339,7 +29339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -29372,7 +29372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -29387,7 +29387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -29415,7 +29415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -29455,7 +29455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29490,7 +29490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29551,7 +29551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29610,7 +29610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29639,7 +29639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29689,7 +29689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29723,7 +29723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29796,7 +29796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30010,7 +30010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30042,7 +30042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30080,7 +30080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30130,7 +30130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30162,7 +30162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30285,7 +30285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30330,7 +30330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30375,7 +30375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30420,7 +30420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30465,7 +30465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30517,7 +30517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30561,7 +30561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30575,7 +30575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30590,7 +30590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30630,7 +30630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30682,7 +30682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30696,7 +30696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30842,7 +30842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30921,7 +30921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30936,7 +30936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30951,7 +30951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30966,7 +30966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30981,7 +30981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31008,7 +31008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31041,7 +31041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31055,7 +31055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31070,7 +31070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31106,7 +31106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31138,7 +31138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31170,7 +31170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31190,7 +31190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31320,7 +31320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -31358,7 +31358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -31373,7 +31373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -31388,7 +31388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31416,7 +31416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31456,7 +31456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31495,7 +31495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31587,7 +31587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31608,7 +31608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31658,7 +31658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31715,7 +31715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31766,7 +31766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31817,7 +31817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31870,7 +31870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31903,12 +31903,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -32000,7 +32000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32028,7 +32028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32076,7 +32076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -32115,7 +32115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -32129,7 +32129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32287,7 +32287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32389,7 +32389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32536,7 +32536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32644,7 +32644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32659,7 +32659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32674,7 +32674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32689,7 +32689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32703,7 +32703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32717,7 +32717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -32731,7 +32731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32800,7 +32800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32857,7 +32857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -32914,7 +32914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32971,7 +32971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32999,7 +32999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33030,7 +33030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -33039,7 +33039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33100,7 +33100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33186,7 +33186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33290,7 +33290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33500,7 +33500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34040,7 +34040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34485,6 +34485,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -34519,7 +34547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34546,7 +34574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34789,9 +34817,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -35225,7 +35253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35245,7 +35273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35260,7 +35288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -35275,7 +35303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -35289,7 +35317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -35303,7 +35331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -35317,7 +35345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -35392,7 +35420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -35449,7 +35477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -35506,7 +35534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -35563,7 +35591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -35616,7 +35644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -35631,7 +35659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -35789,7 +35817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -35822,7 +35850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -35855,7 +35883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -35888,7 +35916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -35927,7 +35955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -35947,7 +35975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36042,7 +36070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36071,7 +36099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36086,7 +36114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36101,7 +36129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36116,7 +36144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -36131,7 +36159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -36165,7 +36193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36306,7 +36334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36355,7 +36383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36423,7 +36451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36437,7 +36465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36469,7 +36497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -36592,7 +36620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -36697,7 +36725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36802,7 +36830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36907,7 +36935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36922,7 +36950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36937,7 +36965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36969,7 +36997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -37001,7 +37029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -37033,7 +37061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37061,7 +37089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -37117,7 +37145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -37174,7 +37202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -37283,7 +37311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -37334,7 +37362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -37385,7 +37413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -37436,7 +37464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -37487,7 +37515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -37502,7 +37530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -37517,7 +37545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37531,7 +37559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -37576,7 +37604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -38402,6 +38430,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -38452,7 +38498,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -38493,80 +38585,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38664,12 +38682,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -38679,6 +38691,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38714,46 +38738,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -38782,6 +38766,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38835,7 +38837,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -38882,134 +38930,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39101,30 +39021,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -39134,6 +39030,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39169,64 +39077,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -39255,6 +39105,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39308,7 +39176,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -39355,134 +39269,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39574,30 +39360,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -39607,6 +39369,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39642,64 +39416,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -39728,6 +39444,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39805,7 +39539,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -39852,140 +39638,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40083,30 +39735,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -40116,6 +39744,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40146,64 +39786,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -40894,7 +40476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -40985,7 +40567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41138,7 +40720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -41189,7 +40771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -41282,7 +40864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -41435,7 +41017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41588,7 +41170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41741,7 +41323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -41869,7 +41451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -41898,7 +41480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42070,7 +41652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -42235,9 +41817,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42401,9 +41983,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42567,9 +42149,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42733,7 +42315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -42792,9 +42374,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42852,9 +42434,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42912,9 +42494,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42972,7 +42554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43037,9 +42619,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43103,9 +42685,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43169,9 +42751,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43235,7 +42817,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43336,9 +42918,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43444,9 +43026,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43546,9 +43128,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43648,7 +43230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43749,9 +43331,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43857,9 +43439,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43959,9 +43541,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44061,7 +43643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -44150,9 +43732,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44240,9 +43822,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44330,9 +43912,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -44424,7 +44006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44438,7 +44020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44452,7 +44034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44514,7 +44096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44559,7 +44141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -44614,7 +44196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -44723,43 +44305,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44767,7 +44349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -44818,7 +44400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44867,43 +44449,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44911,7 +44493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -45020,43 +44602,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -45064,7 +44646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -45173,43 +44755,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -45217,7 +44799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -45326,43 +44908,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -45370,7 +44952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -45486,7 +45068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -45512,7 +45094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -45544,7 +45126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -45576,7 +45158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -45598,7 +45180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -45758,9 +45340,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -45925,7 +45507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -46074,9 +45656,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46224,9 +45806,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46374,9 +45956,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46524,7 +46106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -46577,9 +46159,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46631,9 +46213,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46685,9 +46267,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46739,7 +46321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -46804,9 +46386,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46870,9 +46452,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46936,9 +46518,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47002,7 +46584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -47091,9 +46673,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47181,9 +46763,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47271,9 +46853,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -47361,7 +46943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -47444,9 +47026,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47528,9 +47110,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47612,9 +47194,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47696,7 +47278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -47779,9 +47361,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47863,9 +47445,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47947,9 +47529,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48031,7 +47613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -48053,7 +47635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -48103,7 +47685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -48117,7 +47699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -48131,7 +47713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -48193,7 +47775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -48238,7 +47820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -48295,7 +47877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -48340,7 +47922,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -48355,7 +47937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -48391,7 +47973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48422,7 +48004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -48468,7 +48050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -48497,7 +48079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -48547,7 +48129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48587,7 +48169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -48614,7 +48196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -48652,7 +48234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48684,7 +48266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -48837,7 +48419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48990,7 +48572,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -49143,7 +48725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -49296,7 +48878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -49449,7 +49031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -49602,7 +49184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -49755,7 +49337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -49907,7 +49489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -50059,7 +49641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -50212,7 +49794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -50365,7 +49947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -50518,7 +50100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -50671,7 +50253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -50830,7 +50412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50881,7 +50463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50932,7 +50514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50983,7 +50565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -51034,7 +50616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -51048,7 +50630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -51062,7 +50644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -51082,7 +50664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -51176,7 +50758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -51190,7 +50772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -51204,7 +50786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -51797,7 +51379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -51817,7 +51399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -51831,7 +51413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -51859,7 +51441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -52059,7 +51641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -53948,6 +53530,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV71J19.svd
+++ b/data/Atmel/ATSAMV71J19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -428,7 +428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -495,7 +495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -795,7 +795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -822,7 +822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -849,7 +849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -876,7 +876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -944,7 +944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -961,7 +961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -978,7 +978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -995,7 +995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -1010,7 +1010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -1024,7 +1024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -1040,7 +1040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -1056,7 +1056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -1071,7 +1071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -1088,7 +1088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -1102,7 +1102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -1142,7 +1142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1163,7 +1163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1423,7 +1423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1553,7 +1553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1609,7 +1609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1803,7 +1803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1884,7 +1884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1905,7 +1905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -2010,7 +2010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -2115,7 +2115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2220,7 +2220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2325,7 +2325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2406,7 +2406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2426,7 +2426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2506,7 +2506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2586,7 +2586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2600,7 +2600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2615,7 +2615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2629,7 +2629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2672,7 +2672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2692,7 +2692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2718,7 +2718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2798,7 +2798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2812,7 +2812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2832,7 +2832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2912,7 +2912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2940,7 +2940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2961,7 +2961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_VERSION</name>
+               <name>VERSION</name>
                <description>AFEC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -3005,7 +3005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3335,7 +3335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3692,7 +3692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -3796,7 +3796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -3975,7 +3975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -3996,7 +3996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4010,7 +4010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4112,7 +4112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4162,7 +4162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4176,7 +4176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4190,7 +4190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4369,7 +4369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4534,7 +4534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -4699,7 +4699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -4863,7 +4863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -4913,7 +4913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -4928,7 +4928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -4942,7 +4942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -4962,7 +4962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -4982,7 +4982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -4996,7 +4996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5010,7 +5010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5031,7 +5031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5045,7 +5045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5060,7 +5060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5080,7 +5080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5100,7 +5100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5120,7 +5120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5140,7 +5140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5178,7 +5178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5192,7 +5192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5212,7 +5212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5232,7 +5232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5246,7 +5246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5260,7 +5260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5274,7 +5274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5288,7 +5288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5302,7 +5302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5317,7 +5317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5332,7 +5332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5347,7 +5347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5362,7 +5362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MID</name>
+               <name>MID</name>
                <description>Module ID Register</description>
                <addressOffset>0x0FC</addressOffset>
                <size>32</size>
@@ -5383,7 +5383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5398,7 +5398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5413,7 +5413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5428,7 +5428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5443,7 +5443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5458,7 +5458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5473,7 +5473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5488,7 +5488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5503,7 +5503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5518,7 +5518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5533,7 +5533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5548,7 +5548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5563,7 +5563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5578,7 +5578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5593,7 +5593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -5608,7 +5608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -5623,7 +5623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -5653,7 +5653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -5668,7 +5668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -5683,7 +5683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -5698,7 +5698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -5713,7 +5713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6072,7 +6072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6086,7 +6086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6100,7 +6100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6114,7 +6114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6135,7 +6135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6176,7 +6176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6191,7 +6191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6206,7 +6206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6221,7 +6221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6236,7 +6236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6251,7 +6251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6266,7 +6266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6336,7 +6336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6352,7 +6352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6368,7 +6368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6382,7 +6382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6402,7 +6402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6416,7 +6416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6432,7 +6432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6472,7 +6472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6548,7 +6548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -6601,7 +6601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -6654,7 +6654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -6706,7 +6706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -6720,7 +6720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -6740,7 +6740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -6783,7 +6783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -6803,7 +6803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -6846,7 +6846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -6866,7 +6866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -6909,7 +6909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -6929,7 +6929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -6972,7 +6972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -6992,7 +6992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7035,7 +7035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7055,7 +7055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7098,7 +7098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7118,7 +7118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7161,7 +7161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7181,7 +7181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7224,7 +7224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7244,7 +7244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7287,7 +7287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7307,7 +7307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7350,7 +7350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7413,7 +7413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7433,7 +7433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7476,7 +7476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7496,7 +7496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7539,7 +7539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7559,7 +7559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -7602,7 +7602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -7622,7 +7622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -7665,7 +7665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -7685,7 +7685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -7728,7 +7728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -7748,7 +7748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -7791,7 +7791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -7811,7 +7811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -7854,7 +7854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -7874,7 +7874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -7917,7 +7917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -7980,7 +7980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8000,7 +8000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8043,7 +8043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8063,7 +8063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8106,7 +8106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8126,7 +8126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8169,7 +8169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8189,7 +8189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8282,7 +8282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8321,7 +8321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8371,7 +8371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8434,7 +8434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8494,7 +8494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8751,7 +8751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8771,7 +8771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8836,7 +8836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8851,7 +8851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -8866,7 +8866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -8881,7 +8881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9034,7 +9034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9187,7 +9187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9340,7 +9340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9493,7 +9493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9541,7 +9541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9573,7 +9573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -9601,7 +9601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -9622,7 +9622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -9645,7 +9645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -9678,7 +9678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9764,7 +9764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9809,7 +9809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9836,7 +9836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9887,7 +9887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9938,7 +9938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9989,7 +9989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10040,7 +10040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10083,7 +10083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10097,7 +10097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10113,7 +10113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10147,7 +10147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10245,7 +10245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10353,7 +10353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10373,7 +10373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10387,7 +10387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10419,7 +10419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10451,7 +10451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10483,7 +10483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10515,7 +10515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10547,7 +10547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10580,7 +10580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10661,7 +10661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10724,7 +10724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10787,7 +10787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10850,7 +10850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10871,7 +10871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10892,7 +10892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10913,7 +10913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10927,7 +10927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10959,7 +10959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10973,7 +10973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10987,7 +10987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11019,7 +11019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11033,7 +11033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11061,7 +11061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11082,7 +11082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -11120,7 +11120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11179,7 +11179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11229,7 +11229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11285,7 +11285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11318,7 +11318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11494,7 +11494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11522,7 +11522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x01FC</addressOffset>
                <size>32</size>
@@ -11587,7 +11587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11632,7 +11632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11647,7 +11647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11661,7 +11661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11718,7 +11718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11786,7 +11786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11806,7 +11806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12019,7 +12019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12051,7 +12051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12089,7 +12089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12103,7 +12103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12165,7 +12165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12179,7 +12179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12212,7 +12212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -12341,7 +12341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12541,7 +12541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12741,7 +12741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12941,7 +12941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12961,7 +12961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13045,7 +13045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13065,7 +13065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13085,7 +13085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13099,7 +13099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13155,7 +13155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13355,7 +13355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13555,7 +13555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13587,7 +13587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13626,7 +13626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13640,7 +13640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13654,7 +13654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13686,7 +13686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13754,7 +13754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13768,7 +13768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13923,7 +13923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13955,7 +13955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13988,7 +13988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14045,7 +14045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14246,7 +14246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14446,7 +14446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14646,7 +14646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14847,7 +14847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15048,7 +15048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15248,7 +15248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15448,7 +15448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15474,7 +15474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15513,7 +15513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15546,7 +15546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -15652,7 +15652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -15666,7 +15666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -15680,7 +15680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -15724,7 +15724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -15757,7 +15757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -15855,7 +15855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -15881,7 +15881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -15909,7 +15909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -15925,7 +15925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -15942,7 +15942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -15959,7 +15959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -15975,7 +15975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15989,7 +15989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -16003,7 +16003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -16042,7 +16042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -16089,7 +16089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -16105,7 +16105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -16138,7 +16138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -16339,7 +16339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16540,7 +16540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16741,7 +16741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16942,7 +16942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17143,7 +17143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -17344,7 +17344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17545,7 +17545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17746,7 +17746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17947,7 +17947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18148,7 +18148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -18349,7 +18349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18549,7 +18549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18750,7 +18750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18951,7 +18951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -19152,7 +19152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -19353,7 +19353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19554,7 +19554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19755,7 +19755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19956,7 +19956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -20157,7 +20157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -20358,7 +20358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20559,7 +20559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20762,7 +20762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20962,7 +20962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -21163,7 +21163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -21364,7 +21364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21565,7 +21565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21579,7 +21579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21780,7 +21780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21981,7 +21981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -22182,7 +22182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -22383,7 +22383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22584,7 +22584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22785,7 +22785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22986,7 +22986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -23187,7 +23187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -23388,7 +23388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23589,7 +23589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23790,7 +23790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23991,7 +23991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -24192,7 +24192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -24393,7 +24393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24594,7 +24594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24795,7 +24795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24823,7 +24823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24844,7 +24844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -24865,7 +24865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25065,7 +25065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25681,7 +25681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25737,7 +25737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25770,7 +25770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25803,7 +25803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25836,7 +25836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25857,7 +25857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25907,7 +25907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25964,7 +25964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -26021,7 +26021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -26084,7 +26084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -26243,7 +26243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -26402,7 +26402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26752,7 +26752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26873,7 +26873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26895,7 +26895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26943,7 +26943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -27042,7 +27042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -27141,7 +27141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -27258,7 +27258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -27357,7 +27357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27515,7 +27515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27619,7 +27619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27634,7 +27634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27662,7 +27662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27683,7 +27683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -27704,7 +27704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27863,7 +27863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -28022,7 +28022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -28181,7 +28181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -28253,7 +28253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -28297,7 +28297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28456,7 +28456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28615,7 +28615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28774,7 +28774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28933,7 +28933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28947,7 +28947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -29106,7 +29106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -29265,7 +29265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29424,7 +29424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29583,7 +29583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29598,7 +29598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -29624,7 +29624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -29671,7 +29671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29845,7 +29845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29878,7 +29878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29911,7 +29911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29944,7 +29944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30001,7 +30001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30058,7 +30058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30115,7 +30115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30172,7 +30172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30240,7 +30240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30255,7 +30255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30269,7 +30269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30289,7 +30289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30304,7 +30304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30421,7 +30421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30538,7 +30538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30655,7 +30655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30772,7 +30772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30828,7 +30828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30884,7 +30884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30941,7 +30941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30998,7 +30998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -31055,7 +31055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -31112,7 +31112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -31138,7 +31138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -31159,7 +31159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -31174,7 +31174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -31230,7 +31230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -31264,7 +31264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -31320,7 +31320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -31340,7 +31340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -31355,7 +31355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -31387,7 +31387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -31443,7 +31443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31526,7 +31526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31619,7 +31619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -31646,7 +31646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31666,7 +31666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31687,7 +31687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31731,7 +31731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31771,7 +31771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31913,7 +31913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31927,7 +31927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31942,7 +31942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31956,7 +31956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31971,7 +31971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31986,7 +31986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32006,7 +32006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32028,7 +32028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -32049,7 +32049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -32070,7 +32070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -32150,7 +32150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -32188,7 +32188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -32209,7 +32209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -32289,7 +32289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -32327,7 +32327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -32375,7 +32375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32408,7 +32408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32528,7 +32528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32543,7 +32543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32558,7 +32558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32615,7 +32615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32666,7 +32666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32717,7 +32717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32768,7 +32768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32800,7 +32800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32814,7 +32814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32834,7 +32834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33012,7 +33012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33045,7 +33045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33060,7 +33060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33088,7 +33088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33109,7 +33109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -33149,7 +33149,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33184,7 +33184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33245,7 +33245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33304,7 +33304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33333,7 +33333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33383,7 +33383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33417,7 +33417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33490,7 +33490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33704,7 +33704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33736,7 +33736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33774,7 +33774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33824,7 +33824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33856,7 +33856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33979,7 +33979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34024,7 +34024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34069,7 +34069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34114,7 +34114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34159,7 +34159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34192,7 +34192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34232,7 +34232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34276,7 +34276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34290,7 +34290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34305,7 +34305,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34345,7 +34345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34384,7 +34384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34398,7 +34398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34556,7 +34556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34658,7 +34658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34805,7 +34805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34913,7 +34913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34928,7 +34928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34943,7 +34943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34958,7 +34958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34972,7 +34972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34986,7 +34986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35000,7 +35000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35069,7 +35069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35126,7 +35126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35183,7 +35183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35240,7 +35240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35268,7 +35268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35289,7 +35289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35329,7 +35329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35390,7 +35390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35476,7 +35476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35580,7 +35580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35790,7 +35790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36330,7 +36330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36830,7 +36830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36857,7 +36857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37100,7 +37100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37120,7 +37120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37135,7 +37135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37150,7 +37150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37164,7 +37164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37178,7 +37178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37192,7 +37192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37267,7 +37267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37324,7 +37324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37381,7 +37381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37438,7 +37438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37491,7 +37491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37506,7 +37506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -37652,7 +37652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -37679,7 +37679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -37706,7 +37706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -37733,7 +37733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -37766,7 +37766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -37786,7 +37786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37814,7 +37814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -37902,7 +37902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37931,7 +37931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37946,7 +37946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37961,7 +37961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -37976,7 +37976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37991,7 +37991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38006,7 +38006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -38046,7 +38046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38187,7 +38187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38236,7 +38236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38304,7 +38304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38318,7 +38318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38350,7 +38350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38473,7 +38473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38578,7 +38578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -38683,7 +38683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -38788,7 +38788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -38803,7 +38803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -38818,7 +38818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -38850,7 +38850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -38882,7 +38882,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -38914,7 +38914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_DR</name>
+               <name>DR</name>
                <description>Debug Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38947,7 +38947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38975,7 +38975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -38996,7 +38996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -39044,7 +39044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39107,7 +39107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39216,7 +39216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39267,7 +39267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39318,7 +39318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39369,7 +39369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39438,7 +39438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39453,7 +39453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39468,7 +39468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39482,7 +39482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39527,7 +39527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -39555,7 +39555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -41128,7 +41128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41219,7 +41219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41372,7 +41372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -41423,7 +41423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -41516,7 +41516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -41669,7 +41669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41822,7 +41822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41975,7 +41975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42103,7 +42103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42132,7 +42132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42304,7 +42304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -42469,7 +42469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -42528,7 +42528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -42593,7 +42593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42694,7 +42694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -42795,7 +42795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -42888,7 +42888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -42902,7 +42902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -42916,7 +42916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -42978,7 +42978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43023,7 +43023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43078,7 +43078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43231,7 +43231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43282,7 +43282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43375,7 +43375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -43528,7 +43528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -43681,7 +43681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -43834,7 +43834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -43950,7 +43950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -43976,7 +43976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44008,7 +44008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44040,7 +44040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44062,7 +44062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44222,7 +44222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -44371,7 +44371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -44424,7 +44424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -44489,7 +44489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -44578,7 +44578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -44661,7 +44661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -44744,7 +44744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -44766,7 +44766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -44816,7 +44816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44830,7 +44830,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44844,7 +44844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44906,7 +44906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44951,7 +44951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -45008,7 +45008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -45053,7 +45053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45068,7 +45068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45089,7 +45089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA1</name>
+               <name>TSTA1</name>
                <description>General Test A1 Register</description>
                <addressOffset>0x0810</addressOffset>
                <size>32</size>
@@ -45133,7 +45133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA2</name>
+               <name>TSTA2</name>
                <description>General Test A2 Register</description>
                <addressOffset>0x0814</addressOffset>
                <size>32</size>
@@ -45195,7 +45195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_VERSION</name>
+               <name>VERSION</name>
                <description>General Version Register</description>
                <addressOffset>0x0818</addressOffset>
                <size>32</size>
@@ -45216,7 +45216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_FSM</name>
+               <name>FSM</name>
                <description>General Finite State Machine Register</description>
                <addressOffset>0x082C</addressOffset>
                <size>32</size>
@@ -45329,7 +45329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45360,7 +45360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45406,7 +45406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45435,7 +45435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -45485,7 +45485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -45525,7 +45525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -45552,7 +45552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -45590,7 +45590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -45622,7 +45622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -45775,7 +45775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45928,7 +45928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -46081,7 +46081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -46234,7 +46234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -46387,7 +46387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -46540,7 +46540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -46693,7 +46693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -46845,7 +46845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -46997,7 +46997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47150,7 +47150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47303,7 +47303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -47456,7 +47456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -47609,7 +47609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -47768,7 +47768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47819,7 +47819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47870,7 +47870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47921,7 +47921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47972,7 +47972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -47986,7 +47986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -48000,7 +48000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -48020,7 +48020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -48114,7 +48114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -48128,7 +48128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -48142,7 +48142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -48472,7 +48472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -48492,7 +48492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -48506,7 +48506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -48521,7 +48521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>XDMAC_VERSION</name>
+               <name>VERSION</name>
                <description>XDMAC Version Register</description>
                <addressOffset>0xFFC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV71J19B.svd
+++ b/data/Atmel/ATSAMV71J19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7457,7 +7457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7502,7 +7502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7529,7 +7529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7580,7 +7580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7631,7 +7631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7682,7 +7682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7733,7 +7733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7776,7 +7776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7806,7 +7806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7840,7 +7840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8046,7 +8046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8066,7 +8066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8080,7 +8080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8112,7 +8112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8144,7 +8144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8176,7 +8176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8208,7 +8208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8240,7 +8240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8273,7 +8273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8354,7 +8354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8417,7 +8417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -8543,7 +8543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -8564,7 +8564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -8585,7 +8585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8606,7 +8606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8620,7 +8620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8666,7 +8666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8680,7 +8680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8712,7 +8712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8754,7 +8754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8792,7 +8792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -8851,7 +8851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8901,7 +8901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -8957,7 +8957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -8990,7 +8990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -9212,7 +9212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -9240,7 +9240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -9284,7 +9284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9329,7 +9329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9358,7 +9358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9409,7 +9409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9471,7 +9471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9491,7 +9491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9700,7 +9700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9732,7 +9732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9770,7 +9770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9784,7 +9784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -9846,7 +9846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -9860,7 +9860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9893,7 +9893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10034,7 +10034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10054,7 +10054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10230,7 +10230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10406,7 +10406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10582,7 +10582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -10602,7 +10602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -10686,7 +10686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -10706,7 +10706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -10726,7 +10726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -10740,7 +10740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -10796,7 +10796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -10996,7 +10996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -11196,7 +11196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -11228,7 +11228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -11267,7 +11267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -11281,7 +11281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -11295,7 +11295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -11327,7 +11327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -11395,7 +11395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -11409,7 +11409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11596,7 +11596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -11629,7 +11629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -11686,7 +11686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -11887,7 +11887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12087,7 +12087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -12287,7 +12287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -12488,7 +12488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -12689,7 +12689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -12889,7 +12889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -13089,7 +13089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -13115,7 +13115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -13154,7 +13154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -13187,7 +13187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -13293,7 +13293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -13307,7 +13307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -13321,7 +13321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -13365,7 +13365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -13398,7 +13398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -13496,7 +13496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -13522,7 +13522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -13550,7 +13550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13566,7 +13566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13583,7 +13583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13600,7 +13600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13616,7 +13616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13630,7 +13630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -13644,7 +13644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -13683,7 +13683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -13730,7 +13730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -13746,7 +13746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -13779,7 +13779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -13980,7 +13980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -14181,7 +14181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -14382,7 +14382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -14583,7 +14583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -14784,7 +14784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -14985,7 +14985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -15186,7 +15186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -15387,7 +15387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -15588,7 +15588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -15789,7 +15789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -15990,7 +15990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16190,7 +16190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -16391,7 +16391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -16592,7 +16592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -16793,7 +16793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -16994,7 +16994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -17195,7 +17195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -17396,7 +17396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -17597,7 +17597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -17798,7 +17798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -17999,7 +17999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18200,7 +18200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -18403,7 +18403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -18603,7 +18603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -18804,7 +18804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -19005,7 +19005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -19206,7 +19206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -19220,7 +19220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -19421,7 +19421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -19622,7 +19622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -19823,7 +19823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -20024,7 +20024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -20225,7 +20225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -20426,7 +20426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -20627,7 +20627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -20828,7 +20828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -21029,7 +21029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -21230,7 +21230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -21431,7 +21431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -21632,7 +21632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -21833,7 +21833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -22034,7 +22034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -22235,7 +22235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -22436,7 +22436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -22464,7 +22464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -22485,7 +22485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22685,7 +22685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -23301,7 +23301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -23357,7 +23357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -23390,7 +23390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -23423,7 +23423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -23456,7 +23456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -23477,7 +23477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -23527,7 +23527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -23590,7 +23590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -23653,7 +23653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -23722,7 +23722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -23845,7 +23845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -24282,7 +24282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -24403,7 +24403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -24425,7 +24425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24473,7 +24473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -24578,7 +24578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -24683,7 +24683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -24806,7 +24806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -24911,7 +24911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -25069,7 +25069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -25173,7 +25173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -25188,7 +25188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25216,7 +25216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25237,7 +25237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25378,7 +25378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -25519,7 +25519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -25660,7 +25660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -25732,7 +25732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -25776,7 +25776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -25899,7 +25899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26022,7 +26022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -26145,7 +26145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -26268,7 +26268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -26282,7 +26282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -26423,7 +26423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -26564,7 +26564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -26705,7 +26705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -26846,7 +26846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -26880,7 +26880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27054,7 +27054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27087,7 +27087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27120,7 +27120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27153,7 +27153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27210,7 +27210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27267,7 +27267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27324,7 +27324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27381,7 +27381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27449,7 +27449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -27464,7 +27464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -27478,7 +27478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -27498,7 +27498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27513,7 +27513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -27630,7 +27630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27747,7 +27747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27864,7 +27864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27981,7 +27981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28037,7 +28037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -28093,7 +28093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28150,7 +28150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -28207,7 +28207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -28264,7 +28264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -28321,7 +28321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -28347,7 +28347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -28368,7 +28368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -28383,7 +28383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -28439,7 +28439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -28473,7 +28473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -28529,7 +28529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -28549,7 +28549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -28564,7 +28564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -28596,7 +28596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -28652,7 +28652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28735,7 +28735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28834,7 +28834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28867,7 +28867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28888,7 +28888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28932,7 +28932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28972,7 +28972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29166,7 +29166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29180,7 +29180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29195,7 +29195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29209,7 +29209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -29224,7 +29224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -29239,7 +29239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -29259,7 +29259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -29281,7 +29281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -29302,7 +29302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -29323,7 +29323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -29403,7 +29403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -29441,7 +29441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -29462,7 +29462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -29542,7 +29542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -29580,7 +29580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -29628,7 +29628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29661,7 +29661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29781,7 +29781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29796,7 +29796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29811,7 +29811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29868,7 +29868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29919,7 +29919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29970,7 +29970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30021,7 +30021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30053,7 +30053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30067,7 +30067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30087,7 +30087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30265,7 +30265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30298,7 +30298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30313,7 +30313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30341,7 +30341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30381,7 +30381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30416,7 +30416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30477,7 +30477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30536,7 +30536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30565,7 +30565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30615,7 +30615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30649,7 +30649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30722,7 +30722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30936,7 +30936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30968,7 +30968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31006,7 +31006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31056,7 +31056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31088,7 +31088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31211,7 +31211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31256,7 +31256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31301,7 +31301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31346,7 +31346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31391,7 +31391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31443,7 +31443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31487,7 +31487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31501,7 +31501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31516,7 +31516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31556,7 +31556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -31595,7 +31595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -31609,7 +31609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31767,7 +31767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31869,7 +31869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32016,7 +32016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32124,7 +32124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32139,7 +32139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32154,7 +32154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32169,7 +32169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32183,7 +32183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32197,7 +32197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -32211,7 +32211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32280,7 +32280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32337,7 +32337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -32394,7 +32394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32451,7 +32451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32479,7 +32479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32510,7 +32510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -32519,7 +32519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32580,7 +32580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32666,7 +32666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32770,7 +32770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32980,7 +32980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33520,7 +33520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33965,6 +33965,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -33999,7 +34027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34026,7 +34054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34269,9 +34297,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -34705,7 +34733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34725,7 +34753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34740,7 +34768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34755,7 +34783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34769,7 +34797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34783,7 +34811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34797,7 +34825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34872,7 +34900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34929,7 +34957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34986,7 +35014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -35043,7 +35071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -35096,7 +35124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -35111,7 +35139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -35269,7 +35297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -35302,7 +35330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -35335,7 +35363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -35368,7 +35396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -35407,7 +35435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -35427,7 +35455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35522,7 +35550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35551,7 +35579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35566,7 +35594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35581,7 +35609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35596,7 +35624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35611,7 +35639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35645,7 +35673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35786,7 +35814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35835,7 +35863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35903,7 +35931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35917,7 +35945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35949,7 +35977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -36072,7 +36100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -36177,7 +36205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36282,7 +36310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36387,7 +36415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36402,7 +36430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36417,7 +36445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36449,7 +36477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36481,7 +36509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36513,7 +36541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36541,7 +36569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36589,7 +36617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36646,7 +36674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36755,7 +36783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36806,7 +36834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36857,7 +36885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36908,7 +36936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36959,7 +36987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36974,7 +37002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36989,7 +37017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37003,7 +37031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -37048,7 +37076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -37858,6 +37886,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -37908,7 +37954,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -37949,80 +38041,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38120,12 +38138,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -38135,6 +38147,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38170,46 +38194,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -38238,6 +38222,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38291,7 +38293,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -38338,134 +38386,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38557,30 +38477,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -38590,6 +38486,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38625,64 +38533,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -38711,6 +38561,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38764,7 +38632,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -38811,134 +38725,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39030,30 +38816,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -39063,6 +38825,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39098,64 +38872,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -39184,6 +38900,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39261,7 +38995,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -39308,140 +39094,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39539,30 +39191,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -39572,6 +39200,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39602,64 +39242,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -40342,7 +39924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -40433,7 +40015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -40586,7 +40168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40637,7 +40219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40730,7 +40312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40883,7 +40465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41036,7 +40618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41189,7 +40771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -41317,7 +40899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -41346,7 +40928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -41518,7 +41100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -41683,9 +41265,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41849,9 +41431,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42015,9 +41597,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42181,7 +41763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -42240,9 +41822,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42300,9 +41882,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42360,9 +41942,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42420,7 +42002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -42485,9 +42067,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42551,9 +42133,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42617,9 +42199,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42683,7 +42265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42784,9 +42366,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42892,9 +42474,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42994,9 +42576,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43096,7 +42678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43197,9 +42779,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43305,9 +42887,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43407,9 +42989,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43509,7 +43091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43598,9 +43180,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43688,9 +43270,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43778,9 +43360,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43872,7 +43454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43886,7 +43468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43900,7 +43482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43962,7 +43544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44007,7 +43589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -44062,7 +43644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -44171,43 +43753,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44215,7 +43797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -44266,7 +43848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44315,43 +43897,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44359,7 +43941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44468,43 +44050,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44512,7 +44094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44621,43 +44203,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44665,7 +44247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44774,43 +44356,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44818,7 +44400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44934,7 +44516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44960,7 +44542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44992,7 +44574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -45024,7 +44606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -45046,7 +44628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -45206,9 +44788,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -45373,7 +44955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45522,9 +45104,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45672,9 +45254,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45822,9 +45404,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45972,7 +45554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -46025,9 +45607,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46079,9 +45661,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46133,9 +45715,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46187,7 +45769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -46252,9 +45834,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46318,9 +45900,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46384,9 +45966,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46450,7 +46032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -46539,9 +46121,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46629,9 +46211,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46719,9 +46301,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46809,7 +46391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46892,9 +46474,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46976,9 +46558,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47060,9 +46642,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47144,7 +46726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -47227,9 +46809,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47311,9 +46893,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47395,9 +46977,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47479,7 +47061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -47501,7 +47083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -47551,7 +47133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47565,7 +47147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47579,7 +47161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47641,7 +47223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47686,7 +47268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47743,7 +47325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47788,7 +47370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47803,7 +47385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47839,7 +47421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47870,7 +47452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47916,7 +47498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47945,7 +47527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47995,7 +47577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48035,7 +47617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -48062,7 +47644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -48100,7 +47682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48132,7 +47714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -48285,7 +47867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48438,7 +48020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -48591,7 +48173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48744,7 +48326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48897,7 +48479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -49050,7 +48632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -49203,7 +48785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -49355,7 +48937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -49507,7 +49089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49660,7 +49242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49813,7 +49395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49966,7 +49548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -50119,7 +49701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -50278,7 +49860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50329,7 +49911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50380,7 +49962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50431,7 +50013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50482,7 +50064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -50496,7 +50078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -50510,7 +50092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -50530,7 +50112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -50624,7 +50206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50638,7 +50220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50652,7 +50234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -51135,7 +50717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -51155,7 +50737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -51169,7 +50751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -51197,7 +50779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -53086,6 +52668,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV71J20.svd
+++ b/data/Atmel/ATSAMV71J20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -428,7 +428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -495,7 +495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -795,7 +795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -822,7 +822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -849,7 +849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -876,7 +876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -944,7 +944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -961,7 +961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -978,7 +978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -995,7 +995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -1010,7 +1010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -1024,7 +1024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -1040,7 +1040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -1056,7 +1056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -1071,7 +1071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -1088,7 +1088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -1102,7 +1102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -1142,7 +1142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1163,7 +1163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1423,7 +1423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1553,7 +1553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1609,7 +1609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1803,7 +1803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1884,7 +1884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1905,7 +1905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -2010,7 +2010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -2115,7 +2115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2220,7 +2220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2325,7 +2325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2406,7 +2406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2426,7 +2426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2506,7 +2506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2586,7 +2586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2600,7 +2600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2615,7 +2615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2629,7 +2629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2672,7 +2672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2692,7 +2692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2718,7 +2718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2798,7 +2798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2812,7 +2812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2832,7 +2832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2912,7 +2912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2940,7 +2940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2961,7 +2961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_VERSION</name>
+               <name>VERSION</name>
                <description>AFEC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -3005,7 +3005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3335,7 +3335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3369,7 +3369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3384,7 +3384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3480,7 +3480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3702,7 +3702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3723,7 +3723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3744,7 +3744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3779,7 +3779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3800,7 +3800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3833,7 +3833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3866,7 +3866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3899,7 +3899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3932,7 +3932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3952,7 +3952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3980,7 +3980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4001,7 +4001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -4364,7 +4364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4468,7 +4468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4647,7 +4647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4784,7 +4784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4834,7 +4834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4848,7 +4848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4862,7 +4862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4894,7 +4894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -5041,7 +5041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5206,7 +5206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5371,7 +5371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5585,7 +5585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5600,7 +5600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5614,7 +5614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5634,7 +5634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5654,7 +5654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5668,7 +5668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5703,7 +5703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5717,7 +5717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5732,7 +5732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5752,7 +5752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5772,7 +5772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5812,7 +5812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5850,7 +5850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5864,7 +5864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5884,7 +5884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5904,7 +5904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5918,7 +5918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5932,7 +5932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5946,7 +5946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5974,7 +5974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5989,7 +5989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -6004,7 +6004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -6019,7 +6019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -6034,7 +6034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MID</name>
+               <name>MID</name>
                <description>Module ID Register</description>
                <addressOffset>0x0FC</addressOffset>
                <size>32</size>
@@ -6055,7 +6055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -6070,7 +6070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -6085,7 +6085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -6100,7 +6100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -6115,7 +6115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -6130,7 +6130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -6145,7 +6145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -6160,7 +6160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -6175,7 +6175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6190,7 +6190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6205,7 +6205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6250,7 +6250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6265,7 +6265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6280,7 +6280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6295,7 +6295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6310,7 +6310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6325,7 +6325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6340,7 +6340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6355,7 +6355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6370,7 +6370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6385,7 +6385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6400,7 +6400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6415,7 +6415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6430,7 +6430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6445,7 +6445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6460,7 +6460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6475,7 +6475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6490,7 +6490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6520,7 +6520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6535,7 +6535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6550,7 +6550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6565,7 +6565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6580,7 +6580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6595,7 +6595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6610,7 +6610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6625,7 +6625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6640,7 +6640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6655,7 +6655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6670,7 +6670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6685,7 +6685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6700,7 +6700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6715,7 +6715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6730,7 +6730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6744,7 +6744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6758,7 +6758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6772,7 +6772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6786,7 +6786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6833,7 +6833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6863,7 +6863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6878,7 +6878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6893,7 +6893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6938,7 +6938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6955,7 +6955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -7008,7 +7008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -7024,7 +7024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -7040,7 +7040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -7054,7 +7054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -7074,7 +7074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -7088,7 +7088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -7104,7 +7104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7220,7 +7220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7273,7 +7273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7326,7 +7326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7378,7 +7378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7392,7 +7392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7412,7 +7412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7455,7 +7455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7475,7 +7475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7518,7 +7518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7538,7 +7538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7601,7 +7601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7644,7 +7644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7664,7 +7664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7707,7 +7707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7727,7 +7727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7770,7 +7770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7833,7 +7833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7853,7 +7853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7916,7 +7916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7959,7 +7959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7979,7 +7979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -8022,7 +8022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -8042,7 +8042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -8085,7 +8085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -8105,7 +8105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -8148,7 +8148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -8168,7 +8168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -8211,7 +8211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -8231,7 +8231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8274,7 +8274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8294,7 +8294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8337,7 +8337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8357,7 +8357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8400,7 +8400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8420,7 +8420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8463,7 +8463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8483,7 +8483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8526,7 +8526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8546,7 +8546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8589,7 +8589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8609,7 +8609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8672,7 +8672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8715,7 +8715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8735,7 +8735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8778,7 +8778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8798,7 +8798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8841,7 +8841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8861,7 +8861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8954,7 +8954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8993,7 +8993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9043,7 +9043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9106,7 +9106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9152,7 +9152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9166,7 +9166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9423,7 +9423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9508,7 +9508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9523,7 +9523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9538,7 +9538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9553,7 +9553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9706,7 +9706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9859,7 +9859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10012,7 +10012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10165,7 +10165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10213,7 +10213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10245,7 +10245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10273,7 +10273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10294,7 +10294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -10317,7 +10317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10350,7 +10350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10436,7 +10436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10508,7 +10508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10559,7 +10559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10610,7 +10610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10661,7 +10661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10712,7 +10712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10769,7 +10769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10785,7 +10785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10819,7 +10819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10917,7 +10917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11025,7 +11025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11045,7 +11045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11059,7 +11059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11091,7 +11091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11123,7 +11123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11155,7 +11155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11187,7 +11187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11219,7 +11219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11252,7 +11252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11333,7 +11333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11396,7 +11396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11459,7 +11459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11522,7 +11522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11585,7 +11585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11599,7 +11599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11631,7 +11631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11645,7 +11645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11659,7 +11659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11691,7 +11691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11705,7 +11705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11733,7 +11733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11754,7 +11754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -11792,7 +11792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11851,7 +11851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11901,7 +11901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11957,7 +11957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11990,7 +11990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -12166,7 +12166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -12194,7 +12194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -12215,7 +12215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x01FC</addressOffset>
                <size>32</size>
@@ -12259,7 +12259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -12304,7 +12304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -12319,7 +12319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -12333,7 +12333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -12390,7 +12390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12458,7 +12458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12478,7 +12478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12691,7 +12691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12723,7 +12723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12761,7 +12761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12775,7 +12775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12837,7 +12837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12851,7 +12851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12884,7 +12884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -13013,7 +13013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -13213,7 +13213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -13413,7 +13413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13613,7 +13613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13633,7 +13633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13717,7 +13717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13737,7 +13737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13757,7 +13757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13771,7 +13771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13827,7 +13827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -14027,7 +14027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -14227,7 +14227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -14259,7 +14259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -14298,7 +14298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -14312,7 +14312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -14326,7 +14326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -14358,7 +14358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -14426,7 +14426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -14440,7 +14440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14595,7 +14595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14627,7 +14627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14660,7 +14660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14717,7 +14717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14918,7 +14918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15118,7 +15118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -15318,7 +15318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15519,7 +15519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15720,7 +15720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15920,7 +15920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -16120,7 +16120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -16146,7 +16146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -16185,7 +16185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -16218,7 +16218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -16324,7 +16324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -16338,7 +16338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -16352,7 +16352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -16396,7 +16396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -16429,7 +16429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -16527,7 +16527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -16553,7 +16553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -16581,7 +16581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -16597,7 +16597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -16614,7 +16614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -16631,7 +16631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -16647,7 +16647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -16661,7 +16661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -16675,7 +16675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -16714,7 +16714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -16761,7 +16761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -16777,7 +16777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -16810,7 +16810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17011,7 +17011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17212,7 +17212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17413,7 +17413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17614,7 +17614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17815,7 +17815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18016,7 +18016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -18217,7 +18217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -18418,7 +18418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -18619,7 +18619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18820,7 +18820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -19021,7 +19021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -19221,7 +19221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -19422,7 +19422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -19623,7 +19623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -19824,7 +19824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -20025,7 +20025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -20226,7 +20226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -20427,7 +20427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -20628,7 +20628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -20829,7 +20829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -21030,7 +21030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -21231,7 +21231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -21434,7 +21434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -21634,7 +21634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -21835,7 +21835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -22036,7 +22036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -22237,7 +22237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -22251,7 +22251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -22452,7 +22452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -22653,7 +22653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -22854,7 +22854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -23055,7 +23055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -23256,7 +23256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -23457,7 +23457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -23658,7 +23658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -23859,7 +23859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -24060,7 +24060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -24261,7 +24261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -24462,7 +24462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -24663,7 +24663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -24864,7 +24864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -25065,7 +25065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -25266,7 +25266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -25467,7 +25467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25495,7 +25495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25516,7 +25516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -25537,7 +25537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25737,7 +25737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26353,7 +26353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -26409,7 +26409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -26442,7 +26442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -26475,7 +26475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -26508,7 +26508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -26529,7 +26529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -26579,7 +26579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -26636,7 +26636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -26693,7 +26693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -26756,7 +26756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -26915,7 +26915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -27074,7 +27074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -27424,7 +27424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -27545,7 +27545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -27567,7 +27567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27615,7 +27615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -27714,7 +27714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -27813,7 +27813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -27930,7 +27930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -28029,7 +28029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -28187,7 +28187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -28291,7 +28291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -28306,7 +28306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -28334,7 +28334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -28355,7 +28355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -28376,7 +28376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -28535,7 +28535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -28694,7 +28694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -28853,7 +28853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -28925,7 +28925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -28969,7 +28969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -29128,7 +29128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -29287,7 +29287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -29446,7 +29446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -29605,7 +29605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -29619,7 +29619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -29778,7 +29778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -29937,7 +29937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -30096,7 +30096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -30255,7 +30255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -30270,7 +30270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -30296,7 +30296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -30343,7 +30343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30517,7 +30517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30550,7 +30550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30583,7 +30583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30616,7 +30616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30673,7 +30673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30730,7 +30730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30787,7 +30787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30844,7 +30844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30912,7 +30912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30927,7 +30927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30941,7 +30941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30961,7 +30961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30976,7 +30976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31093,7 +31093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31210,7 +31210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31327,7 +31327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31444,7 +31444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31500,7 +31500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31556,7 +31556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31613,7 +31613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31670,7 +31670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -31727,7 +31727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -31784,7 +31784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -31810,7 +31810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -31831,7 +31831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -31846,7 +31846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -31902,7 +31902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -31936,7 +31936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -31992,7 +31992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -32012,7 +32012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -32027,7 +32027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -32059,7 +32059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -32115,7 +32115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32198,7 +32198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32291,7 +32291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -32318,7 +32318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32338,7 +32338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32359,7 +32359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32403,7 +32403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32443,7 +32443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32585,7 +32585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32599,7 +32599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32614,7 +32614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32628,7 +32628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -32643,7 +32643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -32658,7 +32658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32678,7 +32678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32700,7 +32700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -32721,7 +32721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -32742,7 +32742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -32822,7 +32822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -32860,7 +32860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -32881,7 +32881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -32961,7 +32961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -32999,7 +32999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -33047,7 +33047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33080,7 +33080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33200,7 +33200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33215,7 +33215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33230,7 +33230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33287,7 +33287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33338,7 +33338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33389,7 +33389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33440,7 +33440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33472,7 +33472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33486,7 +33486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33506,7 +33506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33684,7 +33684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33717,7 +33717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33732,7 +33732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33760,7 +33760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33781,7 +33781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -33821,7 +33821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33856,7 +33856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33917,7 +33917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33976,7 +33976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34005,7 +34005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34055,7 +34055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34089,7 +34089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34162,7 +34162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34376,7 +34376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34408,7 +34408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34446,7 +34446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34496,7 +34496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34528,7 +34528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34651,7 +34651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34696,7 +34696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34741,7 +34741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34786,7 +34786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34831,7 +34831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34864,7 +34864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34904,7 +34904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34948,7 +34948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34962,7 +34962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34977,7 +34977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35017,7 +35017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -35056,7 +35056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -35070,7 +35070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35228,7 +35228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35330,7 +35330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35477,7 +35477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35585,7 +35585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35600,7 +35600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35615,7 +35615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35630,7 +35630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35644,7 +35644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35658,7 +35658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35672,7 +35672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35741,7 +35741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35798,7 +35798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35855,7 +35855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35912,7 +35912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35940,7 +35940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35961,7 +35961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -36001,7 +36001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36062,7 +36062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36148,7 +36148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36252,7 +36252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36462,7 +36462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37002,7 +37002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37502,7 +37502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37529,7 +37529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37772,7 +37772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37792,7 +37792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37807,7 +37807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37822,7 +37822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37836,7 +37836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37850,7 +37850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37864,7 +37864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37939,7 +37939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37996,7 +37996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38053,7 +38053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38110,7 +38110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38163,7 +38163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38178,7 +38178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38324,7 +38324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38351,7 +38351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38378,7 +38378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38405,7 +38405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38438,7 +38438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38458,7 +38458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38486,7 +38486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -38574,7 +38574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38603,7 +38603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38618,7 +38618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38633,7 +38633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38648,7 +38648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38663,7 +38663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38678,7 +38678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -38718,7 +38718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38859,7 +38859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38908,7 +38908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38976,7 +38976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38990,7 +38990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39022,7 +39022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39145,7 +39145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39250,7 +39250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39355,7 +39355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39460,7 +39460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39475,7 +39475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39490,7 +39490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39522,7 +39522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39554,7 +39554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39586,7 +39586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_DR</name>
+               <name>DR</name>
                <description>Debug Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39619,7 +39619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39647,7 +39647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39668,7 +39668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -39716,7 +39716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39779,7 +39779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39888,7 +39888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39939,7 +39939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39990,7 +39990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40041,7 +40041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40110,7 +40110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40125,7 +40125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40140,7 +40140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40154,7 +40154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40199,7 +40199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40227,7 +40227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -41800,7 +41800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41891,7 +41891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -42044,7 +42044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42095,7 +42095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42188,7 +42188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -42341,7 +42341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -42494,7 +42494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -42647,7 +42647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42775,7 +42775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42804,7 +42804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42976,7 +42976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43141,7 +43141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -43200,7 +43200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43265,7 +43265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43366,7 +43366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43467,7 +43467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43560,7 +43560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43574,7 +43574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43588,7 +43588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43650,7 +43650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43695,7 +43695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43750,7 +43750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43903,7 +43903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43954,7 +43954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44047,7 +44047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44200,7 +44200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44353,7 +44353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44506,7 +44506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44622,7 +44622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44648,7 +44648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44680,7 +44680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44712,7 +44712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44734,7 +44734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44894,7 +44894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45043,7 +45043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45096,7 +45096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45161,7 +45161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45250,7 +45250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -45333,7 +45333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -45416,7 +45416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -45438,7 +45438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -45488,7 +45488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45502,7 +45502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45516,7 +45516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45578,7 +45578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45623,7 +45623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -45680,7 +45680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -45725,7 +45725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45740,7 +45740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45761,7 +45761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA1</name>
+               <name>TSTA1</name>
                <description>General Test A1 Register</description>
                <addressOffset>0x0810</addressOffset>
                <size>32</size>
@@ -45805,7 +45805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA2</name>
+               <name>TSTA2</name>
                <description>General Test A2 Register</description>
                <addressOffset>0x0814</addressOffset>
                <size>32</size>
@@ -45867,7 +45867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_VERSION</name>
+               <name>VERSION</name>
                <description>General Version Register</description>
                <addressOffset>0x0818</addressOffset>
                <size>32</size>
@@ -45888,7 +45888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_FSM</name>
+               <name>FSM</name>
                <description>General Finite State Machine Register</description>
                <addressOffset>0x082C</addressOffset>
                <size>32</size>
@@ -46001,7 +46001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46032,7 +46032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -46078,7 +46078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46107,7 +46107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46157,7 +46157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46197,7 +46197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46224,7 +46224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46262,7 +46262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46294,7 +46294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -46447,7 +46447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46600,7 +46600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -46753,7 +46753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -46906,7 +46906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -47059,7 +47059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -47212,7 +47212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -47365,7 +47365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -47517,7 +47517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -47669,7 +47669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47822,7 +47822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47975,7 +47975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -48128,7 +48128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -48281,7 +48281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -48440,7 +48440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -48491,7 +48491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -48542,7 +48542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -48593,7 +48593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -48644,7 +48644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -48658,7 +48658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -48672,7 +48672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -48692,7 +48692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -48786,7 +48786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -48800,7 +48800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -48814,7 +48814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -49144,7 +49144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -49164,7 +49164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -49178,7 +49178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -49193,7 +49193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>XDMAC_VERSION</name>
+               <name>VERSION</name>
                <description>XDMAC Version Register</description>
                <addressOffset>0xFFC</addressOffset>
                <size>32</size>
@@ -49226,7 +49226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -49426,7 +49426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV71J20B.svd
+++ b/data/Atmel/ATSAMV71J20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7457,7 +7457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7502,7 +7502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7529,7 +7529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7580,7 +7580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7631,7 +7631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7682,7 +7682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7733,7 +7733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7776,7 +7776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7806,7 +7806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7840,7 +7840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8046,7 +8046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8066,7 +8066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8080,7 +8080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8112,7 +8112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8144,7 +8144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8176,7 +8176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8208,7 +8208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8240,7 +8240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8273,7 +8273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8354,7 +8354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8417,7 +8417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -8543,7 +8543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -8564,7 +8564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -8585,7 +8585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8606,7 +8606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8620,7 +8620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8666,7 +8666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8680,7 +8680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8712,7 +8712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8754,7 +8754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8792,7 +8792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -8851,7 +8851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8901,7 +8901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -8957,7 +8957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -8990,7 +8990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -9212,7 +9212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -9240,7 +9240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -9284,7 +9284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9329,7 +9329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9358,7 +9358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9409,7 +9409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9471,7 +9471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9491,7 +9491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9700,7 +9700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9732,7 +9732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9770,7 +9770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9784,7 +9784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -9846,7 +9846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -9860,7 +9860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9893,7 +9893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10034,7 +10034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10054,7 +10054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10230,7 +10230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10406,7 +10406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10582,7 +10582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -10602,7 +10602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -10686,7 +10686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -10706,7 +10706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -10726,7 +10726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -10740,7 +10740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -10796,7 +10796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -10996,7 +10996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -11196,7 +11196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -11228,7 +11228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -11267,7 +11267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -11281,7 +11281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -11295,7 +11295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -11327,7 +11327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -11395,7 +11395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -11409,7 +11409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11596,7 +11596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -11629,7 +11629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -11686,7 +11686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -11887,7 +11887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12087,7 +12087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -12287,7 +12287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -12488,7 +12488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -12689,7 +12689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -12889,7 +12889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -13089,7 +13089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -13115,7 +13115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -13154,7 +13154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -13187,7 +13187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -13293,7 +13293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -13307,7 +13307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -13321,7 +13321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -13365,7 +13365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -13398,7 +13398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -13496,7 +13496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -13522,7 +13522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -13550,7 +13550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13566,7 +13566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13583,7 +13583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13600,7 +13600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13616,7 +13616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13630,7 +13630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -13644,7 +13644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -13683,7 +13683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -13730,7 +13730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -13746,7 +13746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -13779,7 +13779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -13980,7 +13980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -14181,7 +14181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -14382,7 +14382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -14583,7 +14583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -14784,7 +14784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -14985,7 +14985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -15186,7 +15186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -15387,7 +15387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -15588,7 +15588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -15789,7 +15789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -15990,7 +15990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16190,7 +16190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -16391,7 +16391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -16592,7 +16592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -16793,7 +16793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -16994,7 +16994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -17195,7 +17195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -17396,7 +17396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -17597,7 +17597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -17798,7 +17798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -17999,7 +17999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18200,7 +18200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -18403,7 +18403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -18603,7 +18603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -18804,7 +18804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -19005,7 +19005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -19206,7 +19206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -19220,7 +19220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -19421,7 +19421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -19622,7 +19622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -19823,7 +19823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -20024,7 +20024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -20225,7 +20225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -20426,7 +20426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -20627,7 +20627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -20828,7 +20828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -21029,7 +21029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -21230,7 +21230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -21431,7 +21431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -21632,7 +21632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -21833,7 +21833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -22034,7 +22034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -22235,7 +22235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -22436,7 +22436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -22464,7 +22464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -22485,7 +22485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22685,7 +22685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -23301,7 +23301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -23357,7 +23357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -23390,7 +23390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -23423,7 +23423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -23456,7 +23456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -23477,7 +23477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -23527,7 +23527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -23590,7 +23590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -23653,7 +23653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -23722,7 +23722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -23845,7 +23845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -24282,7 +24282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -24403,7 +24403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -24425,7 +24425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24473,7 +24473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -24578,7 +24578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -24683,7 +24683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -24806,7 +24806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -24911,7 +24911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -25069,7 +25069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -25173,7 +25173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -25188,7 +25188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25216,7 +25216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25237,7 +25237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25378,7 +25378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -25519,7 +25519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -25660,7 +25660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -25732,7 +25732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -25776,7 +25776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -25899,7 +25899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26022,7 +26022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -26145,7 +26145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -26268,7 +26268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -26282,7 +26282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -26423,7 +26423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -26564,7 +26564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -26705,7 +26705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -26846,7 +26846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -26880,7 +26880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27054,7 +27054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27087,7 +27087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27120,7 +27120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27153,7 +27153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27210,7 +27210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27267,7 +27267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27324,7 +27324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27381,7 +27381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27449,7 +27449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -27464,7 +27464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -27478,7 +27478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -27498,7 +27498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27513,7 +27513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -27630,7 +27630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27747,7 +27747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27864,7 +27864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27981,7 +27981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28037,7 +28037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -28093,7 +28093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28150,7 +28150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -28207,7 +28207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -28264,7 +28264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -28321,7 +28321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -28347,7 +28347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -28368,7 +28368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -28383,7 +28383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -28439,7 +28439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -28473,7 +28473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -28529,7 +28529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -28549,7 +28549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -28564,7 +28564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -28596,7 +28596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -28652,7 +28652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28735,7 +28735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28834,7 +28834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28867,7 +28867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28888,7 +28888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28932,7 +28932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28972,7 +28972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29166,7 +29166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29180,7 +29180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29195,7 +29195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29209,7 +29209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -29224,7 +29224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -29239,7 +29239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -29259,7 +29259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -29281,7 +29281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -29302,7 +29302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -29323,7 +29323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -29403,7 +29403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -29441,7 +29441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -29462,7 +29462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -29542,7 +29542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -29580,7 +29580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -29628,7 +29628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29661,7 +29661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29781,7 +29781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29796,7 +29796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29811,7 +29811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29868,7 +29868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29919,7 +29919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29970,7 +29970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30021,7 +30021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30053,7 +30053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30067,7 +30067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30087,7 +30087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30265,7 +30265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30298,7 +30298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30313,7 +30313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30341,7 +30341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30381,7 +30381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30416,7 +30416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30477,7 +30477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30536,7 +30536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30565,7 +30565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30615,7 +30615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30649,7 +30649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30722,7 +30722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30936,7 +30936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30968,7 +30968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31006,7 +31006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31056,7 +31056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31088,7 +31088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31211,7 +31211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31256,7 +31256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31301,7 +31301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31346,7 +31346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31391,7 +31391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31443,7 +31443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31487,7 +31487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31501,7 +31501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31516,7 +31516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31556,7 +31556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -31595,7 +31595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -31609,7 +31609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31767,7 +31767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31869,7 +31869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32016,7 +32016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32124,7 +32124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32139,7 +32139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32154,7 +32154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32169,7 +32169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32183,7 +32183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32197,7 +32197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -32211,7 +32211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32280,7 +32280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32337,7 +32337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -32394,7 +32394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32451,7 +32451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32479,7 +32479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32510,7 +32510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -32519,7 +32519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32580,7 +32580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32666,7 +32666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32770,7 +32770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32980,7 +32980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33520,7 +33520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33965,6 +33965,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -33999,7 +34027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34026,7 +34054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34269,9 +34297,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -34705,7 +34733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34725,7 +34753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34740,7 +34768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34755,7 +34783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34769,7 +34797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34783,7 +34811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34797,7 +34825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34872,7 +34900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34929,7 +34957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34986,7 +35014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -35043,7 +35071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -35096,7 +35124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -35111,7 +35139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -35269,7 +35297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -35302,7 +35330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -35335,7 +35363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -35368,7 +35396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -35407,7 +35435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -35427,7 +35455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35522,7 +35550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35551,7 +35579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35566,7 +35594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35581,7 +35609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35596,7 +35624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35611,7 +35639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35645,7 +35673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35786,7 +35814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35835,7 +35863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35903,7 +35931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35917,7 +35945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35949,7 +35977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -36072,7 +36100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -36177,7 +36205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36282,7 +36310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36387,7 +36415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36402,7 +36430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36417,7 +36445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36449,7 +36477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36481,7 +36509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36513,7 +36541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36541,7 +36569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36589,7 +36617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36646,7 +36674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36755,7 +36783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36806,7 +36834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36857,7 +36885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36908,7 +36936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36959,7 +36987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36974,7 +37002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36989,7 +37017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37003,7 +37031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -37048,7 +37076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -37858,6 +37886,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -37908,7 +37954,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -37949,80 +38041,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38120,12 +38138,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -38135,6 +38147,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38170,46 +38194,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -38238,6 +38222,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38291,7 +38293,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -38338,134 +38386,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38557,30 +38477,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -38590,6 +38486,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38625,64 +38533,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -38711,6 +38561,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38764,7 +38632,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -38811,134 +38725,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39030,30 +38816,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -39063,6 +38825,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39098,64 +38872,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -39184,6 +38900,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39261,7 +38995,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -39308,140 +39094,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39539,30 +39191,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -39572,6 +39200,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39602,64 +39242,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -40342,7 +39924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -40433,7 +40015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -40586,7 +40168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40637,7 +40219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40730,7 +40312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40883,7 +40465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41036,7 +40618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41189,7 +40771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -41317,7 +40899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -41346,7 +40928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -41518,7 +41100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -41683,9 +41265,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41849,9 +41431,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42015,9 +41597,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42181,7 +41763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -42240,9 +41822,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42300,9 +41882,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42360,9 +41942,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42420,7 +42002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -42485,9 +42067,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42551,9 +42133,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42617,9 +42199,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42683,7 +42265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42784,9 +42366,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42892,9 +42474,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42994,9 +42576,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43096,7 +42678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43197,9 +42779,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43305,9 +42887,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43407,9 +42989,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43509,7 +43091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43598,9 +43180,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43688,9 +43270,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43778,9 +43360,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43872,7 +43454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43886,7 +43468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43900,7 +43482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43962,7 +43544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44007,7 +43589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -44062,7 +43644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -44171,43 +43753,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44215,7 +43797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -44266,7 +43848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44315,43 +43897,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44359,7 +43941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44468,43 +44050,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44512,7 +44094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44621,43 +44203,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44665,7 +44247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44774,43 +44356,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44818,7 +44400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44934,7 +44516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44960,7 +44542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44992,7 +44574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -45024,7 +44606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -45046,7 +44628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -45206,9 +44788,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -45373,7 +44955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45522,9 +45104,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45672,9 +45254,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45822,9 +45404,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45972,7 +45554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -46025,9 +45607,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46079,9 +45661,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46133,9 +45715,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46187,7 +45769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -46252,9 +45834,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46318,9 +45900,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46384,9 +45966,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46450,7 +46032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -46539,9 +46121,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46629,9 +46211,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46719,9 +46301,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46809,7 +46391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46892,9 +46474,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46976,9 +46558,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47060,9 +46642,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47144,7 +46726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -47227,9 +46809,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47311,9 +46893,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47395,9 +46977,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47479,7 +47061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -47501,7 +47083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -47551,7 +47133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47565,7 +47147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47579,7 +47161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47641,7 +47223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47686,7 +47268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47743,7 +47325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47788,7 +47370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47803,7 +47385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47839,7 +47421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47870,7 +47452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47916,7 +47498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47945,7 +47527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47995,7 +47577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48035,7 +47617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -48062,7 +47644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -48100,7 +47682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48132,7 +47714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -48285,7 +47867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48438,7 +48020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -48591,7 +48173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48744,7 +48326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48897,7 +48479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -49050,7 +48632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -49203,7 +48785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -49355,7 +48937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -49507,7 +49089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49660,7 +49242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49813,7 +49395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49966,7 +49548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -50119,7 +49701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -50278,7 +49860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50329,7 +49911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50380,7 +49962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50431,7 +50013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50482,7 +50064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -50496,7 +50078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -50510,7 +50092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -50530,7 +50112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -50624,7 +50206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50638,7 +50220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50652,7 +50234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -51135,7 +50717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -51155,7 +50737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -51169,7 +50751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -51197,7 +50779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -51397,7 +50979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -53286,6 +52868,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV71J21.svd
+++ b/data/Atmel/ATSAMV71J21.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -428,7 +428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -495,7 +495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -795,7 +795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -822,7 +822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -849,7 +849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -876,7 +876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -944,7 +944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -961,7 +961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -978,7 +978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -995,7 +995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -1010,7 +1010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -1024,7 +1024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -1040,7 +1040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -1056,7 +1056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -1071,7 +1071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -1088,7 +1088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -1102,7 +1102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -1142,7 +1142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1163,7 +1163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1423,7 +1423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1553,7 +1553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1609,7 +1609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1803,7 +1803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1884,7 +1884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1905,7 +1905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -2010,7 +2010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -2115,7 +2115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2220,7 +2220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2325,7 +2325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2406,7 +2406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2426,7 +2426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2506,7 +2506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2586,7 +2586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2600,7 +2600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2615,7 +2615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2629,7 +2629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2672,7 +2672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2692,7 +2692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2718,7 +2718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2798,7 +2798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2812,7 +2812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2832,7 +2832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2912,7 +2912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2940,7 +2940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2961,7 +2961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_VERSION</name>
+               <name>VERSION</name>
                <description>AFEC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -3005,7 +3005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3335,7 +3335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3369,7 +3369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3384,7 +3384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3480,7 +3480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3702,7 +3702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3723,7 +3723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3744,7 +3744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3779,7 +3779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3800,7 +3800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3833,7 +3833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3866,7 +3866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3899,7 +3899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3932,7 +3932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3952,7 +3952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3980,7 +3980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4001,7 +4001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -4364,7 +4364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4468,7 +4468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4647,7 +4647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4784,7 +4784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4834,7 +4834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4848,7 +4848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4862,7 +4862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4894,7 +4894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -5041,7 +5041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5206,7 +5206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5371,7 +5371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5585,7 +5585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5600,7 +5600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5614,7 +5614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5634,7 +5634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5654,7 +5654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5668,7 +5668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5703,7 +5703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5717,7 +5717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5732,7 +5732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5752,7 +5752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5772,7 +5772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5812,7 +5812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5850,7 +5850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5864,7 +5864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5884,7 +5884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5904,7 +5904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5918,7 +5918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5932,7 +5932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5946,7 +5946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5974,7 +5974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5989,7 +5989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -6004,7 +6004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -6019,7 +6019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -6034,7 +6034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MID</name>
+               <name>MID</name>
                <description>Module ID Register</description>
                <addressOffset>0x0FC</addressOffset>
                <size>32</size>
@@ -6055,7 +6055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -6070,7 +6070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -6085,7 +6085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -6100,7 +6100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -6115,7 +6115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -6130,7 +6130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -6145,7 +6145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -6160,7 +6160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -6175,7 +6175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6190,7 +6190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6205,7 +6205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6250,7 +6250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6265,7 +6265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6280,7 +6280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6295,7 +6295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6310,7 +6310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6325,7 +6325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6340,7 +6340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6355,7 +6355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6370,7 +6370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6385,7 +6385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6400,7 +6400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6415,7 +6415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6430,7 +6430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6445,7 +6445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6460,7 +6460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6475,7 +6475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6490,7 +6490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6520,7 +6520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6535,7 +6535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6550,7 +6550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6565,7 +6565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6580,7 +6580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6595,7 +6595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6610,7 +6610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6625,7 +6625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6640,7 +6640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6655,7 +6655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6670,7 +6670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6685,7 +6685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6700,7 +6700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6715,7 +6715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6730,7 +6730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6744,7 +6744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6758,7 +6758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6772,7 +6772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6786,7 +6786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6833,7 +6833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6863,7 +6863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6878,7 +6878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6893,7 +6893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6938,7 +6938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6955,7 +6955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -7008,7 +7008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -7024,7 +7024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -7040,7 +7040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -7054,7 +7054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -7074,7 +7074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -7088,7 +7088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -7104,7 +7104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7220,7 +7220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7273,7 +7273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7326,7 +7326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7378,7 +7378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7392,7 +7392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7412,7 +7412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7455,7 +7455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7475,7 +7475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7518,7 +7518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7538,7 +7538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7601,7 +7601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7644,7 +7644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7664,7 +7664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7707,7 +7707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7727,7 +7727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7770,7 +7770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7833,7 +7833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7853,7 +7853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7916,7 +7916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7959,7 +7959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7979,7 +7979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -8022,7 +8022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -8042,7 +8042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -8085,7 +8085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -8105,7 +8105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -8148,7 +8148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -8168,7 +8168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -8211,7 +8211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -8231,7 +8231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8274,7 +8274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8294,7 +8294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8337,7 +8337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8357,7 +8357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8400,7 +8400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8420,7 +8420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8463,7 +8463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8483,7 +8483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8526,7 +8526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8546,7 +8546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8589,7 +8589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8609,7 +8609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8672,7 +8672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8715,7 +8715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8735,7 +8735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8778,7 +8778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8798,7 +8798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8841,7 +8841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8861,7 +8861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8954,7 +8954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8993,7 +8993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9043,7 +9043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9106,7 +9106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9152,7 +9152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9166,7 +9166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9423,7 +9423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9508,7 +9508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9523,7 +9523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9538,7 +9538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9553,7 +9553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9706,7 +9706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9859,7 +9859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10012,7 +10012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10165,7 +10165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10213,7 +10213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10245,7 +10245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10273,7 +10273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10294,7 +10294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -10317,7 +10317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10350,7 +10350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10436,7 +10436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10508,7 +10508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10559,7 +10559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10610,7 +10610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10661,7 +10661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10712,7 +10712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10769,7 +10769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10785,7 +10785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10819,7 +10819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10917,7 +10917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11025,7 +11025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11045,7 +11045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11059,7 +11059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11091,7 +11091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11123,7 +11123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11155,7 +11155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11187,7 +11187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11219,7 +11219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11252,7 +11252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11333,7 +11333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11396,7 +11396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11459,7 +11459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11522,7 +11522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11585,7 +11585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11599,7 +11599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11631,7 +11631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11645,7 +11645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11659,7 +11659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11691,7 +11691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11705,7 +11705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11733,7 +11733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11754,7 +11754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -11792,7 +11792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11851,7 +11851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11901,7 +11901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11957,7 +11957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11990,7 +11990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -12166,7 +12166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -12194,7 +12194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -12215,7 +12215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x01FC</addressOffset>
                <size>32</size>
@@ -12259,7 +12259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -12304,7 +12304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -12319,7 +12319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -12333,7 +12333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -12390,7 +12390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12458,7 +12458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12478,7 +12478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12691,7 +12691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12723,7 +12723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12761,7 +12761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12775,7 +12775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12837,7 +12837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12851,7 +12851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12884,7 +12884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -13013,7 +13013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -13213,7 +13213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -13413,7 +13413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13613,7 +13613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13633,7 +13633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13717,7 +13717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13737,7 +13737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13757,7 +13757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13771,7 +13771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13827,7 +13827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -14027,7 +14027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -14227,7 +14227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -14259,7 +14259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -14298,7 +14298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -14312,7 +14312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -14326,7 +14326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -14358,7 +14358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -14426,7 +14426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -14440,7 +14440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14595,7 +14595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14627,7 +14627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14660,7 +14660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14717,7 +14717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14918,7 +14918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15118,7 +15118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -15318,7 +15318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15519,7 +15519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15720,7 +15720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15920,7 +15920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -16120,7 +16120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -16146,7 +16146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -16185,7 +16185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -16218,7 +16218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -16324,7 +16324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -16338,7 +16338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -16352,7 +16352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -16396,7 +16396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -16429,7 +16429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -16527,7 +16527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -16553,7 +16553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -16581,7 +16581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -16597,7 +16597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -16614,7 +16614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -16631,7 +16631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -16647,7 +16647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -16661,7 +16661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -16675,7 +16675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -16714,7 +16714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -16761,7 +16761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -16777,7 +16777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -16810,7 +16810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17011,7 +17011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17212,7 +17212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17413,7 +17413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17614,7 +17614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17815,7 +17815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18016,7 +18016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -18217,7 +18217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -18418,7 +18418,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -18619,7 +18619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18820,7 +18820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -19021,7 +19021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -19221,7 +19221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -19422,7 +19422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -19623,7 +19623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -19824,7 +19824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -20025,7 +20025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -20226,7 +20226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -20427,7 +20427,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -20628,7 +20628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -20829,7 +20829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -21030,7 +21030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -21231,7 +21231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -21434,7 +21434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -21634,7 +21634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -21835,7 +21835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -22036,7 +22036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -22237,7 +22237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -22251,7 +22251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -22452,7 +22452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -22653,7 +22653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -22854,7 +22854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -23055,7 +23055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -23256,7 +23256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -23457,7 +23457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -23658,7 +23658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -23859,7 +23859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -24060,7 +24060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -24261,7 +24261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -24462,7 +24462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -24663,7 +24663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -24864,7 +24864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -25065,7 +25065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -25266,7 +25266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -25467,7 +25467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25495,7 +25495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25516,7 +25516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -25537,7 +25537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25737,7 +25737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26353,7 +26353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -26409,7 +26409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -26442,7 +26442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -26475,7 +26475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -26508,7 +26508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -26529,7 +26529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -26579,7 +26579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -26636,7 +26636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -26693,7 +26693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -26756,7 +26756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -26915,7 +26915,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -27074,7 +27074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -27424,7 +27424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -27545,7 +27545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -27567,7 +27567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27615,7 +27615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -27714,7 +27714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -27813,7 +27813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -27930,7 +27930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -28029,7 +28029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -28187,7 +28187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -28291,7 +28291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -28306,7 +28306,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -28334,7 +28334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -28355,7 +28355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -28376,7 +28376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -28535,7 +28535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -28694,7 +28694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -28853,7 +28853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -28925,7 +28925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -28969,7 +28969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -29128,7 +29128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -29287,7 +29287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -29446,7 +29446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -29605,7 +29605,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -29619,7 +29619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -29778,7 +29778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -29937,7 +29937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -30096,7 +30096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -30255,7 +30255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -30270,7 +30270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -30296,7 +30296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -30343,7 +30343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30517,7 +30517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30550,7 +30550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30583,7 +30583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30616,7 +30616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30673,7 +30673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30730,7 +30730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30787,7 +30787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30844,7 +30844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30912,7 +30912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30927,7 +30927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30941,7 +30941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30961,7 +30961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30976,7 +30976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31093,7 +31093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31210,7 +31210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31327,7 +31327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31444,7 +31444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31500,7 +31500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31556,7 +31556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31613,7 +31613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31670,7 +31670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -31727,7 +31727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -31784,7 +31784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -31810,7 +31810,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -31831,7 +31831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -31846,7 +31846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -31902,7 +31902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -31936,7 +31936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -31992,7 +31992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -32012,7 +32012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -32027,7 +32027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -32059,7 +32059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -32115,7 +32115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32198,7 +32198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32291,7 +32291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -32318,7 +32318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32338,7 +32338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32359,7 +32359,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32403,7 +32403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32443,7 +32443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32585,7 +32585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32599,7 +32599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32614,7 +32614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32628,7 +32628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -32643,7 +32643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -32658,7 +32658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32678,7 +32678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32700,7 +32700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -32721,7 +32721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -32742,7 +32742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -32822,7 +32822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -32860,7 +32860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -32881,7 +32881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -32961,7 +32961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -32999,7 +32999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -33047,7 +33047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33080,7 +33080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33200,7 +33200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33215,7 +33215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33230,7 +33230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33287,7 +33287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33338,7 +33338,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33389,7 +33389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33440,7 +33440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33472,7 +33472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33486,7 +33486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33506,7 +33506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33684,7 +33684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33717,7 +33717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33732,7 +33732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33760,7 +33760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33781,7 +33781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -33821,7 +33821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33856,7 +33856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33917,7 +33917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33976,7 +33976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34005,7 +34005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34055,7 +34055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34089,7 +34089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34162,7 +34162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34376,7 +34376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34408,7 +34408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34446,7 +34446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34496,7 +34496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34528,7 +34528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34651,7 +34651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34696,7 +34696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34741,7 +34741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34786,7 +34786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34831,7 +34831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34864,7 +34864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34904,7 +34904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34948,7 +34948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34962,7 +34962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34977,7 +34977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35017,7 +35017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -35056,7 +35056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -35070,7 +35070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35228,7 +35228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35330,7 +35330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35477,7 +35477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35585,7 +35585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35600,7 +35600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35615,7 +35615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35630,7 +35630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35644,7 +35644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35658,7 +35658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35672,7 +35672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35741,7 +35741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35798,7 +35798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35855,7 +35855,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35912,7 +35912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35940,7 +35940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35961,7 +35961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -36001,7 +36001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36062,7 +36062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36148,7 +36148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36252,7 +36252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36462,7 +36462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37002,7 +37002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37502,7 +37502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37529,7 +37529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37772,7 +37772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37792,7 +37792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37807,7 +37807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37822,7 +37822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37836,7 +37836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37850,7 +37850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37864,7 +37864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37939,7 +37939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37996,7 +37996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38053,7 +38053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38110,7 +38110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38163,7 +38163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38178,7 +38178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38324,7 +38324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38351,7 +38351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38378,7 +38378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38405,7 +38405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38438,7 +38438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38458,7 +38458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38486,7 +38486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -38574,7 +38574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38603,7 +38603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38618,7 +38618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38633,7 +38633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38648,7 +38648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38663,7 +38663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38678,7 +38678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -38718,7 +38718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38859,7 +38859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38908,7 +38908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38976,7 +38976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38990,7 +38990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39022,7 +39022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39145,7 +39145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39250,7 +39250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39355,7 +39355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39460,7 +39460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39475,7 +39475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39490,7 +39490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39522,7 +39522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39554,7 +39554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39586,7 +39586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_DR</name>
+               <name>DR</name>
                <description>Debug Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39619,7 +39619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39647,7 +39647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39668,7 +39668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -39716,7 +39716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39779,7 +39779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39888,7 +39888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39939,7 +39939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39990,7 +39990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40041,7 +40041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40110,7 +40110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40125,7 +40125,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40140,7 +40140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40154,7 +40154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40199,7 +40199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40227,7 +40227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -41800,7 +41800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41891,7 +41891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -42044,7 +42044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42095,7 +42095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42188,7 +42188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -42341,7 +42341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -42494,7 +42494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -42647,7 +42647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42775,7 +42775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42804,7 +42804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42976,7 +42976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43141,7 +43141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -43200,7 +43200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43265,7 +43265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43366,7 +43366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43467,7 +43467,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43560,7 +43560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43574,7 +43574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43588,7 +43588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43650,7 +43650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43695,7 +43695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43750,7 +43750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43903,7 +43903,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43954,7 +43954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44047,7 +44047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44200,7 +44200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44353,7 +44353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44506,7 +44506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44622,7 +44622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44648,7 +44648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44680,7 +44680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44712,7 +44712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44734,7 +44734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44894,7 +44894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45043,7 +45043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45096,7 +45096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45161,7 +45161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45250,7 +45250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -45333,7 +45333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -45416,7 +45416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -45438,7 +45438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -45488,7 +45488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45502,7 +45502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45516,7 +45516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45578,7 +45578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45623,7 +45623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -45680,7 +45680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -45725,7 +45725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45740,7 +45740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45761,7 +45761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA1</name>
+               <name>TSTA1</name>
                <description>General Test A1 Register</description>
                <addressOffset>0x0810</addressOffset>
                <size>32</size>
@@ -45805,7 +45805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA2</name>
+               <name>TSTA2</name>
                <description>General Test A2 Register</description>
                <addressOffset>0x0814</addressOffset>
                <size>32</size>
@@ -45867,7 +45867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_VERSION</name>
+               <name>VERSION</name>
                <description>General Version Register</description>
                <addressOffset>0x0818</addressOffset>
                <size>32</size>
@@ -45888,7 +45888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_FSM</name>
+               <name>FSM</name>
                <description>General Finite State Machine Register</description>
                <addressOffset>0x082C</addressOffset>
                <size>32</size>
@@ -46001,7 +46001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46032,7 +46032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -46078,7 +46078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46107,7 +46107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46157,7 +46157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46197,7 +46197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46224,7 +46224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46262,7 +46262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46294,7 +46294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -46447,7 +46447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46600,7 +46600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -46753,7 +46753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -46906,7 +46906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -47059,7 +47059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -47212,7 +47212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -47365,7 +47365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -47517,7 +47517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -47669,7 +47669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47822,7 +47822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47975,7 +47975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -48128,7 +48128,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -48281,7 +48281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -48440,7 +48440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -48491,7 +48491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -48542,7 +48542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -48593,7 +48593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -48644,7 +48644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -48658,7 +48658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -48672,7 +48672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -48692,7 +48692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -48786,7 +48786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -48800,7 +48800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -48814,7 +48814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -49144,7 +49144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -49164,7 +49164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -49178,7 +49178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -49193,7 +49193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>XDMAC_VERSION</name>
+               <name>VERSION</name>
                <description>XDMAC Version Register</description>
                <addressOffset>0xFFC</addressOffset>
                <size>32</size>
@@ -49226,7 +49226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -49426,7 +49426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -49626,7 +49626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -49826,7 +49826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV71J21B.svd
+++ b/data/Atmel/ATSAMV71J21B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7457,7 +7457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7502,7 +7502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7529,7 +7529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7580,7 +7580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7631,7 +7631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7682,7 +7682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7733,7 +7733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7776,7 +7776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7806,7 +7806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -7840,7 +7840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7938,7 +7938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8046,7 +8046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8066,7 +8066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8080,7 +8080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8112,7 +8112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8144,7 +8144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8176,7 +8176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8208,7 +8208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8240,7 +8240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -8273,7 +8273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -8354,7 +8354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -8417,7 +8417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -8543,7 +8543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -8564,7 +8564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -8585,7 +8585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8606,7 +8606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8620,7 +8620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8666,7 +8666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8680,7 +8680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8712,7 +8712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -8726,7 +8726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8754,7 +8754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8792,7 +8792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -8851,7 +8851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8901,7 +8901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -8957,7 +8957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -8990,7 +8990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -9212,7 +9212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -9240,7 +9240,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -9284,7 +9284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9329,7 +9329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9344,7 +9344,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9358,7 +9358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9409,7 +9409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9471,7 +9471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9491,7 +9491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9700,7 +9700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9732,7 +9732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9770,7 +9770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9784,7 +9784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -9846,7 +9846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -9860,7 +9860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9893,7 +9893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10034,7 +10034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10054,7 +10054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10230,7 +10230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10406,7 +10406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10582,7 +10582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -10602,7 +10602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -10686,7 +10686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -10706,7 +10706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -10726,7 +10726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -10740,7 +10740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -10796,7 +10796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -10996,7 +10996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -11196,7 +11196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -11228,7 +11228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -11267,7 +11267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -11281,7 +11281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -11295,7 +11295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -11327,7 +11327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -11395,7 +11395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -11409,7 +11409,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -11596,7 +11596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -11629,7 +11629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -11686,7 +11686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -11887,7 +11887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -12087,7 +12087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -12287,7 +12287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -12488,7 +12488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -12689,7 +12689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -12889,7 +12889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -13089,7 +13089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -13115,7 +13115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -13154,7 +13154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -13187,7 +13187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -13293,7 +13293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -13307,7 +13307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -13321,7 +13321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -13365,7 +13365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -13398,7 +13398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -13496,7 +13496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -13522,7 +13522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -13550,7 +13550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13566,7 +13566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13583,7 +13583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13600,7 +13600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13616,7 +13616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -13630,7 +13630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -13644,7 +13644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -13683,7 +13683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -13730,7 +13730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -13746,7 +13746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -13779,7 +13779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -13980,7 +13980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -14181,7 +14181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -14382,7 +14382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -14583,7 +14583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -14784,7 +14784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -14985,7 +14985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -15186,7 +15186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -15387,7 +15387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -15588,7 +15588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -15789,7 +15789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -15990,7 +15990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -16190,7 +16190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -16391,7 +16391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -16592,7 +16592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -16793,7 +16793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -16994,7 +16994,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -17195,7 +17195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -17396,7 +17396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -17597,7 +17597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -17798,7 +17798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -17999,7 +17999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -18200,7 +18200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -18403,7 +18403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -18603,7 +18603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -18804,7 +18804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -19005,7 +19005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -19206,7 +19206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -19220,7 +19220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -19421,7 +19421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -19622,7 +19622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -19823,7 +19823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -20024,7 +20024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -20225,7 +20225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -20426,7 +20426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -20627,7 +20627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -20828,7 +20828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -21029,7 +21029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -21230,7 +21230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -21431,7 +21431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -21632,7 +21632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -21833,7 +21833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -22034,7 +22034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -22235,7 +22235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -22436,7 +22436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -22464,7 +22464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -22485,7 +22485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -22685,7 +22685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -23301,7 +23301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -23357,7 +23357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -23390,7 +23390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -23423,7 +23423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -23456,7 +23456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -23477,7 +23477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -23527,7 +23527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -23590,7 +23590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -23653,7 +23653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -23722,7 +23722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -23845,7 +23845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -24282,7 +24282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -24403,7 +24403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -24425,7 +24425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -24473,7 +24473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -24578,7 +24578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -24683,7 +24683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -24806,7 +24806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -24911,7 +24911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -25069,7 +25069,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -25173,7 +25173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -25188,7 +25188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25216,7 +25216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25237,7 +25237,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25378,7 +25378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -25519,7 +25519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -25660,7 +25660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -25732,7 +25732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -25776,7 +25776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -25899,7 +25899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26022,7 +26022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -26145,7 +26145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -26268,7 +26268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -26282,7 +26282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -26423,7 +26423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -26564,7 +26564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -26705,7 +26705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -26846,7 +26846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -26880,7 +26880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -27054,7 +27054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -27087,7 +27087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -27120,7 +27120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -27153,7 +27153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -27210,7 +27210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -27267,7 +27267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -27324,7 +27324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -27381,7 +27381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -27449,7 +27449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -27464,7 +27464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -27478,7 +27478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -27498,7 +27498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -27513,7 +27513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -27630,7 +27630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -27747,7 +27747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -27864,7 +27864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27981,7 +27981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -28037,7 +28037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -28093,7 +28093,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -28150,7 +28150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -28207,7 +28207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -28264,7 +28264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -28321,7 +28321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -28347,7 +28347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -28368,7 +28368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -28383,7 +28383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -28439,7 +28439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -28473,7 +28473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -28529,7 +28529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -28549,7 +28549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -28564,7 +28564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -28596,7 +28596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -28652,7 +28652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -28735,7 +28735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -28834,7 +28834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -28867,7 +28867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -28888,7 +28888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -28932,7 +28932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -28972,7 +28972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -29166,7 +29166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -29180,7 +29180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -29195,7 +29195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -29209,7 +29209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -29224,7 +29224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -29239,7 +29239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -29259,7 +29259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -29281,7 +29281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -29302,7 +29302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -29323,7 +29323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -29403,7 +29403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -29441,7 +29441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -29462,7 +29462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -29542,7 +29542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -29580,7 +29580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -29628,7 +29628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29661,7 +29661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29781,7 +29781,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29796,7 +29796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29811,7 +29811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29868,7 +29868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29919,7 +29919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29970,7 +29970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30021,7 +30021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30053,7 +30053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30067,7 +30067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30087,7 +30087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30265,7 +30265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30298,7 +30298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30313,7 +30313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30341,7 +30341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30381,7 +30381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30416,7 +30416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30477,7 +30477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30536,7 +30536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30565,7 +30565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30615,7 +30615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30649,7 +30649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30722,7 +30722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30936,7 +30936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30968,7 +30968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31006,7 +31006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31056,7 +31056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31088,7 +31088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -31211,7 +31211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -31256,7 +31256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -31301,7 +31301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -31346,7 +31346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -31391,7 +31391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -31443,7 +31443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31487,7 +31487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31501,7 +31501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31516,7 +31516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31556,7 +31556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -31595,7 +31595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -31609,7 +31609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -31767,7 +31767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -31869,7 +31869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32016,7 +32016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32124,7 +32124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32139,7 +32139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -32154,7 +32154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32169,7 +32169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32183,7 +32183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32197,7 +32197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -32211,7 +32211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32280,7 +32280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32337,7 +32337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -32394,7 +32394,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -32451,7 +32451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32479,7 +32479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32510,7 +32510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -32519,7 +32519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32580,7 +32580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32666,7 +32666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32770,7 +32770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32980,7 +32980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33520,7 +33520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33965,6 +33965,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -33999,7 +34027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34026,7 +34054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34269,9 +34297,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -34705,7 +34733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34725,7 +34753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34740,7 +34768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -34755,7 +34783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -34769,7 +34797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -34783,7 +34811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -34797,7 +34825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -34872,7 +34900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -34929,7 +34957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -34986,7 +35014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -35043,7 +35071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -35096,7 +35124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -35111,7 +35139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -35269,7 +35297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -35302,7 +35330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -35335,7 +35363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -35368,7 +35396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -35407,7 +35435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -35427,7 +35455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35522,7 +35550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35551,7 +35579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35566,7 +35594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35581,7 +35609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35596,7 +35624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35611,7 +35639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -35645,7 +35673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35786,7 +35814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35835,7 +35863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35903,7 +35931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35917,7 +35945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35949,7 +35977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -36072,7 +36100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -36177,7 +36205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -36282,7 +36310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -36387,7 +36415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36402,7 +36430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36417,7 +36445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36449,7 +36477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36481,7 +36509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36513,7 +36541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36541,7 +36569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36589,7 +36617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -36646,7 +36674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -36755,7 +36783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -36806,7 +36834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -36857,7 +36885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -36908,7 +36936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -36959,7 +36987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -36974,7 +37002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -36989,7 +37017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -37003,7 +37031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -37048,7 +37076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -37858,6 +37886,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -37908,7 +37954,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -37949,80 +38041,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38120,12 +38138,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -38135,6 +38147,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38170,46 +38194,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -38238,6 +38222,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38291,7 +38293,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -38338,134 +38386,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38557,30 +38477,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -38590,6 +38486,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38625,64 +38533,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -38711,6 +38561,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -38764,7 +38632,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -38811,134 +38725,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39030,30 +38816,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -39063,6 +38825,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39098,64 +38872,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -39184,6 +38900,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39261,7 +38995,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -39308,140 +39094,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39539,30 +39191,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -39572,6 +39200,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -39602,64 +39242,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -40342,7 +39924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -40433,7 +40015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -40586,7 +40168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40637,7 +40219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40730,7 +40312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40883,7 +40465,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41036,7 +40618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41189,7 +40771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -41317,7 +40899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -41346,7 +40928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -41518,7 +41100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -41683,9 +41265,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -41849,9 +41431,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42015,9 +41597,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42181,7 +41763,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -42240,9 +41822,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42300,9 +41882,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42360,9 +41942,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42420,7 +42002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -42485,9 +42067,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42551,9 +42133,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42617,9 +42199,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -42683,7 +42265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -42784,9 +42366,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42892,9 +42474,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -42994,9 +42576,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -43096,7 +42678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43197,9 +42779,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43305,9 +42887,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43407,9 +42989,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43509,7 +43091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43598,9 +43180,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43688,9 +43270,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43778,9 +43360,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -43872,7 +43454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43886,7 +43468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43900,7 +43482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43962,7 +43544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44007,7 +43589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -44062,7 +43644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -44171,43 +43753,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44215,7 +43797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -44266,7 +43848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44315,43 +43897,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44359,7 +43941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44468,43 +44050,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44512,7 +44094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44621,43 +44203,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44665,7 +44247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44774,43 +44356,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -44818,7 +44400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44934,7 +44516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44960,7 +44542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44992,7 +44574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -45024,7 +44606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -45046,7 +44628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -45206,9 +44788,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -45373,7 +44955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45522,9 +45104,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45672,9 +45254,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45822,9 +45404,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45972,7 +45554,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -46025,9 +45607,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46079,9 +45661,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46133,9 +45715,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46187,7 +45769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -46252,9 +45834,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46318,9 +45900,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46384,9 +45966,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46450,7 +46032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -46539,9 +46121,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46629,9 +46211,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46719,9 +46301,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46809,7 +46391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46892,9 +46474,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46976,9 +46558,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47060,9 +46642,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47144,7 +46726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -47227,9 +46809,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47311,9 +46893,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47395,9 +46977,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47479,7 +47061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -47501,7 +47083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -47551,7 +47133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47565,7 +47147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47579,7 +47161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47641,7 +47223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47686,7 +47268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47743,7 +47325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47788,7 +47370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47803,7 +47385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47839,7 +47421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47870,7 +47452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47916,7 +47498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47945,7 +47527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47995,7 +47577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48035,7 +47617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -48062,7 +47644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -48100,7 +47682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -48132,7 +47714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -48285,7 +47867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48438,7 +48020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -48591,7 +48173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48744,7 +48326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48897,7 +48479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -49050,7 +48632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -49203,7 +48785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -49355,7 +48937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -49507,7 +49089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49660,7 +49242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49813,7 +49395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49966,7 +49548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -50119,7 +49701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -50278,7 +49860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50329,7 +49911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50380,7 +49962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50431,7 +50013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50482,7 +50064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -50496,7 +50078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -50510,7 +50092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -50530,7 +50112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -50624,7 +50206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50638,7 +50220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50652,7 +50234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -51135,7 +50717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -51155,7 +50737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -51169,7 +50751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -51197,7 +50779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -51397,7 +50979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -51597,7 +51179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -51797,7 +51379,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>
@@ -53686,6 +53268,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV71N19.svd
+++ b/data/Atmel/ATSAMV71N19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -428,7 +428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -495,7 +495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -795,7 +795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -822,7 +822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -849,7 +849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -876,7 +876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -944,7 +944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -961,7 +961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -978,7 +978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -995,7 +995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -1010,7 +1010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -1024,7 +1024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -1040,7 +1040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -1056,7 +1056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -1071,7 +1071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -1088,7 +1088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -1102,7 +1102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -1142,7 +1142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1163,7 +1163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1423,7 +1423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1553,7 +1553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1609,7 +1609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1803,7 +1803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1884,7 +1884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1905,7 +1905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -2010,7 +2010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -2115,7 +2115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2220,7 +2220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2325,7 +2325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2406,7 +2406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2426,7 +2426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2506,7 +2506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2586,7 +2586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2600,7 +2600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2615,7 +2615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2629,7 +2629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2672,7 +2672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2692,7 +2692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2718,7 +2718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2798,7 +2798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2812,7 +2812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2832,7 +2832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2912,7 +2912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2940,7 +2940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2961,7 +2961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_VERSION</name>
+               <name>VERSION</name>
                <description>AFEC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -3005,7 +3005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3335,7 +3335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3369,7 +3369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3384,7 +3384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3480,7 +3480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3702,7 +3702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3723,7 +3723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3744,7 +3744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3779,7 +3779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3800,7 +3800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3833,7 +3833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3866,7 +3866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3899,7 +3899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3932,7 +3932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3952,7 +3952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3980,7 +3980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4001,7 +4001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -4364,7 +4364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4468,7 +4468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4647,7 +4647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4784,7 +4784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4834,7 +4834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4848,7 +4848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4862,7 +4862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4894,7 +4894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -5041,7 +5041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5206,7 +5206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5371,7 +5371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5585,7 +5585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5600,7 +5600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5614,7 +5614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5634,7 +5634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5654,7 +5654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5668,7 +5668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5703,7 +5703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5717,7 +5717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5732,7 +5732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5752,7 +5752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5772,7 +5772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5812,7 +5812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5850,7 +5850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5864,7 +5864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5884,7 +5884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5904,7 +5904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5918,7 +5918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5932,7 +5932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5946,7 +5946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5974,7 +5974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5989,7 +5989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -6004,7 +6004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -6019,7 +6019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -6034,7 +6034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MID</name>
+               <name>MID</name>
                <description>Module ID Register</description>
                <addressOffset>0x0FC</addressOffset>
                <size>32</size>
@@ -6055,7 +6055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -6070,7 +6070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -6085,7 +6085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -6100,7 +6100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -6115,7 +6115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -6130,7 +6130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -6145,7 +6145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -6160,7 +6160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -6175,7 +6175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6190,7 +6190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6205,7 +6205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6250,7 +6250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6265,7 +6265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6280,7 +6280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6295,7 +6295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6310,7 +6310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6325,7 +6325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6340,7 +6340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6355,7 +6355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6370,7 +6370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6385,7 +6385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6400,7 +6400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6415,7 +6415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6430,7 +6430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6445,7 +6445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6460,7 +6460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6475,7 +6475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6490,7 +6490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6520,7 +6520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6535,7 +6535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6550,7 +6550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6565,7 +6565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6580,7 +6580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6595,7 +6595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6610,7 +6610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6625,7 +6625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6640,7 +6640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6655,7 +6655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6670,7 +6670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6685,7 +6685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6700,7 +6700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6715,7 +6715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6730,7 +6730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6744,7 +6744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6758,7 +6758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6772,7 +6772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6786,7 +6786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6833,7 +6833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6863,7 +6863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6878,7 +6878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6893,7 +6893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6938,7 +6938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6955,7 +6955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -7008,7 +7008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -7024,7 +7024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -7040,7 +7040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -7054,7 +7054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -7074,7 +7074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -7088,7 +7088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -7104,7 +7104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7220,7 +7220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7273,7 +7273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7326,7 +7326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7378,7 +7378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7392,7 +7392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7412,7 +7412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7455,7 +7455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7475,7 +7475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7518,7 +7518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7538,7 +7538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7601,7 +7601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7644,7 +7644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7664,7 +7664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7707,7 +7707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7727,7 +7727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7770,7 +7770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7833,7 +7833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7853,7 +7853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7916,7 +7916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7959,7 +7959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7979,7 +7979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -8022,7 +8022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -8042,7 +8042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -8085,7 +8085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -8105,7 +8105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -8148,7 +8148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -8168,7 +8168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -8211,7 +8211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -8231,7 +8231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8274,7 +8274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8294,7 +8294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8337,7 +8337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8357,7 +8357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8400,7 +8400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8420,7 +8420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8463,7 +8463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8483,7 +8483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8526,7 +8526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8546,7 +8546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8589,7 +8589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8609,7 +8609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8672,7 +8672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8715,7 +8715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8735,7 +8735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8778,7 +8778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8798,7 +8798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8841,7 +8841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8861,7 +8861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8954,7 +8954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8993,7 +8993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9043,7 +9043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9106,7 +9106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9152,7 +9152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9166,7 +9166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9423,7 +9423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9508,7 +9508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9523,7 +9523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9538,7 +9538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9553,7 +9553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9706,7 +9706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9859,7 +9859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10012,7 +10012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10165,7 +10165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10213,7 +10213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10245,7 +10245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10273,7 +10273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10294,7 +10294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -10317,7 +10317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10350,7 +10350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10436,7 +10436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10508,7 +10508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10559,7 +10559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10610,7 +10610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10661,7 +10661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10712,7 +10712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10769,7 +10769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10785,7 +10785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10819,7 +10819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10917,7 +10917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11025,7 +11025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11045,7 +11045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11059,7 +11059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11091,7 +11091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11123,7 +11123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11155,7 +11155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11187,7 +11187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11219,7 +11219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11252,7 +11252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11333,7 +11333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11396,7 +11396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11459,7 +11459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11522,7 +11522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11585,7 +11585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11599,7 +11599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11631,7 +11631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11645,7 +11645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11659,7 +11659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11691,7 +11691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11705,7 +11705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11733,7 +11733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11754,7 +11754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -11792,7 +11792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11851,7 +11851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11901,7 +11901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11957,7 +11957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11990,7 +11990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -12166,7 +12166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -12194,7 +12194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -12215,7 +12215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x01FC</addressOffset>
                <size>32</size>
@@ -12259,7 +12259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -12304,7 +12304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -12319,7 +12319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -12333,7 +12333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -12390,7 +12390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12458,7 +12458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12478,7 +12478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12691,7 +12691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12723,7 +12723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12761,7 +12761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12775,7 +12775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12837,7 +12837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12851,7 +12851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12884,7 +12884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -13013,7 +13013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -13213,7 +13213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -13413,7 +13413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13613,7 +13613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13633,7 +13633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13717,7 +13717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13737,7 +13737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13757,7 +13757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13771,7 +13771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13827,7 +13827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -14027,7 +14027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -14227,7 +14227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -14259,7 +14259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -14298,7 +14298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -14312,7 +14312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -14326,7 +14326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -14358,7 +14358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -14426,7 +14426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -14440,7 +14440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14595,7 +14595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14627,7 +14627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14660,7 +14660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14717,7 +14717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14918,7 +14918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15118,7 +15118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -15318,7 +15318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15519,7 +15519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15720,7 +15720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15920,7 +15920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -16120,7 +16120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -16146,7 +16146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -16185,7 +16185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -16230,7 +16230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -16336,7 +16336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -16350,7 +16350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -16364,7 +16364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -16408,7 +16408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -16441,7 +16441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -16539,7 +16539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -16565,7 +16565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -16593,7 +16593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -16609,7 +16609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -16626,7 +16626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -16643,7 +16643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -16659,7 +16659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -16673,7 +16673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -16687,7 +16687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -16726,7 +16726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -16773,7 +16773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -16789,7 +16789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -16822,7 +16822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17023,7 +17023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17224,7 +17224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17425,7 +17425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17626,7 +17626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17827,7 +17827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18028,7 +18028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -18229,7 +18229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -18430,7 +18430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -18631,7 +18631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18832,7 +18832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -19033,7 +19033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -19233,7 +19233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -19434,7 +19434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -19635,7 +19635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -19836,7 +19836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -20037,7 +20037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -20238,7 +20238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -20439,7 +20439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -20640,7 +20640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -20841,7 +20841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -21042,7 +21042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -21243,7 +21243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -21446,7 +21446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -21646,7 +21646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -21847,7 +21847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -22048,7 +22048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -22249,7 +22249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -22263,7 +22263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -22464,7 +22464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -22665,7 +22665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -22866,7 +22866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -23268,7 +23268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -23469,7 +23469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -23670,7 +23670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -23871,7 +23871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -24072,7 +24072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -24273,7 +24273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -24474,7 +24474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -24675,7 +24675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -24876,7 +24876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -25077,7 +25077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -25278,7 +25278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -25479,7 +25479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25507,7 +25507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25528,7 +25528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -25549,7 +25549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25749,7 +25749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -26421,7 +26421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -26454,7 +26454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -26487,7 +26487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -26520,7 +26520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -26541,7 +26541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -26591,7 +26591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -26648,7 +26648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -26705,7 +26705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -26768,7 +26768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -26927,7 +26927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -27086,7 +27086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -27436,7 +27436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -27557,7 +27557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -27579,7 +27579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27627,7 +27627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -27726,7 +27726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -27825,7 +27825,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -27942,7 +27942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -28041,7 +28041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -28199,7 +28199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -28303,7 +28303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -28318,7 +28318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -28346,7 +28346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -28367,7 +28367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -28388,7 +28388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -28547,7 +28547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -28706,7 +28706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -28865,7 +28865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -28937,7 +28937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -28981,7 +28981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -29140,7 +29140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -29299,7 +29299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -29458,7 +29458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -29617,7 +29617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -29631,7 +29631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -29790,7 +29790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -29949,7 +29949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -30108,7 +30108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -30267,7 +30267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -30282,7 +30282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -30308,7 +30308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -30355,7 +30355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30529,7 +30529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30562,7 +30562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30595,7 +30595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30628,7 +30628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30685,7 +30685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30742,7 +30742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30799,7 +30799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30856,7 +30856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30924,7 +30924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30939,7 +30939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30953,7 +30953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30973,7 +30973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30988,7 +30988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31105,7 +31105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31222,7 +31222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31339,7 +31339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31456,7 +31456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31512,7 +31512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31568,7 +31568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31625,7 +31625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31682,7 +31682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -31739,7 +31739,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -31796,7 +31796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -31822,7 +31822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -31843,7 +31843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -31858,7 +31858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -31914,7 +31914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -31948,7 +31948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -32004,7 +32004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -32024,7 +32024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -32039,7 +32039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -32071,7 +32071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -32127,7 +32127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32210,7 +32210,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32303,7 +32303,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -32330,7 +32330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32350,7 +32350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32371,7 +32371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32415,7 +32415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32455,7 +32455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32597,7 +32597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32611,7 +32611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32626,7 +32626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32640,7 +32640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -32655,7 +32655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -32670,7 +32670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32690,7 +32690,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32712,7 +32712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -32733,7 +32733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -32754,7 +32754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -32834,7 +32834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -32872,7 +32872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -32893,7 +32893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -32973,7 +32973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -33011,7 +33011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -33059,7 +33059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33092,7 +33092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33212,7 +33212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33227,7 +33227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33242,7 +33242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33299,7 +33299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33350,7 +33350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33401,7 +33401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33452,7 +33452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33484,7 +33484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33498,7 +33498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33518,7 +33518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33696,7 +33696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33729,7 +33729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33744,7 +33744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33772,7 +33772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33793,7 +33793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -33833,7 +33833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33868,7 +33868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33929,7 +33929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33988,7 +33988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34017,7 +34017,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34067,7 +34067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34101,7 +34101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34174,7 +34174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34388,7 +34388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34420,7 +34420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34458,7 +34458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34508,7 +34508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34540,7 +34540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34663,7 +34663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34708,7 +34708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34753,7 +34753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34798,7 +34798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34843,7 +34843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34876,7 +34876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34916,7 +34916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34960,7 +34960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34974,7 +34974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34989,7 +34989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35029,7 +35029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35092,7 +35092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35148,7 +35148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35169,7 +35169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35196,7 +35196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35253,7 +35253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35304,7 +35304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35355,7 +35355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35408,7 +35408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35512,7 +35512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35540,7 +35540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35561,7 +35561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35601,7 +35601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -35640,7 +35640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -35654,7 +35654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35812,7 +35812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35914,7 +35914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36061,7 +36061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -36169,7 +36169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -36184,7 +36184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -36199,7 +36199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36214,7 +36214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -36228,7 +36228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -36242,7 +36242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -36256,7 +36256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -36325,7 +36325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36382,7 +36382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -36439,7 +36439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36496,7 +36496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36524,7 +36524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36545,7 +36545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -36585,7 +36585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36646,7 +36646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36732,7 +36732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36836,7 +36836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37046,7 +37046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37586,7 +37586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38086,7 +38086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -38113,7 +38113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38356,7 +38356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -38376,7 +38376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -38391,7 +38391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -38406,7 +38406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -38420,7 +38420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -38434,7 +38434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -38448,7 +38448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38523,7 +38523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38580,7 +38580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38637,7 +38637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38694,7 +38694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38747,7 +38747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38762,7 +38762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38908,7 +38908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38935,7 +38935,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38962,7 +38962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38989,7 +38989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -39022,7 +39022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -39042,7 +39042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39070,7 +39070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -39158,7 +39158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -39187,7 +39187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39202,7 +39202,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -39217,7 +39217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -39232,7 +39232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -39247,7 +39247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -39262,7 +39262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -39302,7 +39302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -39443,7 +39443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -39492,7 +39492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39560,7 +39560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39574,7 +39574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39606,7 +39606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39729,7 +39729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39834,7 +39834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39939,7 +39939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -40044,7 +40044,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40059,7 +40059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -40074,7 +40074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -40106,7 +40106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -40138,7 +40138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -40170,7 +40170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_DR</name>
+               <name>DR</name>
                <description>Debug Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -40203,7 +40203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -40231,7 +40231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -40252,7 +40252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -40308,7 +40308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -40371,7 +40371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -40480,7 +40480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40531,7 +40531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40582,7 +40582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40633,7 +40633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40702,7 +40702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40717,7 +40717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40732,7 +40732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40746,7 +40746,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40791,7 +40791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40819,7 +40819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -42416,7 +42416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -42507,7 +42507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -42660,7 +42660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42711,7 +42711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42804,7 +42804,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -42957,7 +42957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -43110,7 +43110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -43263,7 +43263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -43391,7 +43391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -43420,7 +43420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -43592,7 +43592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43757,7 +43757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -43816,7 +43816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43881,7 +43881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43982,7 +43982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -44083,7 +44083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -44176,7 +44176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -44190,7 +44190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -44204,7 +44204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -44266,7 +44266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -44311,7 +44311,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -44366,7 +44366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -44519,7 +44519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -44570,7 +44570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -44663,7 +44663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44816,7 +44816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44969,7 +44969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -45122,7 +45122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -45238,7 +45238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -45264,7 +45264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -45296,7 +45296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -45328,7 +45328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -45350,7 +45350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -45510,7 +45510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -45659,7 +45659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45712,7 +45712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45777,7 +45777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45866,7 +45866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -45949,7 +45949,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -46032,7 +46032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -46054,7 +46054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -46104,7 +46104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46118,7 +46118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46132,7 +46132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46194,7 +46194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46239,7 +46239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -46296,7 +46296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -46341,7 +46341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -46356,7 +46356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -46377,7 +46377,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA1</name>
+               <name>TSTA1</name>
                <description>General Test A1 Register</description>
                <addressOffset>0x0810</addressOffset>
                <size>32</size>
@@ -46421,7 +46421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA2</name>
+               <name>TSTA2</name>
                <description>General Test A2 Register</description>
                <addressOffset>0x0814</addressOffset>
                <size>32</size>
@@ -46483,7 +46483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_VERSION</name>
+               <name>VERSION</name>
                <description>General Version Register</description>
                <addressOffset>0x0818</addressOffset>
                <size>32</size>
@@ -46504,7 +46504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_FSM</name>
+               <name>FSM</name>
                <description>General Finite State Machine Register</description>
                <addressOffset>0x082C</addressOffset>
                <size>32</size>
@@ -46617,7 +46617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46648,7 +46648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -46694,7 +46694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46723,7 +46723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46773,7 +46773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46813,7 +46813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46840,7 +46840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46878,7 +46878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46910,7 +46910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -47063,7 +47063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47216,7 +47216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -47369,7 +47369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -47522,7 +47522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -47675,7 +47675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -47828,7 +47828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -47981,7 +47981,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -48133,7 +48133,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -48285,7 +48285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -48438,7 +48438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -48591,7 +48591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -48744,7 +48744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -48897,7 +48897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -49056,7 +49056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49107,7 +49107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -49158,7 +49158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -49209,7 +49209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -49260,7 +49260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -49274,7 +49274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -49288,7 +49288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -49308,7 +49308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -49402,7 +49402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -49416,7 +49416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -49430,7 +49430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -49760,7 +49760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -49780,7 +49780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -49794,7 +49794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -49809,7 +49809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>XDMAC_VERSION</name>
+               <name>VERSION</name>
                <description>XDMAC Version Register</description>
                <addressOffset>0xFFC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV71N19B.svd
+++ b/data/Atmel/ATSAMV71N19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9279,7 +9279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9353,7 +9353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9398,7 +9398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9425,7 +9425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9476,7 +9476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9527,7 +9527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9578,7 +9578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9629,7 +9629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9672,7 +9672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9686,7 +9686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9702,7 +9702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9736,7 +9736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9834,7 +9834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9942,7 +9942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9962,7 +9962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9976,7 +9976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10008,7 +10008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10040,7 +10040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10072,7 +10072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10104,7 +10104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10169,7 +10169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10250,7 +10250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10313,7 +10313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10376,7 +10376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10439,7 +10439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10460,7 +10460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10502,7 +10502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10516,7 +10516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10548,7 +10548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10562,7 +10562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10576,7 +10576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10608,7 +10608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10622,7 +10622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10650,7 +10650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10688,7 +10688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10747,7 +10747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10797,7 +10797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10853,7 +10853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10892,7 +10892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11126,7 +11126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11154,7 +11154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11198,7 +11198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11243,7 +11243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11258,7 +11258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11272,7 +11272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11323,7 +11323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11385,7 +11385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11405,7 +11405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11614,7 +11614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11646,7 +11646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11684,7 +11684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11698,7 +11698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11760,7 +11760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11774,7 +11774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11807,7 +11807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11948,7 +11948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11968,7 +11968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12144,7 +12144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12320,7 +12320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12496,7 +12496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12516,7 +12516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12600,7 +12600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12620,7 +12620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12640,7 +12640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12654,7 +12654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12710,7 +12710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12910,7 +12910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13110,7 +13110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13142,7 +13142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13181,7 +13181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13195,7 +13195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13209,7 +13209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13241,7 +13241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13309,7 +13309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13323,7 +13323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13478,7 +13478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13510,7 +13510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13543,7 +13543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13600,7 +13600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13801,7 +13801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14001,7 +14001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14201,7 +14201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14402,7 +14402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14603,7 +14603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14803,7 +14803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15003,7 +15003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15029,7 +15029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15068,7 +15068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15113,7 +15113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -15219,7 +15219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -15233,7 +15233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -15247,7 +15247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -15291,7 +15291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -15324,7 +15324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -15422,7 +15422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -15448,7 +15448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -15476,7 +15476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -15492,7 +15492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -15509,7 +15509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -15526,7 +15526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -15542,7 +15542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15556,7 +15556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -15570,7 +15570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -15609,7 +15609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -15656,7 +15656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -15672,7 +15672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -15705,7 +15705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15906,7 +15906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16107,7 +16107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16308,7 +16308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16509,7 +16509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16710,7 +16710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16911,7 +16911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17112,7 +17112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17313,7 +17313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17514,7 +17514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17715,7 +17715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17916,7 +17916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18116,7 +18116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18317,7 +18317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18518,7 +18518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18719,7 +18719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18920,7 +18920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19121,7 +19121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19322,7 +19322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19523,7 +19523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19724,7 +19724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19925,7 +19925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20126,7 +20126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20329,7 +20329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20529,7 +20529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20730,7 +20730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20931,7 +20931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21132,7 +21132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21146,7 +21146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21347,7 +21347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21548,7 +21548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21749,7 +21749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21950,7 +21950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22151,7 +22151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22352,7 +22352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22553,7 +22553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22754,7 +22754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22955,7 +22955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23156,7 +23156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23357,7 +23357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23558,7 +23558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23759,7 +23759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23960,7 +23960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24161,7 +24161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24362,7 +24362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24390,7 +24390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24411,7 +24411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24611,7 +24611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25227,7 +25227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25283,7 +25283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25316,7 +25316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25349,7 +25349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25382,7 +25382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25403,7 +25403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25453,7 +25453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25516,7 +25516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25579,7 +25579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25648,7 +25648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25789,7 +25789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25930,7 +25930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26262,7 +26262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26383,7 +26383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26405,7 +26405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26453,7 +26453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26558,7 +26558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26663,7 +26663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26786,7 +26786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26891,7 +26891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27049,7 +27049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27153,7 +27153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27168,7 +27168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27196,7 +27196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27217,7 +27217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27370,7 +27370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27523,7 +27523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27676,7 +27676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27748,7 +27748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27792,7 +27792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -27933,7 +27933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28074,7 +28074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28215,7 +28215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28356,7 +28356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28370,7 +28370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28523,7 +28523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28676,7 +28676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -28829,7 +28829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -28982,7 +28982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29016,7 +29016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29190,7 +29190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29223,7 +29223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29256,7 +29256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29289,7 +29289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29346,7 +29346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29403,7 +29403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29460,7 +29460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29517,7 +29517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29585,7 +29585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29600,7 +29600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29614,7 +29614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29634,7 +29634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29649,7 +29649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29766,7 +29766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29883,7 +29883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30000,7 +30000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30117,7 +30117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30173,7 +30173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30229,7 +30229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30286,7 +30286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30343,7 +30343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30400,7 +30400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30457,7 +30457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30483,7 +30483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30504,7 +30504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30519,7 +30519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30575,7 +30575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30609,7 +30609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30665,7 +30665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30685,7 +30685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30700,7 +30700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30732,7 +30732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30788,7 +30788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30871,7 +30871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30970,7 +30970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31003,7 +31003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31024,7 +31024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31068,7 +31068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31108,7 +31108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31302,7 +31302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31316,7 +31316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31331,7 +31331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31345,7 +31345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31360,7 +31360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31375,7 +31375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31395,7 +31395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31417,7 +31417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31438,7 +31438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31459,7 +31459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31539,7 +31539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31577,7 +31577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31598,7 +31598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31678,7 +31678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31716,7 +31716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31764,7 +31764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31797,7 +31797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31917,7 +31917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31932,7 +31932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31947,7 +31947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32004,7 +32004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32055,7 +32055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32106,7 +32106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32157,7 +32157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32189,7 +32189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32203,7 +32203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32223,7 +32223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32401,7 +32401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32434,7 +32434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32449,7 +32449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32477,7 +32477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32517,7 +32517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32552,7 +32552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32613,7 +32613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32672,7 +32672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32701,7 +32701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32751,7 +32751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32785,7 +32785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32858,7 +32858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33072,7 +33072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33104,7 +33104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33142,7 +33142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33192,7 +33192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33224,7 +33224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33347,7 +33347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33392,7 +33392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33437,7 +33437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33482,7 +33482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33527,7 +33527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33579,7 +33579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33623,7 +33623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33637,7 +33637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33652,7 +33652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33692,7 +33692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33731,7 +33731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33823,7 +33823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33844,7 +33844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33894,7 +33894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33951,7 +33951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34002,7 +34002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34053,7 +34053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34106,7 +34106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34139,12 +34139,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -34236,7 +34236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34264,7 +34264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34304,7 +34304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34343,7 +34343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34357,7 +34357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34515,7 +34515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34617,7 +34617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34764,7 +34764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34872,7 +34872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34887,7 +34887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34902,7 +34902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34917,7 +34917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34931,7 +34931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34945,7 +34945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -34959,7 +34959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35028,7 +35028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35085,7 +35085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35142,7 +35142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35199,7 +35199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35227,7 +35227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35258,7 +35258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -35267,7 +35267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35328,7 +35328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35414,7 +35414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35518,7 +35518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35728,7 +35728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36268,7 +36268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36713,6 +36713,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -36747,7 +36775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36774,7 +36802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37017,9 +37045,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -37453,7 +37481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37473,7 +37501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37488,7 +37516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37503,7 +37531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37517,7 +37545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37531,7 +37559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37545,7 +37573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37620,7 +37648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37677,7 +37705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37734,7 +37762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37791,7 +37819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37844,7 +37872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37859,7 +37887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38017,7 +38045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38050,7 +38078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38083,7 +38111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38116,7 +38144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38155,7 +38183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38175,7 +38203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38270,7 +38298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38299,7 +38327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38314,7 +38342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38329,7 +38357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38344,7 +38372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38359,7 +38387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38393,7 +38421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38534,7 +38562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38583,7 +38611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38651,7 +38679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38665,7 +38693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38697,7 +38725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38820,7 +38848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38925,7 +38953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39030,7 +39058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39135,7 +39163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39150,7 +39178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39165,7 +39193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39197,7 +39225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39229,7 +39257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39261,7 +39289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39289,7 +39317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39345,7 +39373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39402,7 +39430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39511,7 +39539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39562,7 +39590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39613,7 +39641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39664,7 +39692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39715,7 +39743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39730,7 +39758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39745,7 +39773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39759,7 +39787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39804,7 +39832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40630,6 +40658,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -40680,7 +40726,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -40721,80 +40813,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40892,12 +40910,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -40907,6 +40919,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40942,46 +40966,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -41010,6 +40994,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41063,7 +41065,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -41110,134 +41158,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41329,30 +41249,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -41362,6 +41258,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41397,64 +41305,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -41483,6 +41333,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41536,7 +41404,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -41583,134 +41497,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41802,30 +41588,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -41835,6 +41597,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41870,64 +41644,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -41956,6 +41672,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42033,7 +41767,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -42080,140 +41866,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42311,30 +41963,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -42344,6 +41972,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42374,64 +42014,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -43122,7 +42704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -43213,7 +42795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -43366,7 +42948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -43417,7 +42999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -43510,7 +43092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -43663,7 +43245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -43816,7 +43398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -43969,7 +43551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -44097,7 +43679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -44126,7 +43708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -44298,7 +43880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -44463,9 +44045,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44629,9 +44211,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44795,9 +44377,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44961,7 +44543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -45020,9 +44602,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45080,9 +44662,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45140,9 +44722,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45200,7 +44782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -45265,9 +44847,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45331,9 +44913,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45397,9 +44979,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45463,7 +45045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -45564,9 +45146,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45672,9 +45254,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45774,9 +45356,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45876,7 +45458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -45977,9 +45559,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46085,9 +45667,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46187,9 +45769,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46289,7 +45871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -46378,9 +45960,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46468,9 +46050,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46558,9 +46140,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46652,7 +46234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46666,7 +46248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46680,7 +46262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46742,7 +46324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46787,7 +46369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -46842,7 +46424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -46951,43 +46533,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46995,7 +46577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -47046,7 +46628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -47095,43 +46677,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47139,7 +46721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -47248,43 +46830,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47292,7 +46874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -47401,43 +46983,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47445,7 +47027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -47554,43 +47136,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47598,7 +47180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -47714,7 +47296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -47740,7 +47322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -47772,7 +47354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -47804,7 +47386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -47826,7 +47408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -47986,9 +47568,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -48153,7 +47735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -48302,9 +47884,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48452,9 +48034,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48602,9 +48184,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48752,7 +48334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -48805,9 +48387,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48859,9 +48441,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48913,9 +48495,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48967,7 +48549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -49032,9 +48614,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49098,9 +48680,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49164,9 +48746,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49230,7 +48812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -49319,9 +48901,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49409,9 +48991,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49499,9 +49081,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49589,7 +49171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -49672,9 +49254,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49756,9 +49338,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49840,9 +49422,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49924,7 +49506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -50007,9 +49589,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50091,9 +49673,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50175,9 +49757,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50259,7 +49841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -50281,7 +49863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -50331,7 +49913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50345,7 +49927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50359,7 +49941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50421,7 +50003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50466,7 +50048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -50523,7 +50105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -50568,7 +50150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -50583,7 +50165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -50619,7 +50201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -50650,7 +50232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -50696,7 +50278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50725,7 +50307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50775,7 +50357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50815,7 +50397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50842,7 +50424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50880,7 +50462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50912,7 +50494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -51065,7 +50647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51218,7 +50800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -51371,7 +50953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -51524,7 +51106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -51677,7 +51259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -51830,7 +51412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -51983,7 +51565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -52135,7 +51717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -52287,7 +51869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -52440,7 +52022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -52593,7 +52175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -52746,7 +52328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -52899,7 +52481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -53058,7 +52640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -53109,7 +52691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -53160,7 +52742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -53211,7 +52793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -53262,7 +52844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -53276,7 +52858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -53290,7 +52872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -53310,7 +52892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -53404,7 +52986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -53418,7 +53000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -53432,7 +53014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -53995,7 +53577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -54015,7 +53597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -54029,7 +53611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -54057,7 +53639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -55946,6 +55528,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV71N20.svd
+++ b/data/Atmel/ATSAMV71N20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -428,7 +428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -495,7 +495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -795,7 +795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -822,7 +822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -849,7 +849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -876,7 +876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -944,7 +944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -961,7 +961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -978,7 +978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -995,7 +995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -1010,7 +1010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -1024,7 +1024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -1040,7 +1040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -1056,7 +1056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -1071,7 +1071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -1088,7 +1088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -1102,7 +1102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -1142,7 +1142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1163,7 +1163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1423,7 +1423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1553,7 +1553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1609,7 +1609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1803,7 +1803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1884,7 +1884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1905,7 +1905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -2010,7 +2010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -2115,7 +2115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2220,7 +2220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2325,7 +2325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2406,7 +2406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2426,7 +2426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2506,7 +2506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2586,7 +2586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2600,7 +2600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2615,7 +2615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2629,7 +2629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2672,7 +2672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2692,7 +2692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2718,7 +2718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2798,7 +2798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2812,7 +2812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2832,7 +2832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2912,7 +2912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2940,7 +2940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2961,7 +2961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_VERSION</name>
+               <name>VERSION</name>
                <description>AFEC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -3005,7 +3005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3335,7 +3335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3692,7 +3692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -3796,7 +3796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -3975,7 +3975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -3996,7 +3996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4010,7 +4010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4112,7 +4112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4162,7 +4162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4176,7 +4176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4190,7 +4190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4369,7 +4369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4534,7 +4534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -4699,7 +4699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -4863,7 +4863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -4913,7 +4913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -4928,7 +4928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -4942,7 +4942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -4962,7 +4962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -4982,7 +4982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -4996,7 +4996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5010,7 +5010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5031,7 +5031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5045,7 +5045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5060,7 +5060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5080,7 +5080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5100,7 +5100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5120,7 +5120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5140,7 +5140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5178,7 +5178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5192,7 +5192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5212,7 +5212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5232,7 +5232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5246,7 +5246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5260,7 +5260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5274,7 +5274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5288,7 +5288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5302,7 +5302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5317,7 +5317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5332,7 +5332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5347,7 +5347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5362,7 +5362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MID</name>
+               <name>MID</name>
                <description>Module ID Register</description>
                <addressOffset>0x0FC</addressOffset>
                <size>32</size>
@@ -5383,7 +5383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5398,7 +5398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5413,7 +5413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5428,7 +5428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5443,7 +5443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5458,7 +5458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5473,7 +5473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5488,7 +5488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5503,7 +5503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5518,7 +5518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5533,7 +5533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5548,7 +5548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5563,7 +5563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5578,7 +5578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5593,7 +5593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -5608,7 +5608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -5623,7 +5623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -5653,7 +5653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -5668,7 +5668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -5683,7 +5683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -5698,7 +5698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -5713,7 +5713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6072,7 +6072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6086,7 +6086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6100,7 +6100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6114,7 +6114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6135,7 +6135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6176,7 +6176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6191,7 +6191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6206,7 +6206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6221,7 +6221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6236,7 +6236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6251,7 +6251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6266,7 +6266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6336,7 +6336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6352,7 +6352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6368,7 +6368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6382,7 +6382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6402,7 +6402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6416,7 +6416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6432,7 +6432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6472,7 +6472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6548,7 +6548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -6601,7 +6601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -6654,7 +6654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -6706,7 +6706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -6720,7 +6720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -6740,7 +6740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -6783,7 +6783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -6803,7 +6803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -6846,7 +6846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -6866,7 +6866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -6909,7 +6909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -6929,7 +6929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -6972,7 +6972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -6992,7 +6992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7035,7 +7035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7055,7 +7055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7098,7 +7098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7118,7 +7118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7161,7 +7161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7181,7 +7181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7224,7 +7224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7244,7 +7244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7287,7 +7287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7307,7 +7307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7350,7 +7350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7413,7 +7413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7433,7 +7433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7476,7 +7476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7496,7 +7496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7539,7 +7539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7559,7 +7559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -7602,7 +7602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -7622,7 +7622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -7665,7 +7665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -7685,7 +7685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -7728,7 +7728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -7748,7 +7748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -7791,7 +7791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -7811,7 +7811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -7854,7 +7854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -7874,7 +7874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -7917,7 +7917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -7980,7 +7980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8000,7 +8000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8043,7 +8043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8063,7 +8063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8106,7 +8106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8126,7 +8126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8169,7 +8169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8189,7 +8189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8282,7 +8282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8321,7 +8321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8371,7 +8371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8434,7 +8434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8494,7 +8494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8751,7 +8751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8771,7 +8771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8836,7 +8836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8851,7 +8851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -8866,7 +8866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -8881,7 +8881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9034,7 +9034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9187,7 +9187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9340,7 +9340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9493,7 +9493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9541,7 +9541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9573,7 +9573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -9601,7 +9601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -9622,7 +9622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -9645,7 +9645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -9678,7 +9678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9764,7 +9764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9809,7 +9809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9836,7 +9836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9887,7 +9887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9938,7 +9938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9989,7 +9989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10040,7 +10040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10083,7 +10083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10097,7 +10097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10113,7 +10113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10147,7 +10147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10245,7 +10245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10353,7 +10353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10373,7 +10373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10387,7 +10387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10419,7 +10419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10451,7 +10451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10483,7 +10483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10515,7 +10515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10547,7 +10547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10580,7 +10580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10661,7 +10661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10724,7 +10724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10787,7 +10787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10850,7 +10850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10871,7 +10871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10892,7 +10892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10913,7 +10913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10927,7 +10927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10959,7 +10959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10973,7 +10973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10987,7 +10987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11019,7 +11019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11033,7 +11033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11061,7 +11061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11082,7 +11082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -11120,7 +11120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11179,7 +11179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11229,7 +11229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11285,7 +11285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11318,7 +11318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11494,7 +11494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11522,7 +11522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x01FC</addressOffset>
                <size>32</size>
@@ -11587,7 +11587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11632,7 +11632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11647,7 +11647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11661,7 +11661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11718,7 +11718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11786,7 +11786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11806,7 +11806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12019,7 +12019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12051,7 +12051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12089,7 +12089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12103,7 +12103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12165,7 +12165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12179,7 +12179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12212,7 +12212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -12341,7 +12341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12541,7 +12541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12741,7 +12741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12941,7 +12941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12961,7 +12961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13045,7 +13045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13065,7 +13065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13085,7 +13085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13099,7 +13099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13155,7 +13155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13355,7 +13355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13555,7 +13555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13587,7 +13587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13626,7 +13626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13640,7 +13640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13654,7 +13654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13686,7 +13686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13754,7 +13754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13768,7 +13768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13923,7 +13923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13955,7 +13955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13988,7 +13988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14045,7 +14045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14246,7 +14246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14446,7 +14446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14646,7 +14646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14847,7 +14847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15048,7 +15048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15248,7 +15248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15448,7 +15448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15474,7 +15474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15513,7 +15513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15558,7 +15558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -15664,7 +15664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -15678,7 +15678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -15692,7 +15692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -15736,7 +15736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -15769,7 +15769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -15867,7 +15867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -15893,7 +15893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -15921,7 +15921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -15937,7 +15937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -15954,7 +15954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -15971,7 +15971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -15987,7 +15987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -16001,7 +16001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -16015,7 +16015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -16054,7 +16054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -16101,7 +16101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -16117,7 +16117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -16150,7 +16150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -16351,7 +16351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16552,7 +16552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16753,7 +16753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16954,7 +16954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17155,7 +17155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -17356,7 +17356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17557,7 +17557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17758,7 +17758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17959,7 +17959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18160,7 +18160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -18361,7 +18361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18561,7 +18561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18762,7 +18762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18963,7 +18963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -19164,7 +19164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -19365,7 +19365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19566,7 +19566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19767,7 +19767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19968,7 +19968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -20169,7 +20169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -20370,7 +20370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20571,7 +20571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20774,7 +20774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20974,7 +20974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -21175,7 +21175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -21376,7 +21376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21577,7 +21577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21591,7 +21591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21792,7 +21792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21993,7 +21993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -22194,7 +22194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -22395,7 +22395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22596,7 +22596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22797,7 +22797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22998,7 +22998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -23199,7 +23199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -23400,7 +23400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23601,7 +23601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23802,7 +23802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -24003,7 +24003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -24204,7 +24204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -24405,7 +24405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24606,7 +24606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24807,7 +24807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24835,7 +24835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24856,7 +24856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -24877,7 +24877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25077,7 +25077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25693,7 +25693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25749,7 +25749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25782,7 +25782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25815,7 +25815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25848,7 +25848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25869,7 +25869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25919,7 +25919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25976,7 +25976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -26033,7 +26033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -26096,7 +26096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -26255,7 +26255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -26414,7 +26414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26764,7 +26764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26885,7 +26885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26907,7 +26907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26955,7 +26955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -27054,7 +27054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -27153,7 +27153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -27270,7 +27270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -27369,7 +27369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27527,7 +27527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27631,7 +27631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27646,7 +27646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27674,7 +27674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27695,7 +27695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -27716,7 +27716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27875,7 +27875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -28034,7 +28034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -28193,7 +28193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -28265,7 +28265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -28309,7 +28309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28468,7 +28468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28627,7 +28627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28786,7 +28786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28945,7 +28945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28959,7 +28959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -29118,7 +29118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -29277,7 +29277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29436,7 +29436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29595,7 +29595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29610,7 +29610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -29636,7 +29636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -29683,7 +29683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29857,7 +29857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29890,7 +29890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29923,7 +29923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29956,7 +29956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30013,7 +30013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30070,7 +30070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30127,7 +30127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30184,7 +30184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30252,7 +30252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30267,7 +30267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30281,7 +30281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30301,7 +30301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30316,7 +30316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30433,7 +30433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30550,7 +30550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30667,7 +30667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30784,7 +30784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30840,7 +30840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30896,7 +30896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30953,7 +30953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31010,7 +31010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -31067,7 +31067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -31124,7 +31124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -31150,7 +31150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -31171,7 +31171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -31186,7 +31186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -31242,7 +31242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -31276,7 +31276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -31332,7 +31332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -31352,7 +31352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -31367,7 +31367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -31399,7 +31399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -31455,7 +31455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31538,7 +31538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31631,7 +31631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -31658,7 +31658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31678,7 +31678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31699,7 +31699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31743,7 +31743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31783,7 +31783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31925,7 +31925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31939,7 +31939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31954,7 +31954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31968,7 +31968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31983,7 +31983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31998,7 +31998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32018,7 +32018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32040,7 +32040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -32061,7 +32061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -32082,7 +32082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -32162,7 +32162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -32200,7 +32200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -32221,7 +32221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -32301,7 +32301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -32339,7 +32339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -32387,7 +32387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32420,7 +32420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32540,7 +32540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32555,7 +32555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32570,7 +32570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32627,7 +32627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32678,7 +32678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32729,7 +32729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32780,7 +32780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32812,7 +32812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32826,7 +32826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32846,7 +32846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33024,7 +33024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33057,7 +33057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33072,7 +33072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33100,7 +33100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33121,7 +33121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -33161,7 +33161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33196,7 +33196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33257,7 +33257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33316,7 +33316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33345,7 +33345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33395,7 +33395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33429,7 +33429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33502,7 +33502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33716,7 +33716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33748,7 +33748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33786,7 +33786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33836,7 +33836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33868,7 +33868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33991,7 +33991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34036,7 +34036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34081,7 +34081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34126,7 +34126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34171,7 +34171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34204,7 +34204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34244,7 +34244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34288,7 +34288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34302,7 +34302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34317,7 +34317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34357,7 +34357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34396,7 +34396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34452,7 +34452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34473,7 +34473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34500,7 +34500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34557,7 +34557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34608,7 +34608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34659,7 +34659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34712,7 +34712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34816,7 +34816,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34844,7 +34844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34865,7 +34865,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34905,7 +34905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34944,7 +34944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34958,7 +34958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35116,7 +35116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35218,7 +35218,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35365,7 +35365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35473,7 +35473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35488,7 +35488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35503,7 +35503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35518,7 +35518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35532,7 +35532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35546,7 +35546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35560,7 +35560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35629,7 +35629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35686,7 +35686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35743,7 +35743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35800,7 +35800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35828,7 +35828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35849,7 +35849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35889,7 +35889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35950,7 +35950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36036,7 +36036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36140,7 +36140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36350,7 +36350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36890,7 +36890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37390,7 +37390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37417,7 +37417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37660,7 +37660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37680,7 +37680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37695,7 +37695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37710,7 +37710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37724,7 +37724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37738,7 +37738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37752,7 +37752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37827,7 +37827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37884,7 +37884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37941,7 +37941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37998,7 +37998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38051,7 +38051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38066,7 +38066,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38212,7 +38212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38239,7 +38239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38266,7 +38266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38293,7 +38293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38326,7 +38326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38346,7 +38346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38374,7 +38374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -38462,7 +38462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38491,7 +38491,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38506,7 +38506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38521,7 +38521,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38536,7 +38536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38551,7 +38551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38566,7 +38566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -38606,7 +38606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38747,7 +38747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38796,7 +38796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38864,7 +38864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38878,7 +38878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38910,7 +38910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39033,7 +39033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39138,7 +39138,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39243,7 +39243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39348,7 +39348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39363,7 +39363,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39378,7 +39378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39410,7 +39410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39442,7 +39442,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39474,7 +39474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_DR</name>
+               <name>DR</name>
                <description>Debug Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39507,7 +39507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39535,7 +39535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39556,7 +39556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -39612,7 +39612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39675,7 +39675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39784,7 +39784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39835,7 +39835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39886,7 +39886,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39937,7 +39937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40006,7 +40006,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40021,7 +40021,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40036,7 +40036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40050,7 +40050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40095,7 +40095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40123,7 +40123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -41720,7 +41720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41811,7 +41811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41964,7 +41964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42015,7 +42015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42108,7 +42108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -42261,7 +42261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -42414,7 +42414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -42567,7 +42567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42695,7 +42695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42724,7 +42724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42896,7 +42896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43061,7 +43061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -43120,7 +43120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43185,7 +43185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43286,7 +43286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43387,7 +43387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43480,7 +43480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43494,7 +43494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43508,7 +43508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43570,7 +43570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43615,7 +43615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43670,7 +43670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43823,7 +43823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43874,7 +43874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43967,7 +43967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44120,7 +44120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44273,7 +44273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44426,7 +44426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44542,7 +44542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44568,7 +44568,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44600,7 +44600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44632,7 +44632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44654,7 +44654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44814,7 +44814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -44963,7 +44963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45016,7 +45016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45081,7 +45081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45170,7 +45170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -45253,7 +45253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -45336,7 +45336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -45358,7 +45358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -45408,7 +45408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45422,7 +45422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45436,7 +45436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45498,7 +45498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45543,7 +45543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -45600,7 +45600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -45645,7 +45645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45660,7 +45660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45681,7 +45681,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA1</name>
+               <name>TSTA1</name>
                <description>General Test A1 Register</description>
                <addressOffset>0x0810</addressOffset>
                <size>32</size>
@@ -45725,7 +45725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA2</name>
+               <name>TSTA2</name>
                <description>General Test A2 Register</description>
                <addressOffset>0x0814</addressOffset>
                <size>32</size>
@@ -45787,7 +45787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_VERSION</name>
+               <name>VERSION</name>
                <description>General Version Register</description>
                <addressOffset>0x0818</addressOffset>
                <size>32</size>
@@ -45808,7 +45808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_FSM</name>
+               <name>FSM</name>
                <description>General Finite State Machine Register</description>
                <addressOffset>0x082C</addressOffset>
                <size>32</size>
@@ -45921,7 +45921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45952,7 +45952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -45998,7 +45998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46027,7 +46027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46077,7 +46077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46117,7 +46117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46144,7 +46144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46182,7 +46182,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46214,7 +46214,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -46367,7 +46367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46520,7 +46520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -46673,7 +46673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -46826,7 +46826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -46979,7 +46979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -47132,7 +47132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -47285,7 +47285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -47437,7 +47437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -47589,7 +47589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47742,7 +47742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47895,7 +47895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -48048,7 +48048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -48201,7 +48201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -48360,7 +48360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -48411,7 +48411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -48462,7 +48462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -48513,7 +48513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -48564,7 +48564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -48578,7 +48578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -48592,7 +48592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -48612,7 +48612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -48706,7 +48706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -48720,7 +48720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -48734,7 +48734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -49064,7 +49064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -49084,7 +49084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -49098,7 +49098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -49113,7 +49113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>XDMAC_VERSION</name>
+               <name>VERSION</name>
                <description>XDMAC Version Register</description>
                <addressOffset>0xFFC</addressOffset>
                <size>32</size>
@@ -49146,7 +49146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -49346,7 +49346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV71N20B.svd
+++ b/data/Atmel/ATSAMV71N20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9279,7 +9279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9353,7 +9353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9398,7 +9398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9425,7 +9425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9476,7 +9476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9527,7 +9527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9578,7 +9578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9629,7 +9629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9672,7 +9672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9686,7 +9686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9702,7 +9702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9736,7 +9736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9834,7 +9834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9942,7 +9942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9962,7 +9962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9976,7 +9976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10008,7 +10008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10040,7 +10040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10072,7 +10072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10104,7 +10104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10169,7 +10169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10250,7 +10250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10313,7 +10313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10376,7 +10376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10439,7 +10439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10460,7 +10460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10502,7 +10502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10516,7 +10516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10548,7 +10548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10562,7 +10562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10576,7 +10576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10608,7 +10608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10622,7 +10622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10650,7 +10650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10688,7 +10688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10747,7 +10747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10797,7 +10797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10853,7 +10853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10892,7 +10892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11126,7 +11126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11154,7 +11154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11198,7 +11198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11243,7 +11243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11258,7 +11258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11272,7 +11272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11323,7 +11323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11385,7 +11385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11405,7 +11405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11614,7 +11614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11646,7 +11646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11684,7 +11684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11698,7 +11698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11760,7 +11760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11774,7 +11774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11807,7 +11807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11948,7 +11948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11968,7 +11968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12144,7 +12144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12320,7 +12320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12496,7 +12496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12516,7 +12516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12600,7 +12600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12620,7 +12620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12640,7 +12640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12654,7 +12654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12710,7 +12710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12910,7 +12910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13110,7 +13110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13142,7 +13142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13181,7 +13181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13195,7 +13195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13209,7 +13209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13241,7 +13241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13309,7 +13309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13323,7 +13323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13478,7 +13478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13510,7 +13510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13543,7 +13543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13600,7 +13600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13801,7 +13801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14001,7 +14001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14201,7 +14201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14402,7 +14402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14603,7 +14603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14803,7 +14803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15003,7 +15003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15029,7 +15029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15068,7 +15068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15113,7 +15113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -15219,7 +15219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -15233,7 +15233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -15247,7 +15247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -15291,7 +15291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -15324,7 +15324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -15422,7 +15422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -15448,7 +15448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -15476,7 +15476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -15492,7 +15492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -15509,7 +15509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -15526,7 +15526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -15542,7 +15542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15556,7 +15556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -15570,7 +15570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -15609,7 +15609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -15656,7 +15656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -15672,7 +15672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -15705,7 +15705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15906,7 +15906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16107,7 +16107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16308,7 +16308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16509,7 +16509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16710,7 +16710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16911,7 +16911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17112,7 +17112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17313,7 +17313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17514,7 +17514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17715,7 +17715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17916,7 +17916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18116,7 +18116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18317,7 +18317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18518,7 +18518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18719,7 +18719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18920,7 +18920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19121,7 +19121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19322,7 +19322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19523,7 +19523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19724,7 +19724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19925,7 +19925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20126,7 +20126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20329,7 +20329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20529,7 +20529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20730,7 +20730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20931,7 +20931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21132,7 +21132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21146,7 +21146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21347,7 +21347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21548,7 +21548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21749,7 +21749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21950,7 +21950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22151,7 +22151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22352,7 +22352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22553,7 +22553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22754,7 +22754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22955,7 +22955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23156,7 +23156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23357,7 +23357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23558,7 +23558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23759,7 +23759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23960,7 +23960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24161,7 +24161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24362,7 +24362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24390,7 +24390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24411,7 +24411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24611,7 +24611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25227,7 +25227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25283,7 +25283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25316,7 +25316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25349,7 +25349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25382,7 +25382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25403,7 +25403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25453,7 +25453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25516,7 +25516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25579,7 +25579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25648,7 +25648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25789,7 +25789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25930,7 +25930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26262,7 +26262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26383,7 +26383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26405,7 +26405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26453,7 +26453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26558,7 +26558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26663,7 +26663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26786,7 +26786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26891,7 +26891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27049,7 +27049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27153,7 +27153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27168,7 +27168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27196,7 +27196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27217,7 +27217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27370,7 +27370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27523,7 +27523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27676,7 +27676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27748,7 +27748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27792,7 +27792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -27933,7 +27933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28074,7 +28074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28215,7 +28215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28356,7 +28356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28370,7 +28370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28523,7 +28523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28676,7 +28676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -28829,7 +28829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -28982,7 +28982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29016,7 +29016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29190,7 +29190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29223,7 +29223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29256,7 +29256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29289,7 +29289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29346,7 +29346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29403,7 +29403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29460,7 +29460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29517,7 +29517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29585,7 +29585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29600,7 +29600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29614,7 +29614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29634,7 +29634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29649,7 +29649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29766,7 +29766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29883,7 +29883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30000,7 +30000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30117,7 +30117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30173,7 +30173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30229,7 +30229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30286,7 +30286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30343,7 +30343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30400,7 +30400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30457,7 +30457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30483,7 +30483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30504,7 +30504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30519,7 +30519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30575,7 +30575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30609,7 +30609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30665,7 +30665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30685,7 +30685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30700,7 +30700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30732,7 +30732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30788,7 +30788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30871,7 +30871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30970,7 +30970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31003,7 +31003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31024,7 +31024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31068,7 +31068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31108,7 +31108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31302,7 +31302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31316,7 +31316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31331,7 +31331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31345,7 +31345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31360,7 +31360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31375,7 +31375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31395,7 +31395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31417,7 +31417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31438,7 +31438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31459,7 +31459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31539,7 +31539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31577,7 +31577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31598,7 +31598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31678,7 +31678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31716,7 +31716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31764,7 +31764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31797,7 +31797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31917,7 +31917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31932,7 +31932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31947,7 +31947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32004,7 +32004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32055,7 +32055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32106,7 +32106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32157,7 +32157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32189,7 +32189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32203,7 +32203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32223,7 +32223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32401,7 +32401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32434,7 +32434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32449,7 +32449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32477,7 +32477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32517,7 +32517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32552,7 +32552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32613,7 +32613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32672,7 +32672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32701,7 +32701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32751,7 +32751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32785,7 +32785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32858,7 +32858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33072,7 +33072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33104,7 +33104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33142,7 +33142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33192,7 +33192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33224,7 +33224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33347,7 +33347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33392,7 +33392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33437,7 +33437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33482,7 +33482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33527,7 +33527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33579,7 +33579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33623,7 +33623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33637,7 +33637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33652,7 +33652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33692,7 +33692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33731,7 +33731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33823,7 +33823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33844,7 +33844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33894,7 +33894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33951,7 +33951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34002,7 +34002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34053,7 +34053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34106,7 +34106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34139,12 +34139,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -34236,7 +34236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34264,7 +34264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34304,7 +34304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34343,7 +34343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34357,7 +34357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34515,7 +34515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34617,7 +34617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34764,7 +34764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34872,7 +34872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34887,7 +34887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34902,7 +34902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34917,7 +34917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34931,7 +34931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34945,7 +34945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -34959,7 +34959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35028,7 +35028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35085,7 +35085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35142,7 +35142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35199,7 +35199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35227,7 +35227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35258,7 +35258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -35267,7 +35267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35328,7 +35328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35414,7 +35414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35518,7 +35518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35728,7 +35728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36268,7 +36268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36713,6 +36713,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -36747,7 +36775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36774,7 +36802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37017,9 +37045,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -37453,7 +37481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37473,7 +37501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37488,7 +37516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37503,7 +37531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37517,7 +37545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37531,7 +37559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37545,7 +37573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37620,7 +37648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37677,7 +37705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37734,7 +37762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37791,7 +37819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37844,7 +37872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37859,7 +37887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38017,7 +38045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38050,7 +38078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38083,7 +38111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38116,7 +38144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38155,7 +38183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38175,7 +38203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38270,7 +38298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38299,7 +38327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38314,7 +38342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38329,7 +38357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38344,7 +38372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38359,7 +38387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38393,7 +38421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38534,7 +38562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38583,7 +38611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38651,7 +38679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38665,7 +38693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38697,7 +38725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38820,7 +38848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38925,7 +38953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39030,7 +39058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39135,7 +39163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39150,7 +39178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39165,7 +39193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39197,7 +39225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39229,7 +39257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39261,7 +39289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39289,7 +39317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39345,7 +39373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39402,7 +39430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39511,7 +39539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39562,7 +39590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39613,7 +39641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39664,7 +39692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39715,7 +39743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39730,7 +39758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39745,7 +39773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39759,7 +39787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39804,7 +39832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40630,6 +40658,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -40680,7 +40726,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -40721,80 +40813,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40892,12 +40910,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -40907,6 +40919,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40942,46 +40966,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -41010,6 +40994,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41063,7 +41065,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -41110,134 +41158,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41329,30 +41249,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -41362,6 +41258,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41397,64 +41305,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -41483,6 +41333,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41536,7 +41404,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -41583,134 +41497,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41802,30 +41588,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -41835,6 +41597,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41870,64 +41644,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -41956,6 +41672,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42033,7 +41767,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -42080,140 +41866,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42311,30 +41963,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -42344,6 +41972,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42374,64 +42014,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -43122,7 +42704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -43213,7 +42795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -43366,7 +42948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -43417,7 +42999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -43510,7 +43092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -43663,7 +43245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -43816,7 +43398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -43969,7 +43551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -44097,7 +43679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -44126,7 +43708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -44298,7 +43880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -44463,9 +44045,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44629,9 +44211,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44795,9 +44377,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44961,7 +44543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -45020,9 +44602,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45080,9 +44662,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45140,9 +44722,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45200,7 +44782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -45265,9 +44847,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45331,9 +44913,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45397,9 +44979,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45463,7 +45045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -45564,9 +45146,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45672,9 +45254,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45774,9 +45356,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45876,7 +45458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -45977,9 +45559,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46085,9 +45667,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46187,9 +45769,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46289,7 +45871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -46378,9 +45960,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46468,9 +46050,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46558,9 +46140,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46652,7 +46234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46666,7 +46248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46680,7 +46262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46742,7 +46324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46787,7 +46369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -46842,7 +46424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -46951,43 +46533,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46995,7 +46577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -47046,7 +46628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -47095,43 +46677,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47139,7 +46721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -47248,43 +46830,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47292,7 +46874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -47401,43 +46983,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47445,7 +47027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -47554,43 +47136,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47598,7 +47180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -47714,7 +47296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -47740,7 +47322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -47772,7 +47354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -47804,7 +47386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -47826,7 +47408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -47986,9 +47568,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -48153,7 +47735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -48302,9 +47884,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48452,9 +48034,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48602,9 +48184,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48752,7 +48334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -48805,9 +48387,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48859,9 +48441,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48913,9 +48495,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48967,7 +48549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -49032,9 +48614,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49098,9 +48680,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49164,9 +48746,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49230,7 +48812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -49319,9 +48901,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49409,9 +48991,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49499,9 +49081,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49589,7 +49171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -49672,9 +49254,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49756,9 +49338,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49840,9 +49422,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49924,7 +49506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -50007,9 +49589,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50091,9 +49673,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50175,9 +49757,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50259,7 +49841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -50281,7 +49863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -50331,7 +49913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50345,7 +49927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50359,7 +49941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50421,7 +50003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50466,7 +50048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -50523,7 +50105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -50568,7 +50150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -50583,7 +50165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -50619,7 +50201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -50650,7 +50232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -50696,7 +50278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50725,7 +50307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50775,7 +50357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50815,7 +50397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50842,7 +50424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50880,7 +50462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50912,7 +50494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -51065,7 +50647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51218,7 +50800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -51371,7 +50953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -51524,7 +51106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -51677,7 +51259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -51830,7 +51412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -51983,7 +51565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -52135,7 +51717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -52287,7 +51869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -52440,7 +52022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -52593,7 +52175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -52746,7 +52328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -52899,7 +52481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -53058,7 +52640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -53109,7 +52691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -53160,7 +52742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -53211,7 +52793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -53262,7 +52844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -53276,7 +52858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -53290,7 +52872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -53310,7 +52892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -53404,7 +52986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -53418,7 +53000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -53432,7 +53014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -53995,7 +53577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -54015,7 +53597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -54029,7 +53611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -54057,7 +53639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -54257,7 +53839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -56146,6 +55728,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV71N21.svd
+++ b/data/Atmel/ATSAMV71N21.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -428,7 +428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -495,7 +495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -795,7 +795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -822,7 +822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -849,7 +849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -876,7 +876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -944,7 +944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -961,7 +961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -978,7 +978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -995,7 +995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -1010,7 +1010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -1024,7 +1024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -1040,7 +1040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -1056,7 +1056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -1071,7 +1071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -1088,7 +1088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -1102,7 +1102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -1142,7 +1142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1163,7 +1163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1423,7 +1423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1553,7 +1553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1609,7 +1609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1803,7 +1803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1884,7 +1884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1905,7 +1905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -2010,7 +2010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -2115,7 +2115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2220,7 +2220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2325,7 +2325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2406,7 +2406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2426,7 +2426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2506,7 +2506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2586,7 +2586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2600,7 +2600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2615,7 +2615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2629,7 +2629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2672,7 +2672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2692,7 +2692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2718,7 +2718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2798,7 +2798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2812,7 +2812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2832,7 +2832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2912,7 +2912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2940,7 +2940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2961,7 +2961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_VERSION</name>
+               <name>VERSION</name>
                <description>AFEC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -3005,7 +3005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3335,7 +3335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3692,7 +3692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -3796,7 +3796,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -3975,7 +3975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -3996,7 +3996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4010,7 +4010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4112,7 +4112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4162,7 +4162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4176,7 +4176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4190,7 +4190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4222,7 +4222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4369,7 +4369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -4534,7 +4534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -4699,7 +4699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -4863,7 +4863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -4913,7 +4913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -4928,7 +4928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -4942,7 +4942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -4962,7 +4962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -4982,7 +4982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -4996,7 +4996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5010,7 +5010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5031,7 +5031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5045,7 +5045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5060,7 +5060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5080,7 +5080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5100,7 +5100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5120,7 +5120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5140,7 +5140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5178,7 +5178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5192,7 +5192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5212,7 +5212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5232,7 +5232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5246,7 +5246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5260,7 +5260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5274,7 +5274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5288,7 +5288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5302,7 +5302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5317,7 +5317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5332,7 +5332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5347,7 +5347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5362,7 +5362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MID</name>
+               <name>MID</name>
                <description>Module ID Register</description>
                <addressOffset>0x0FC</addressOffset>
                <size>32</size>
@@ -5383,7 +5383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5398,7 +5398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5413,7 +5413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5428,7 +5428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5443,7 +5443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5458,7 +5458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5473,7 +5473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5488,7 +5488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5503,7 +5503,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -5518,7 +5518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -5533,7 +5533,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -5548,7 +5548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -5563,7 +5563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -5578,7 +5578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -5593,7 +5593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -5608,7 +5608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -5623,7 +5623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -5638,7 +5638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -5653,7 +5653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -5668,7 +5668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -5683,7 +5683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -5698,7 +5698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -5713,7 +5713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -5728,7 +5728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -5743,7 +5743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -5758,7 +5758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -5773,7 +5773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -5788,7 +5788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -5803,7 +5803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -5818,7 +5818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -5833,7 +5833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -5848,7 +5848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -5863,7 +5863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -5878,7 +5878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -5893,7 +5893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -5908,7 +5908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -5923,7 +5923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -5938,7 +5938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -5953,7 +5953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -5968,7 +5968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -5983,7 +5983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -5998,7 +5998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6013,7 +6013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6028,7 +6028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6043,7 +6043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6058,7 +6058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6072,7 +6072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6086,7 +6086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6100,7 +6100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6114,7 +6114,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6135,7 +6135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6161,7 +6161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6176,7 +6176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6191,7 +6191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6206,7 +6206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6221,7 +6221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6236,7 +6236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6251,7 +6251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6266,7 +6266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6283,7 +6283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -6336,7 +6336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -6352,7 +6352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -6368,7 +6368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -6382,7 +6382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6402,7 +6402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6416,7 +6416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6432,7 +6432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -6472,7 +6472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -6548,7 +6548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -6601,7 +6601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -6654,7 +6654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -6706,7 +6706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -6720,7 +6720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -6740,7 +6740,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -6783,7 +6783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -6803,7 +6803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -6846,7 +6846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -6866,7 +6866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -6909,7 +6909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -6929,7 +6929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -6972,7 +6972,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -6992,7 +6992,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7035,7 +7035,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7055,7 +7055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7098,7 +7098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7118,7 +7118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7161,7 +7161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7181,7 +7181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7224,7 +7224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7244,7 +7244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7287,7 +7287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7307,7 +7307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -7350,7 +7350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -7370,7 +7370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -7413,7 +7413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -7433,7 +7433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -7476,7 +7476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -7496,7 +7496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -7539,7 +7539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -7559,7 +7559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -7602,7 +7602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -7622,7 +7622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -7665,7 +7665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -7685,7 +7685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -7728,7 +7728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -7748,7 +7748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -7791,7 +7791,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -7811,7 +7811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -7854,7 +7854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -7874,7 +7874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -7917,7 +7917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -7980,7 +7980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8000,7 +8000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8043,7 +8043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8063,7 +8063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8106,7 +8106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8126,7 +8126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8169,7 +8169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8189,7 +8189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8282,7 +8282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8321,7 +8321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -8371,7 +8371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -8434,7 +8434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -8480,7 +8480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -8494,7 +8494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -8751,7 +8751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -8771,7 +8771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -8836,7 +8836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -8851,7 +8851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -8866,7 +8866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -8881,7 +8881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9034,7 +9034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9187,7 +9187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -9340,7 +9340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -9493,7 +9493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -9541,7 +9541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -9573,7 +9573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -9601,7 +9601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -9622,7 +9622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -9645,7 +9645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -9678,7 +9678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9764,7 +9764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9809,7 +9809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9836,7 +9836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9887,7 +9887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9938,7 +9938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9989,7 +9989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10040,7 +10040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10083,7 +10083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10097,7 +10097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10113,7 +10113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10147,7 +10147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10245,7 +10245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10353,7 +10353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10373,7 +10373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -10387,7 +10387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10419,7 +10419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10451,7 +10451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10483,7 +10483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10515,7 +10515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10547,7 +10547,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10580,7 +10580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10661,7 +10661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10724,7 +10724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10787,7 +10787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10850,7 +10850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10871,7 +10871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10892,7 +10892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10913,7 +10913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10927,7 +10927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10959,7 +10959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10973,7 +10973,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10987,7 +10987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11019,7 +11019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11033,7 +11033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11061,7 +11061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11082,7 +11082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -11120,7 +11120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11179,7 +11179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11229,7 +11229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11285,7 +11285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11318,7 +11318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11494,7 +11494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11522,7 +11522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x01FC</addressOffset>
                <size>32</size>
@@ -11587,7 +11587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11632,7 +11632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11647,7 +11647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11661,7 +11661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11718,7 +11718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11786,7 +11786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11806,7 +11806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12019,7 +12019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12051,7 +12051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12089,7 +12089,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12103,7 +12103,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12165,7 +12165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12179,7 +12179,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12212,7 +12212,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -12341,7 +12341,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12541,7 +12541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12741,7 +12741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12941,7 +12941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12961,7 +12961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13045,7 +13045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13065,7 +13065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13085,7 +13085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13099,7 +13099,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13155,7 +13155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -13355,7 +13355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13555,7 +13555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13587,7 +13587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13626,7 +13626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13640,7 +13640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13654,7 +13654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13686,7 +13686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13754,7 +13754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13768,7 +13768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13923,7 +13923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13955,7 +13955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13988,7 +13988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14045,7 +14045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14246,7 +14246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14446,7 +14446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14646,7 +14646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14847,7 +14847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15048,7 +15048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15248,7 +15248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15448,7 +15448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15474,7 +15474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15513,7 +15513,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15558,7 +15558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -15664,7 +15664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -15678,7 +15678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -15692,7 +15692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -15736,7 +15736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -15769,7 +15769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -15867,7 +15867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -15893,7 +15893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -15921,7 +15921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -15937,7 +15937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -15954,7 +15954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -15971,7 +15971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -15987,7 +15987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -16001,7 +16001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -16015,7 +16015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -16054,7 +16054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -16101,7 +16101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -16117,7 +16117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -16150,7 +16150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -16351,7 +16351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16552,7 +16552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16753,7 +16753,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16954,7 +16954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17155,7 +17155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -17356,7 +17356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17557,7 +17557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17758,7 +17758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17959,7 +17959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18160,7 +18160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -18361,7 +18361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18561,7 +18561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18762,7 +18762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18963,7 +18963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -19164,7 +19164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -19365,7 +19365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19566,7 +19566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19767,7 +19767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19968,7 +19968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -20169,7 +20169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -20370,7 +20370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20571,7 +20571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20774,7 +20774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20974,7 +20974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -21175,7 +21175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -21376,7 +21376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21577,7 +21577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21591,7 +21591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21792,7 +21792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21993,7 +21993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -22194,7 +22194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -22395,7 +22395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22596,7 +22596,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22797,7 +22797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22998,7 +22998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -23199,7 +23199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -23400,7 +23400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23601,7 +23601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23802,7 +23802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -24003,7 +24003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -24204,7 +24204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -24405,7 +24405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24606,7 +24606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24807,7 +24807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24835,7 +24835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24856,7 +24856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -24877,7 +24877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25077,7 +25077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25693,7 +25693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25749,7 +25749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25782,7 +25782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25815,7 +25815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25848,7 +25848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25869,7 +25869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25919,7 +25919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25976,7 +25976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -26033,7 +26033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -26096,7 +26096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -26255,7 +26255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -26414,7 +26414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26764,7 +26764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26885,7 +26885,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26907,7 +26907,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26955,7 +26955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -27054,7 +27054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -27153,7 +27153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -27270,7 +27270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -27369,7 +27369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27527,7 +27527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27631,7 +27631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27646,7 +27646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27674,7 +27674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27695,7 +27695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -27716,7 +27716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27875,7 +27875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -28034,7 +28034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -28193,7 +28193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -28265,7 +28265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -28309,7 +28309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28468,7 +28468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28627,7 +28627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28786,7 +28786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28945,7 +28945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28959,7 +28959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -29118,7 +29118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -29277,7 +29277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29436,7 +29436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29595,7 +29595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29610,7 +29610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -29636,7 +29636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -29683,7 +29683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29857,7 +29857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29890,7 +29890,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29923,7 +29923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29956,7 +29956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30013,7 +30013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30070,7 +30070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30127,7 +30127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30184,7 +30184,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30252,7 +30252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30267,7 +30267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30281,7 +30281,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30301,7 +30301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -30316,7 +30316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -30433,7 +30433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30550,7 +30550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30667,7 +30667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30784,7 +30784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30840,7 +30840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30896,7 +30896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30953,7 +30953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31010,7 +31010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -31067,7 +31067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -31124,7 +31124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -31150,7 +31150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -31171,7 +31171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -31186,7 +31186,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -31242,7 +31242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -31276,7 +31276,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -31332,7 +31332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -31352,7 +31352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -31367,7 +31367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -31399,7 +31399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -31455,7 +31455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31538,7 +31538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31631,7 +31631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -31658,7 +31658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31678,7 +31678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31699,7 +31699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31743,7 +31743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31783,7 +31783,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31925,7 +31925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31939,7 +31939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31954,7 +31954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31968,7 +31968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31983,7 +31983,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31998,7 +31998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32018,7 +32018,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32040,7 +32040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -32061,7 +32061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -32082,7 +32082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -32162,7 +32162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -32200,7 +32200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -32221,7 +32221,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -32301,7 +32301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -32339,7 +32339,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -32387,7 +32387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32420,7 +32420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32540,7 +32540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32555,7 +32555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32570,7 +32570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32627,7 +32627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32678,7 +32678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32729,7 +32729,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32780,7 +32780,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32812,7 +32812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32826,7 +32826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32846,7 +32846,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33024,7 +33024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33057,7 +33057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33072,7 +33072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33100,7 +33100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33121,7 +33121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -33161,7 +33161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33196,7 +33196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33257,7 +33257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33316,7 +33316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33345,7 +33345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33395,7 +33395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33429,7 +33429,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33502,7 +33502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33716,7 +33716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33748,7 +33748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33786,7 +33786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33836,7 +33836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33868,7 +33868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33991,7 +33991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34036,7 +34036,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34081,7 +34081,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34126,7 +34126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34171,7 +34171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34204,7 +34204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34244,7 +34244,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34288,7 +34288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34302,7 +34302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34317,7 +34317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34357,7 +34357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34420,7 +34420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34476,7 +34476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34497,7 +34497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34524,7 +34524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34581,7 +34581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34632,7 +34632,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34683,7 +34683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34736,7 +34736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34840,7 +34840,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34868,7 +34868,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34889,7 +34889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34929,7 +34929,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34968,7 +34968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34982,7 +34982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35140,7 +35140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35242,7 +35242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35389,7 +35389,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35497,7 +35497,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35512,7 +35512,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35527,7 +35527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35542,7 +35542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35556,7 +35556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35570,7 +35570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35584,7 +35584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35653,7 +35653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35710,7 +35710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35767,7 +35767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35824,7 +35824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35852,7 +35852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35873,7 +35873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35913,7 +35913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35974,7 +35974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36060,7 +36060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36164,7 +36164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36374,7 +36374,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36914,7 +36914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37414,7 +37414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37441,7 +37441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37684,7 +37684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37704,7 +37704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37719,7 +37719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37734,7 +37734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37748,7 +37748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37762,7 +37762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37776,7 +37776,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37851,7 +37851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37908,7 +37908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37965,7 +37965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38022,7 +38022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38075,7 +38075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38090,7 +38090,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38236,7 +38236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38263,7 +38263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38290,7 +38290,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38317,7 +38317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38350,7 +38350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38370,7 +38370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38398,7 +38398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -38486,7 +38486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38515,7 +38515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38530,7 +38530,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38545,7 +38545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38560,7 +38560,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38575,7 +38575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38590,7 +38590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -38630,7 +38630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38771,7 +38771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38820,7 +38820,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38888,7 +38888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38902,7 +38902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38934,7 +38934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39057,7 +39057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39162,7 +39162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39267,7 +39267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39372,7 +39372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39387,7 +39387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39402,7 +39402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39434,7 +39434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39466,7 +39466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39498,7 +39498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_DR</name>
+               <name>DR</name>
                <description>Debug Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39531,7 +39531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39559,7 +39559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39580,7 +39580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -39636,7 +39636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39699,7 +39699,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39808,7 +39808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39859,7 +39859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39910,7 +39910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39961,7 +39961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40030,7 +40030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40045,7 +40045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40060,7 +40060,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40074,7 +40074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40119,7 +40119,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40147,7 +40147,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -41744,7 +41744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41835,7 +41835,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41988,7 +41988,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -42039,7 +42039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -42132,7 +42132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -42285,7 +42285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -42438,7 +42438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -42591,7 +42591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -42719,7 +42719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -42748,7 +42748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -42920,7 +42920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -43085,7 +43085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -43144,7 +43144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -43209,7 +43209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -43310,7 +43310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -43411,7 +43411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -43504,7 +43504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -43518,7 +43518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -43532,7 +43532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -43594,7 +43594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -43639,7 +43639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -43694,7 +43694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -43847,7 +43847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -43898,7 +43898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -43991,7 +43991,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -44144,7 +44144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -44297,7 +44297,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -44450,7 +44450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -44566,7 +44566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -44592,7 +44592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -44624,7 +44624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -44656,7 +44656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -44678,7 +44678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -44838,7 +44838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -44987,7 +44987,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -45040,7 +45040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -45105,7 +45105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -45194,7 +45194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -45277,7 +45277,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -45360,7 +45360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -45382,7 +45382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -45432,7 +45432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45446,7 +45446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45460,7 +45460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45522,7 +45522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45567,7 +45567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -45624,7 +45624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -45669,7 +45669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -45684,7 +45684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -45705,7 +45705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA1</name>
+               <name>TSTA1</name>
                <description>General Test A1 Register</description>
                <addressOffset>0x0810</addressOffset>
                <size>32</size>
@@ -45749,7 +45749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA2</name>
+               <name>TSTA2</name>
                <description>General Test A2 Register</description>
                <addressOffset>0x0814</addressOffset>
                <size>32</size>
@@ -45811,7 +45811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_VERSION</name>
+               <name>VERSION</name>
                <description>General Version Register</description>
                <addressOffset>0x0818</addressOffset>
                <size>32</size>
@@ -45832,7 +45832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_FSM</name>
+               <name>FSM</name>
                <description>General Finite State Machine Register</description>
                <addressOffset>0x082C</addressOffset>
                <size>32</size>
@@ -45945,7 +45945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -45976,7 +45976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -46022,7 +46022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46051,7 +46051,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46101,7 +46101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46141,7 +46141,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -46168,7 +46168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -46206,7 +46206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -46238,7 +46238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -46391,7 +46391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -46544,7 +46544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -46697,7 +46697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -46850,7 +46850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -47003,7 +47003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -47156,7 +47156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -47309,7 +47309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -47461,7 +47461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -47613,7 +47613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47766,7 +47766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -47919,7 +47919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -48072,7 +48072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -48225,7 +48225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -48384,7 +48384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -48435,7 +48435,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -48486,7 +48486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -48537,7 +48537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -48588,7 +48588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -48602,7 +48602,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -48616,7 +48616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -48636,7 +48636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -48730,7 +48730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -48744,7 +48744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -48758,7 +48758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -49088,7 +49088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -49108,7 +49108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -49122,7 +49122,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -49137,7 +49137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>XDMAC_VERSION</name>
+               <name>VERSION</name>
                <description>XDMAC Version Register</description>
                <addressOffset>0xFFC</addressOffset>
                <size>32</size>
@@ -49170,7 +49170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -49370,7 +49370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -49570,7 +49570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -49770,7 +49770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV71N21B.svd
+++ b/data/Atmel/ATSAMV71N21B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9279,7 +9279,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9353,7 +9353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9398,7 +9398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9425,7 +9425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9476,7 +9476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9527,7 +9527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9578,7 +9578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9629,7 +9629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9672,7 +9672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9686,7 +9686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9702,7 +9702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9736,7 +9736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9834,7 +9834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9942,7 +9942,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9962,7 +9962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9976,7 +9976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10008,7 +10008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10040,7 +10040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10072,7 +10072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10104,7 +10104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10136,7 +10136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10169,7 +10169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10250,7 +10250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10313,7 +10313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10376,7 +10376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10439,7 +10439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10460,7 +10460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10502,7 +10502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10516,7 +10516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10548,7 +10548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10562,7 +10562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10576,7 +10576,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10608,7 +10608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10622,7 +10622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10650,7 +10650,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10688,7 +10688,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10747,7 +10747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10797,7 +10797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10853,7 +10853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10892,7 +10892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11126,7 +11126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11154,7 +11154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11198,7 +11198,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11243,7 +11243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11258,7 +11258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11272,7 +11272,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11323,7 +11323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11385,7 +11385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11405,7 +11405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11614,7 +11614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11646,7 +11646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11684,7 +11684,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11698,7 +11698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11760,7 +11760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11774,7 +11774,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11807,7 +11807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11948,7 +11948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11968,7 +11968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12144,7 +12144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12320,7 +12320,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12496,7 +12496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12516,7 +12516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12600,7 +12600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12620,7 +12620,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12640,7 +12640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12654,7 +12654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12710,7 +12710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12910,7 +12910,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13110,7 +13110,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13142,7 +13142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13181,7 +13181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13195,7 +13195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13209,7 +13209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13241,7 +13241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13309,7 +13309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13323,7 +13323,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13478,7 +13478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13510,7 +13510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13543,7 +13543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13600,7 +13600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13801,7 +13801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14001,7 +14001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14201,7 +14201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14402,7 +14402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14603,7 +14603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14803,7 +14803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15003,7 +15003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15029,7 +15029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15068,7 +15068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15113,7 +15113,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -15219,7 +15219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -15233,7 +15233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -15247,7 +15247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -15291,7 +15291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -15324,7 +15324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -15422,7 +15422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -15448,7 +15448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -15476,7 +15476,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -15492,7 +15492,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -15509,7 +15509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -15526,7 +15526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -15542,7 +15542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15556,7 +15556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -15570,7 +15570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -15609,7 +15609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -15656,7 +15656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -15672,7 +15672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -15705,7 +15705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15906,7 +15906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16107,7 +16107,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16308,7 +16308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16509,7 +16509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16710,7 +16710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16911,7 +16911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17112,7 +17112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17313,7 +17313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17514,7 +17514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17715,7 +17715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17916,7 +17916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18116,7 +18116,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18317,7 +18317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18518,7 +18518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18719,7 +18719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18920,7 +18920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19121,7 +19121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19322,7 +19322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19523,7 +19523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19724,7 +19724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19925,7 +19925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20126,7 +20126,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20329,7 +20329,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20529,7 +20529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20730,7 +20730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20931,7 +20931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21132,7 +21132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21146,7 +21146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21347,7 +21347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21548,7 +21548,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21749,7 +21749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21950,7 +21950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22151,7 +22151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22352,7 +22352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22553,7 +22553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22754,7 +22754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22955,7 +22955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23156,7 +23156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23357,7 +23357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23558,7 +23558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23759,7 +23759,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23960,7 +23960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24161,7 +24161,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24362,7 +24362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24390,7 +24390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24411,7 +24411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24611,7 +24611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25227,7 +25227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25283,7 +25283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25316,7 +25316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25349,7 +25349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25382,7 +25382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25403,7 +25403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25453,7 +25453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25516,7 +25516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25579,7 +25579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25648,7 +25648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25789,7 +25789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25930,7 +25930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26262,7 +26262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26383,7 +26383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26405,7 +26405,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26453,7 +26453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26558,7 +26558,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26663,7 +26663,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26786,7 +26786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26891,7 +26891,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27049,7 +27049,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27153,7 +27153,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27168,7 +27168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27196,7 +27196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27217,7 +27217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27370,7 +27370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27523,7 +27523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27676,7 +27676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27748,7 +27748,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27792,7 +27792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -27933,7 +27933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28074,7 +28074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28215,7 +28215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28356,7 +28356,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28370,7 +28370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28523,7 +28523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28676,7 +28676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -28829,7 +28829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -28982,7 +28982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29016,7 +29016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29190,7 +29190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29223,7 +29223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29256,7 +29256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29289,7 +29289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29346,7 +29346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29403,7 +29403,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29460,7 +29460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29517,7 +29517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29585,7 +29585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29600,7 +29600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29614,7 +29614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29634,7 +29634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29649,7 +29649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29766,7 +29766,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -29883,7 +29883,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30000,7 +30000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30117,7 +30117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30173,7 +30173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30229,7 +30229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30286,7 +30286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30343,7 +30343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30400,7 +30400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30457,7 +30457,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30483,7 +30483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30504,7 +30504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30519,7 +30519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30575,7 +30575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30609,7 +30609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30665,7 +30665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30685,7 +30685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30700,7 +30700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30732,7 +30732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30788,7 +30788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -30871,7 +30871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -30970,7 +30970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31003,7 +31003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31024,7 +31024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31068,7 +31068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31108,7 +31108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31302,7 +31302,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31316,7 +31316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31331,7 +31331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31345,7 +31345,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31360,7 +31360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31375,7 +31375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31395,7 +31395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31417,7 +31417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31438,7 +31438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31459,7 +31459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31539,7 +31539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31577,7 +31577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31598,7 +31598,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31678,7 +31678,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31716,7 +31716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31764,7 +31764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31797,7 +31797,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -31917,7 +31917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -31932,7 +31932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -31947,7 +31947,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32004,7 +32004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32055,7 +32055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32106,7 +32106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32157,7 +32157,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32189,7 +32189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32203,7 +32203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32223,7 +32223,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32401,7 +32401,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32434,7 +32434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32449,7 +32449,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32477,7 +32477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32517,7 +32517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32552,7 +32552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32613,7 +32613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32672,7 +32672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32701,7 +32701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32751,7 +32751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32785,7 +32785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32858,7 +32858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33072,7 +33072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33104,7 +33104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33142,7 +33142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33192,7 +33192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33224,7 +33224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33347,7 +33347,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33392,7 +33392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33437,7 +33437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33482,7 +33482,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33527,7 +33527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33579,7 +33579,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33623,7 +33623,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33637,7 +33637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33652,7 +33652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33692,7 +33692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33731,7 +33731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33823,7 +33823,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33844,7 +33844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33894,7 +33894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33951,7 +33951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34002,7 +34002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34053,7 +34053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34106,7 +34106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34139,12 +34139,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -34236,7 +34236,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34264,7 +34264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34304,7 +34304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -34343,7 +34343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -34357,7 +34357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34515,7 +34515,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34617,7 +34617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34764,7 +34764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34872,7 +34872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34887,7 +34887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34902,7 +34902,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34917,7 +34917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34931,7 +34931,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -34945,7 +34945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -34959,7 +34959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -35028,7 +35028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -35085,7 +35085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -35142,7 +35142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -35199,7 +35199,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35227,7 +35227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35258,7 +35258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -35267,7 +35267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35328,7 +35328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35414,7 +35414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35518,7 +35518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35728,7 +35728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36268,7 +36268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36713,6 +36713,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -36747,7 +36775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -36774,7 +36802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -37017,9 +37045,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -37453,7 +37481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -37473,7 +37501,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -37488,7 +37516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -37503,7 +37531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -37517,7 +37545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -37531,7 +37559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -37545,7 +37573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -37620,7 +37648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -37677,7 +37705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -37734,7 +37762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -37791,7 +37819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -37844,7 +37872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -37859,7 +37887,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -38017,7 +38045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -38050,7 +38078,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -38083,7 +38111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -38116,7 +38144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -38155,7 +38183,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -38175,7 +38203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -38270,7 +38298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38299,7 +38327,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38314,7 +38342,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38329,7 +38357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -38344,7 +38372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -38359,7 +38387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -38393,7 +38421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -38534,7 +38562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -38583,7 +38611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -38651,7 +38679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -38665,7 +38693,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38697,7 +38725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -38820,7 +38848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -38925,7 +38953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -39030,7 +39058,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -39135,7 +39163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -39150,7 +39178,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -39165,7 +39193,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -39197,7 +39225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -39229,7 +39257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -39261,7 +39289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39289,7 +39317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -39345,7 +39373,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -39402,7 +39430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -39511,7 +39539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -39562,7 +39590,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -39613,7 +39641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -39664,7 +39692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -39715,7 +39743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -39730,7 +39758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -39745,7 +39773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -39759,7 +39787,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -39804,7 +39832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -40630,6 +40658,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -40680,7 +40726,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -40721,80 +40813,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40892,12 +40910,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -40907,6 +40919,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -40942,46 +40966,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -41010,6 +40994,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41063,7 +41065,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -41110,134 +41158,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41329,30 +41249,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -41362,6 +41258,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41397,64 +41305,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -41483,6 +41333,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41536,7 +41404,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -41583,134 +41497,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41802,30 +41588,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -41835,6 +41597,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41870,64 +41644,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -41956,6 +41672,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42033,7 +41767,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -42080,140 +41866,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42311,30 +41963,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -42344,6 +41972,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42374,64 +42014,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -43122,7 +42704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -43213,7 +42795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -43366,7 +42948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -43417,7 +42999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -43510,7 +43092,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -43663,7 +43245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -43816,7 +43398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -43969,7 +43551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -44097,7 +43679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -44126,7 +43708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -44298,7 +43880,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -44463,9 +44045,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44629,9 +44211,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44795,9 +44377,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -44961,7 +44543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -45020,9 +44602,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45080,9 +44662,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45140,9 +44722,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45200,7 +44782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -45265,9 +44847,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45331,9 +44913,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45397,9 +44979,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -45463,7 +45045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -45564,9 +45146,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45672,9 +45254,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45774,9 +45356,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45876,7 +45458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -45977,9 +45559,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46085,9 +45667,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46187,9 +45769,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46289,7 +45871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -46378,9 +45960,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46468,9 +46050,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46558,9 +46140,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46652,7 +46234,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -46666,7 +46248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -46680,7 +46262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -46742,7 +46324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -46787,7 +46369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -46842,7 +46424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -46951,43 +46533,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -46995,7 +46577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -47046,7 +46628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -47095,43 +46677,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47139,7 +46721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -47248,43 +46830,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47292,7 +46874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -47401,43 +46983,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47445,7 +47027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -47554,43 +47136,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -47598,7 +47180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -47714,7 +47296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -47740,7 +47322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -47772,7 +47354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -47804,7 +47386,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -47826,7 +47408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -47986,9 +47568,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -48153,7 +47735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -48302,9 +47884,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48452,9 +48034,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48602,9 +48184,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -48752,7 +48334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -48805,9 +48387,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48859,9 +48441,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48913,9 +48495,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -48967,7 +48549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -49032,9 +48614,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49098,9 +48680,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49164,9 +48746,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49230,7 +48812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -49319,9 +48901,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49409,9 +48991,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49499,9 +49081,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49589,7 +49171,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -49672,9 +49254,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49756,9 +49338,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49840,9 +49422,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49924,7 +49506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -50007,9 +49589,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50091,9 +49673,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50175,9 +49757,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50259,7 +49841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -50281,7 +49863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -50331,7 +49913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -50345,7 +49927,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50359,7 +49941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50421,7 +50003,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50466,7 +50048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -50523,7 +50105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -50568,7 +50150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -50583,7 +50165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -50619,7 +50201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -50650,7 +50232,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -50696,7 +50278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50725,7 +50307,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50775,7 +50357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50815,7 +50397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -50842,7 +50424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -50880,7 +50462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -50912,7 +50494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -51065,7 +50647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51218,7 +50800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -51371,7 +50953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -51524,7 +51106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -51677,7 +51259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -51830,7 +51412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -51983,7 +51565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -52135,7 +51717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -52287,7 +51869,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -52440,7 +52022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -52593,7 +52175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -52746,7 +52328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -52899,7 +52481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -53058,7 +52640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -53109,7 +52691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -53160,7 +52742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -53211,7 +52793,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -53262,7 +52844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -53276,7 +52858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -53290,7 +52872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -53310,7 +52892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -53404,7 +52986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -53418,7 +53000,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -53432,7 +53014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -53995,7 +53577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -54015,7 +53597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -54029,7 +53611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -54057,7 +53639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -54257,7 +53839,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -54457,7 +54039,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -54657,7 +54239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>
@@ -56546,6 +56128,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV71Q19.svd
+++ b/data/Atmel/ATSAMV71Q19.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -428,7 +428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -495,7 +495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -795,7 +795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -822,7 +822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -849,7 +849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -876,7 +876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -944,7 +944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -961,7 +961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -978,7 +978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -995,7 +995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -1010,7 +1010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -1024,7 +1024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -1040,7 +1040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -1056,7 +1056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -1071,7 +1071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -1088,7 +1088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -1102,7 +1102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -1142,7 +1142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1163,7 +1163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1423,7 +1423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1553,7 +1553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1609,7 +1609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1803,7 +1803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1884,7 +1884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1905,7 +1905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -2010,7 +2010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -2115,7 +2115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2220,7 +2220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2325,7 +2325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2406,7 +2406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2426,7 +2426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2506,7 +2506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2586,7 +2586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2600,7 +2600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2615,7 +2615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2629,7 +2629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2672,7 +2672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2692,7 +2692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2718,7 +2718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2798,7 +2798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2812,7 +2812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2832,7 +2832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2912,7 +2912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2940,7 +2940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2961,7 +2961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_VERSION</name>
+               <name>VERSION</name>
                <description>AFEC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -3005,7 +3005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3335,7 +3335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3369,7 +3369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3384,7 +3384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3480,7 +3480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3702,7 +3702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3723,7 +3723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3744,7 +3744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3779,7 +3779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3800,7 +3800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3833,7 +3833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3866,7 +3866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3899,7 +3899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3932,7 +3932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3952,7 +3952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3980,7 +3980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4001,7 +4001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -4364,7 +4364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4468,7 +4468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4647,7 +4647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4784,7 +4784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4834,7 +4834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4848,7 +4848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4862,7 +4862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4894,7 +4894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -5041,7 +5041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5206,7 +5206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5371,7 +5371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5585,7 +5585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5600,7 +5600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5614,7 +5614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5634,7 +5634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5654,7 +5654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5668,7 +5668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5703,7 +5703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5717,7 +5717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5732,7 +5732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5752,7 +5752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5772,7 +5772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5812,7 +5812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5850,7 +5850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5864,7 +5864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5884,7 +5884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5904,7 +5904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5918,7 +5918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5932,7 +5932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5946,7 +5946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5974,7 +5974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5989,7 +5989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -6004,7 +6004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -6019,7 +6019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -6034,7 +6034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MID</name>
+               <name>MID</name>
                <description>Module ID Register</description>
                <addressOffset>0x0FC</addressOffset>
                <size>32</size>
@@ -6055,7 +6055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -6070,7 +6070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -6085,7 +6085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -6100,7 +6100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -6115,7 +6115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -6130,7 +6130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -6145,7 +6145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -6160,7 +6160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -6175,7 +6175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6190,7 +6190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6205,7 +6205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6250,7 +6250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6265,7 +6265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6280,7 +6280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6295,7 +6295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6310,7 +6310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6325,7 +6325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6340,7 +6340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6355,7 +6355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6370,7 +6370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6385,7 +6385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6400,7 +6400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6415,7 +6415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6430,7 +6430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6445,7 +6445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6460,7 +6460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6475,7 +6475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6490,7 +6490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6520,7 +6520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6535,7 +6535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6550,7 +6550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6565,7 +6565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6580,7 +6580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6595,7 +6595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6610,7 +6610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6625,7 +6625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6640,7 +6640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6655,7 +6655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6670,7 +6670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6685,7 +6685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6700,7 +6700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6715,7 +6715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6730,7 +6730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6744,7 +6744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6758,7 +6758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6772,7 +6772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6786,7 +6786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6833,7 +6833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6863,7 +6863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6878,7 +6878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6893,7 +6893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6938,7 +6938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6955,7 +6955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -7008,7 +7008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -7024,7 +7024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -7040,7 +7040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -7054,7 +7054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -7074,7 +7074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -7088,7 +7088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -7104,7 +7104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7220,7 +7220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7273,7 +7273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7326,7 +7326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7378,7 +7378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7392,7 +7392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7412,7 +7412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7455,7 +7455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7475,7 +7475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7518,7 +7518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7538,7 +7538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7601,7 +7601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7644,7 +7644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7664,7 +7664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7707,7 +7707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7727,7 +7727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7770,7 +7770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7833,7 +7833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7853,7 +7853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7916,7 +7916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7959,7 +7959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7979,7 +7979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -8022,7 +8022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -8042,7 +8042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -8085,7 +8085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -8105,7 +8105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -8148,7 +8148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -8168,7 +8168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -8211,7 +8211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -8231,7 +8231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8274,7 +8274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8294,7 +8294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8337,7 +8337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8357,7 +8357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8400,7 +8400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8420,7 +8420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8463,7 +8463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8483,7 +8483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8526,7 +8526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8546,7 +8546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8589,7 +8589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8609,7 +8609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8672,7 +8672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8715,7 +8715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8735,7 +8735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8778,7 +8778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8798,7 +8798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8841,7 +8841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8861,7 +8861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8954,7 +8954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8993,7 +8993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9043,7 +9043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9106,7 +9106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9152,7 +9152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9166,7 +9166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9423,7 +9423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9508,7 +9508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9523,7 +9523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9538,7 +9538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9553,7 +9553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9706,7 +9706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9859,7 +9859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10012,7 +10012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10165,7 +10165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10213,7 +10213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10245,7 +10245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10273,7 +10273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10294,7 +10294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -10317,7 +10317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10350,7 +10350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10436,7 +10436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10508,7 +10508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10559,7 +10559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10610,7 +10610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10661,7 +10661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10712,7 +10712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10769,7 +10769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10785,7 +10785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10819,7 +10819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10917,7 +10917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11025,7 +11025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11045,7 +11045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11059,7 +11059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11091,7 +11091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11123,7 +11123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11155,7 +11155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11187,7 +11187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11219,7 +11219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11252,7 +11252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11333,7 +11333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11396,7 +11396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11459,7 +11459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11522,7 +11522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11585,7 +11585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11599,7 +11599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11631,7 +11631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11645,7 +11645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11659,7 +11659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11691,7 +11691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11705,7 +11705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11733,7 +11733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11754,7 +11754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -11792,7 +11792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11851,7 +11851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11901,7 +11901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11957,7 +11957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11990,7 +11990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -12166,7 +12166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -12194,7 +12194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -12215,7 +12215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x01FC</addressOffset>
                <size>32</size>
@@ -12259,7 +12259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -12304,7 +12304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -12319,7 +12319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -12333,7 +12333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -12390,7 +12390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12458,7 +12458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12478,7 +12478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12691,7 +12691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12723,7 +12723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12761,7 +12761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12775,7 +12775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12837,7 +12837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12851,7 +12851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12884,7 +12884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -13013,7 +13013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -13213,7 +13213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -13413,7 +13413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13613,7 +13613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13633,7 +13633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13717,7 +13717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13737,7 +13737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13757,7 +13757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13771,7 +13771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13827,7 +13827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -14027,7 +14027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -14227,7 +14227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -14259,7 +14259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -14298,7 +14298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -14312,7 +14312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -14326,7 +14326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -14358,7 +14358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -14426,7 +14426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -14440,7 +14440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14595,7 +14595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14627,7 +14627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14660,7 +14660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14717,7 +14717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14918,7 +14918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15118,7 +15118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -15318,7 +15318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15519,7 +15519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15720,7 +15720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15920,7 +15920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -16120,7 +16120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -16146,7 +16146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -16185,7 +16185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -16230,7 +16230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -16336,7 +16336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -16350,7 +16350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -16364,7 +16364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -16408,7 +16408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -16441,7 +16441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -16539,7 +16539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -16565,7 +16565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -16593,7 +16593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -16609,7 +16609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -16626,7 +16626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -16643,7 +16643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -16659,7 +16659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -16673,7 +16673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -16687,7 +16687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -16726,7 +16726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -16773,7 +16773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -16789,7 +16789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -16822,7 +16822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17023,7 +17023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17224,7 +17224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17425,7 +17425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17626,7 +17626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17827,7 +17827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18028,7 +18028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -18229,7 +18229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -18430,7 +18430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -18631,7 +18631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18832,7 +18832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -19033,7 +19033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -19233,7 +19233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -19434,7 +19434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -19635,7 +19635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -19836,7 +19836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -20037,7 +20037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -20238,7 +20238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -20439,7 +20439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -20640,7 +20640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -20841,7 +20841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -21042,7 +21042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -21243,7 +21243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -21446,7 +21446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -21646,7 +21646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -21847,7 +21847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -22048,7 +22048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -22249,7 +22249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -22263,7 +22263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -22464,7 +22464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -22665,7 +22665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -22866,7 +22866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -23268,7 +23268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -23469,7 +23469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -23670,7 +23670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -23871,7 +23871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -24072,7 +24072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -24273,7 +24273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -24474,7 +24474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -24675,7 +24675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -24876,7 +24876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -25077,7 +25077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -25278,7 +25278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -25479,7 +25479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25507,7 +25507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25528,7 +25528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -25549,7 +25549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25749,7 +25749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -26421,7 +26421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -26454,7 +26454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -26487,7 +26487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -26520,7 +26520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -26541,7 +26541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -26607,7 +26607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -26664,7 +26664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -26721,7 +26721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -26784,7 +26784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -26943,7 +26943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -27102,7 +27102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -27452,7 +27452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -27573,7 +27573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -27595,7 +27595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27643,7 +27643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -27742,7 +27742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -27841,7 +27841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -27958,7 +27958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -28057,7 +28057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -28215,7 +28215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -28319,7 +28319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -28334,7 +28334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -28362,7 +28362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -28383,7 +28383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -28404,7 +28404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -28563,7 +28563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -28722,7 +28722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -28881,7 +28881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -28953,7 +28953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -28997,7 +28997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -29156,7 +29156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -29315,7 +29315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -29474,7 +29474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -29633,7 +29633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -29647,7 +29647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -29806,7 +29806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -29965,7 +29965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -30124,7 +30124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -30283,7 +30283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -30298,7 +30298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -30324,7 +30324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -30371,7 +30371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30545,7 +30545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30578,7 +30578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30611,7 +30611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30644,7 +30644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30701,7 +30701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30758,7 +30758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30815,7 +30815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30872,7 +30872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30940,7 +30940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30955,7 +30955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30969,7 +30969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30989,7 +30989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31004,7 +31004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31121,7 +31121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31238,7 +31238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31355,7 +31355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31472,7 +31472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31528,7 +31528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31584,7 +31584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31641,7 +31641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31698,7 +31698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -31755,7 +31755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -31812,7 +31812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -31838,7 +31838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -31859,7 +31859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -31874,7 +31874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -31930,7 +31930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -31964,7 +31964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -32020,7 +32020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -32040,7 +32040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -32055,7 +32055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -32087,7 +32087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -32143,7 +32143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32226,7 +32226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32319,7 +32319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -32346,7 +32346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32366,7 +32366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32387,7 +32387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32431,7 +32431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32471,7 +32471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32613,7 +32613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32627,7 +32627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32642,7 +32642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32656,7 +32656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -32671,7 +32671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -32686,7 +32686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32706,7 +32706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32728,7 +32728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -32749,7 +32749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -32770,7 +32770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -32850,7 +32850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -32888,7 +32888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -32909,7 +32909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -32989,7 +32989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -33027,7 +33027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -33075,7 +33075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33108,7 +33108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33228,7 +33228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33243,7 +33243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33258,7 +33258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33315,7 +33315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33366,7 +33366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33417,7 +33417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33468,7 +33468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33500,7 +33500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33514,7 +33514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33534,7 +33534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33712,7 +33712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33745,7 +33745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33760,7 +33760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33788,7 +33788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33809,7 +33809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -33849,7 +33849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33884,7 +33884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33945,7 +33945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34004,7 +34004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34033,7 +34033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34083,7 +34083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34117,7 +34117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34190,7 +34190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34404,7 +34404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34436,7 +34436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34474,7 +34474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34524,7 +34524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34556,7 +34556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34679,7 +34679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34724,7 +34724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34769,7 +34769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34814,7 +34814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34859,7 +34859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34892,7 +34892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34932,7 +34932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34976,7 +34976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34990,7 +34990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35005,7 +35005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35045,7 +35045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35097,7 +35097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35111,7 +35111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35257,7 +35257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35336,7 +35336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35351,7 +35351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35366,7 +35366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35381,7 +35381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35396,7 +35396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35423,7 +35423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35456,7 +35456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35470,7 +35470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35485,7 +35485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35500,7 +35500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_VERSION</name>
+               <name>VERSION</name>
                <description>SDRAMC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35542,7 +35542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -35574,7 +35574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -35606,7 +35606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35626,7 +35626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35756,7 +35756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -35794,7 +35794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -35809,7 +35809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -35824,7 +35824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35852,7 +35852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35873,7 +35873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_VERSION</name>
+               <name>VERSION</name>
                <description>SMC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35913,7 +35913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35976,7 +35976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36032,7 +36032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36053,7 +36053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36080,7 +36080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36137,7 +36137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36188,7 +36188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36239,7 +36239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -36292,7 +36292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36396,7 +36396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36424,7 +36424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36445,7 +36445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -36493,7 +36493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -36532,7 +36532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -36546,7 +36546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36704,7 +36704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36806,7 +36806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36953,7 +36953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37061,7 +37061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -37076,7 +37076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -37091,7 +37091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -37106,7 +37106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -37120,7 +37120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -37134,7 +37134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -37148,7 +37148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -37217,7 +37217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -37274,7 +37274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -37331,7 +37331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -37388,7 +37388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37416,7 +37416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -37437,7 +37437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -37477,7 +37477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37538,7 +37538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37624,7 +37624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -37728,7 +37728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37938,7 +37938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38478,7 +38478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38978,7 +38978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39005,7 +39005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39248,7 +39248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39268,7 +39268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39283,7 +39283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -39298,7 +39298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -39312,7 +39312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -39326,7 +39326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -39340,7 +39340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -39415,7 +39415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -39472,7 +39472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -39529,7 +39529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -39586,7 +39586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -39639,7 +39639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -39654,7 +39654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -39800,7 +39800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -39827,7 +39827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -39854,7 +39854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39881,7 +39881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -39914,7 +39914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -39934,7 +39934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39962,7 +39962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -40050,7 +40050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40079,7 +40079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40094,7 +40094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -40109,7 +40109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -40124,7 +40124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -40139,7 +40139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -40154,7 +40154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -40194,7 +40194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40335,7 +40335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40384,7 +40384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40452,7 +40452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -40466,7 +40466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40498,7 +40498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -40621,7 +40621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -40726,7 +40726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -40831,7 +40831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -40936,7 +40936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40951,7 +40951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -40966,7 +40966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -40998,7 +40998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -41030,7 +41030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -41062,7 +41062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_DR</name>
+               <name>DR</name>
                <description>Debug Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -41095,7 +41095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -41123,7 +41123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -41144,7 +41144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -41200,7 +41200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41263,7 +41263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41372,7 +41372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -41423,7 +41423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -41474,7 +41474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -41525,7 +41525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41594,7 +41594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41609,7 +41609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -41624,7 +41624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -41638,7 +41638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -41683,7 +41683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41711,7 +41711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -43308,7 +43308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -43399,7 +43399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -43552,7 +43552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -43603,7 +43603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -43696,7 +43696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -43849,7 +43849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -44002,7 +44002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -44155,7 +44155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -44283,7 +44283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -44312,7 +44312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -44484,7 +44484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -44649,7 +44649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -44708,7 +44708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -44773,7 +44773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -44874,7 +44874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -44975,7 +44975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -45068,7 +45068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45082,7 +45082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45096,7 +45096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45158,7 +45158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45203,7 +45203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -45258,7 +45258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -45411,7 +45411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -45462,7 +45462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -45555,7 +45555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -45708,7 +45708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -45861,7 +45861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -46014,7 +46014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -46130,7 +46130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -46156,7 +46156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -46188,7 +46188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -46220,7 +46220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -46242,7 +46242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -46402,7 +46402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -46551,7 +46551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -46604,7 +46604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -46669,7 +46669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -46758,7 +46758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46841,7 +46841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -46924,7 +46924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -46946,7 +46946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -46996,7 +46996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47010,7 +47010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47024,7 +47024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47086,7 +47086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47131,7 +47131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47188,7 +47188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47233,7 +47233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47248,7 +47248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47269,7 +47269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA1</name>
+               <name>TSTA1</name>
                <description>General Test A1 Register</description>
                <addressOffset>0x0810</addressOffset>
                <size>32</size>
@@ -47313,7 +47313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA2</name>
+               <name>TSTA2</name>
                <description>General Test A2 Register</description>
                <addressOffset>0x0814</addressOffset>
                <size>32</size>
@@ -47375,7 +47375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_VERSION</name>
+               <name>VERSION</name>
                <description>General Version Register</description>
                <addressOffset>0x0818</addressOffset>
                <size>32</size>
@@ -47396,7 +47396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_FSM</name>
+               <name>FSM</name>
                <description>General Finite State Machine Register</description>
                <addressOffset>0x082C</addressOffset>
                <size>32</size>
@@ -47509,7 +47509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47540,7 +47540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47586,7 +47586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47615,7 +47615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47665,7 +47665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47705,7 +47705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47732,7 +47732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47770,7 +47770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47802,7 +47802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -47955,7 +47955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48108,7 +48108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -48261,7 +48261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48414,7 +48414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48567,7 +48567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -48720,7 +48720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -48873,7 +48873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -49025,7 +49025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -49177,7 +49177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49330,7 +49330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49483,7 +49483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49636,7 +49636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -49789,7 +49789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -49948,7 +49948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49999,7 +49999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50050,7 +50050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50101,7 +50101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50152,7 +50152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -50166,7 +50166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -50180,7 +50180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -50200,7 +50200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -50294,7 +50294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50308,7 +50308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50322,7 +50322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -50652,7 +50652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -50672,7 +50672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -50686,7 +50686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -50701,7 +50701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>XDMAC_VERSION</name>
+               <name>VERSION</name>
                <description>XDMAC Version Register</description>
                <addressOffset>0xFFC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV71Q19B.svd
+++ b/data/Atmel/ATSAMV71Q19B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9287,7 +9287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9361,7 +9361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9406,7 +9406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9433,7 +9433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9484,7 +9484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9535,7 +9535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9586,7 +9586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9637,7 +9637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9694,7 +9694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9710,7 +9710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9744,7 +9744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9842,7 +9842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9950,7 +9950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9970,7 +9970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9984,7 +9984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10016,7 +10016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10048,7 +10048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10080,7 +10080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10112,7 +10112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10144,7 +10144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10177,7 +10177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10258,7 +10258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10321,7 +10321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10384,7 +10384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10447,7 +10447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10468,7 +10468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10489,7 +10489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10510,7 +10510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10524,7 +10524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10556,7 +10556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10570,7 +10570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10584,7 +10584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10616,7 +10616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10630,7 +10630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10658,7 +10658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10696,7 +10696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10861,7 +10861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10900,7 +10900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11134,7 +11134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11162,7 +11162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11206,7 +11206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11251,7 +11251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11266,7 +11266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11280,7 +11280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11331,7 +11331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11393,7 +11393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11413,7 +11413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11622,7 +11622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11654,7 +11654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11692,7 +11692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11706,7 +11706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11768,7 +11768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11782,7 +11782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11815,7 +11815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11956,7 +11956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11976,7 +11976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12152,7 +12152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12328,7 +12328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12504,7 +12504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12524,7 +12524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12608,7 +12608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12628,7 +12628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12648,7 +12648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12662,7 +12662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12718,7 +12718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12918,7 +12918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13118,7 +13118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13150,7 +13150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13189,7 +13189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13203,7 +13203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13217,7 +13217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13249,7 +13249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13317,7 +13317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13331,7 +13331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13486,7 +13486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13518,7 +13518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13551,7 +13551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13608,7 +13608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13809,7 +13809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14009,7 +14009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14209,7 +14209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14410,7 +14410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14611,7 +14611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14811,7 +14811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15011,7 +15011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15037,7 +15037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15076,7 +15076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15121,7 +15121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -15227,7 +15227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -15241,7 +15241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -15255,7 +15255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -15299,7 +15299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -15332,7 +15332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -15430,7 +15430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -15456,7 +15456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -15484,7 +15484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -15500,7 +15500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -15517,7 +15517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -15534,7 +15534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -15550,7 +15550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15564,7 +15564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -15578,7 +15578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -15617,7 +15617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -15664,7 +15664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -15680,7 +15680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -15713,7 +15713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15914,7 +15914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16115,7 +16115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16316,7 +16316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16517,7 +16517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16718,7 +16718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16919,7 +16919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17120,7 +17120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17321,7 +17321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17522,7 +17522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17723,7 +17723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17924,7 +17924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18124,7 +18124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18325,7 +18325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18526,7 +18526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18727,7 +18727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18928,7 +18928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19129,7 +19129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19330,7 +19330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19531,7 +19531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19732,7 +19732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19933,7 +19933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20134,7 +20134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20337,7 +20337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20537,7 +20537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20738,7 +20738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20939,7 +20939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21140,7 +21140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21154,7 +21154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21355,7 +21355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21556,7 +21556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21757,7 +21757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21958,7 +21958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22159,7 +22159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22360,7 +22360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22561,7 +22561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22762,7 +22762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22963,7 +22963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23164,7 +23164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23365,7 +23365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23566,7 +23566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23767,7 +23767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24169,7 +24169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24370,7 +24370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24398,7 +24398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24419,7 +24419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24619,7 +24619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25235,7 +25235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25291,7 +25291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25324,7 +25324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25357,7 +25357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25390,7 +25390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25411,7 +25411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25477,7 +25477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25540,7 +25540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25603,7 +25603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25672,7 +25672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25831,7 +25831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25990,7 +25990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26340,7 +26340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26461,7 +26461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26483,7 +26483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26531,7 +26531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26636,7 +26636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26741,7 +26741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26864,7 +26864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26969,7 +26969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27127,7 +27127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27231,7 +27231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27246,7 +27246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27274,7 +27274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27295,7 +27295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27454,7 +27454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27613,7 +27613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27772,7 +27772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27844,7 +27844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27888,7 +27888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28047,7 +28047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28206,7 +28206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28365,7 +28365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28524,7 +28524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28538,7 +28538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28697,7 +28697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28856,7 +28856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29015,7 +29015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29174,7 +29174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29208,7 +29208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29382,7 +29382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29415,7 +29415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29448,7 +29448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29481,7 +29481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29538,7 +29538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29595,7 +29595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29652,7 +29652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29709,7 +29709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29777,7 +29777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29792,7 +29792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29806,7 +29806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29826,7 +29826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29841,7 +29841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29958,7 +29958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30075,7 +30075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30192,7 +30192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30309,7 +30309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30365,7 +30365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30421,7 +30421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30478,7 +30478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30535,7 +30535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30592,7 +30592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30649,7 +30649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30675,7 +30675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30696,7 +30696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30711,7 +30711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30767,7 +30767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30801,7 +30801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30857,7 +30857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30877,7 +30877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30892,7 +30892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30924,7 +30924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30980,7 +30980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31063,7 +31063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31162,7 +31162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31195,7 +31195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31216,7 +31216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31260,7 +31260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31300,7 +31300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31494,7 +31494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31508,7 +31508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31523,7 +31523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31537,7 +31537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31552,7 +31552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31567,7 +31567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31587,7 +31587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31609,7 +31609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31630,7 +31630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31651,7 +31651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31731,7 +31731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31769,7 +31769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31790,7 +31790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31870,7 +31870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31908,7 +31908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31956,7 +31956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31989,7 +31989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32109,7 +32109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32124,7 +32124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32139,7 +32139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32196,7 +32196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32247,7 +32247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32298,7 +32298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32349,7 +32349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32381,7 +32381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32395,7 +32395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32415,7 +32415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32593,7 +32593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32626,7 +32626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32641,7 +32641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32669,7 +32669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32709,7 +32709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32744,7 +32744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32805,7 +32805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32864,7 +32864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32893,7 +32893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32943,7 +32943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32977,7 +32977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33050,7 +33050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33264,7 +33264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33296,7 +33296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33334,7 +33334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33384,7 +33384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33416,7 +33416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33539,7 +33539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33584,7 +33584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33629,7 +33629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33674,7 +33674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33719,7 +33719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33771,7 +33771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33815,7 +33815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33829,7 +33829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33844,7 +33844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33884,7 +33884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33936,7 +33936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33950,7 +33950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34096,7 +34096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34175,7 +34175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34190,7 +34190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34205,7 +34205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34220,7 +34220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34235,7 +34235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34262,7 +34262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34295,7 +34295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34309,7 +34309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34324,7 +34324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34360,7 +34360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34392,7 +34392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34424,7 +34424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34444,7 +34444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34574,7 +34574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -34612,7 +34612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -34627,7 +34627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -34642,7 +34642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34670,7 +34670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34710,7 +34710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34749,7 +34749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34841,7 +34841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34862,7 +34862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34912,7 +34912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34969,7 +34969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35020,7 +35020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35071,7 +35071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35124,7 +35124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35157,12 +35157,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -35254,7 +35254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35282,7 +35282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35330,7 +35330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -35369,7 +35369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -35383,7 +35383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35541,7 +35541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35643,7 +35643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35790,7 +35790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35898,7 +35898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35913,7 +35913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35928,7 +35928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35943,7 +35943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35957,7 +35957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35971,7 +35971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35985,7 +35985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -36054,7 +36054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36111,7 +36111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -36168,7 +36168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36225,7 +36225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36253,7 +36253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36284,7 +36284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -36293,7 +36293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36354,7 +36354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36440,7 +36440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36544,7 +36544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36754,7 +36754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37294,7 +37294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37739,6 +37739,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -37773,7 +37801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37800,7 +37828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38043,9 +38071,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -38479,7 +38507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -38499,7 +38527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -38514,7 +38542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -38529,7 +38557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -38543,7 +38571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -38557,7 +38585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -38571,7 +38599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38646,7 +38674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38703,7 +38731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38760,7 +38788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38817,7 +38845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38870,7 +38898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38885,7 +38913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -39043,7 +39071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -39076,7 +39104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -39109,7 +39137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39142,7 +39170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -39181,7 +39209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -39201,7 +39229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39296,7 +39324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -39325,7 +39353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39340,7 +39368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -39355,7 +39383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -39370,7 +39398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -39385,7 +39413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -39419,7 +39447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -39560,7 +39588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -39609,7 +39637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39677,7 +39705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39691,7 +39719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39723,7 +39751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39846,7 +39874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39951,7 +39979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -40056,7 +40084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -40161,7 +40189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40176,7 +40204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -40191,7 +40219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -40223,7 +40251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -40255,7 +40283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -40287,7 +40315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -40315,7 +40343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -40371,7 +40399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -40428,7 +40456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -40537,7 +40565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40588,7 +40616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40639,7 +40667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40690,7 +40718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40741,7 +40769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40756,7 +40784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40771,7 +40799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40785,7 +40813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40830,7 +40858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41656,6 +41684,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -41706,7 +41752,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -41747,80 +41839,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41918,12 +41936,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -41933,6 +41945,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41968,46 +41992,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -42036,6 +42020,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42089,7 +42091,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -42136,134 +42184,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42355,30 +42275,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -42388,6 +42284,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42423,64 +42331,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -42509,6 +42359,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42562,7 +42430,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -42609,134 +42523,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42828,30 +42614,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -42861,6 +42623,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42896,64 +42670,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -42982,6 +42698,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -43059,7 +42793,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -43106,140 +42892,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -43337,30 +42989,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -43370,6 +42998,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -43400,64 +43040,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -44148,7 +43730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -44239,7 +43821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -44392,7 +43974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -44443,7 +44025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -44536,7 +44118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -44689,7 +44271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -44842,7 +44424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -44995,7 +44577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -45123,7 +44705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -45152,7 +44734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -45324,7 +44906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -45489,9 +45071,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45655,9 +45237,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45821,9 +45403,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45987,7 +45569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -46046,9 +45628,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46106,9 +45688,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46166,9 +45748,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46226,7 +45808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -46291,9 +45873,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46357,9 +45939,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46423,9 +46005,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46489,7 +46071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -46590,9 +46172,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46698,9 +46280,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46800,9 +46382,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46902,7 +46484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -47003,9 +46585,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47111,9 +46693,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47213,9 +46795,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47315,7 +46897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -47404,9 +46986,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47494,9 +47076,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47584,9 +47166,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47678,7 +47260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47692,7 +47274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47706,7 +47288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47768,7 +47350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47813,7 +47395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -47868,7 +47450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -47977,43 +47559,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48021,7 +47603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -48072,7 +47654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -48121,43 +47703,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48165,7 +47747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -48274,43 +47856,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48318,7 +47900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -48427,43 +48009,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48471,7 +48053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -48580,43 +48162,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48624,7 +48206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -48740,7 +48322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -48766,7 +48348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -48798,7 +48380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -48830,7 +48412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -48852,7 +48434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -49012,9 +48594,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -49179,7 +48761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -49328,9 +48910,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49478,9 +49060,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49628,9 +49210,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49778,7 +49360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -49831,9 +49413,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49885,9 +49467,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49939,9 +49521,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49993,7 +49575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -50058,9 +49640,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50124,9 +49706,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50190,9 +49772,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50256,7 +49838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -50345,9 +49927,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -50435,9 +50017,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -50525,9 +50107,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -50615,7 +50197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -50698,9 +50280,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50782,9 +50364,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50866,9 +50448,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50950,7 +50532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -51033,9 +50615,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -51117,9 +50699,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -51201,9 +50783,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -51285,7 +50867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -51307,7 +50889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -51357,7 +50939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -51371,7 +50953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -51385,7 +50967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -51447,7 +51029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -51492,7 +51074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -51549,7 +51131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -51594,7 +51176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -51609,7 +51191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -51645,7 +51227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51676,7 +51258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -51722,7 +51304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51751,7 +51333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51801,7 +51383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51841,7 +51423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51868,7 +51450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51906,7 +51488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51938,7 +51520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -52091,7 +51673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -52244,7 +51826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -52397,7 +51979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -52550,7 +52132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -52703,7 +52285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -52856,7 +52438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -53009,7 +52591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -53161,7 +52743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -53313,7 +52895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -53466,7 +53048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -53619,7 +53201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -53772,7 +53354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -53925,7 +53507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -54084,7 +53666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -54135,7 +53717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -54186,7 +53768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -54237,7 +53819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -54288,7 +53870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -54302,7 +53884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -54316,7 +53898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -54336,7 +53918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -54430,7 +54012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -54444,7 +54026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -54458,7 +54040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -55051,7 +54633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -55071,7 +54653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -55085,7 +54667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -55113,7 +54695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -57002,6 +56584,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV71Q20.svd
+++ b/data/Atmel/ATSAMV71Q20.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -428,7 +428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -495,7 +495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -795,7 +795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -822,7 +822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -849,7 +849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -876,7 +876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -944,7 +944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -961,7 +961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -978,7 +978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -995,7 +995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -1010,7 +1010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -1024,7 +1024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -1040,7 +1040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -1056,7 +1056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -1071,7 +1071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -1088,7 +1088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -1102,7 +1102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -1142,7 +1142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1163,7 +1163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1423,7 +1423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1553,7 +1553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1609,7 +1609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1803,7 +1803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1884,7 +1884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1905,7 +1905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -2010,7 +2010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -2115,7 +2115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2220,7 +2220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2325,7 +2325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2406,7 +2406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2426,7 +2426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2506,7 +2506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2586,7 +2586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2600,7 +2600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2615,7 +2615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2629,7 +2629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2672,7 +2672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2692,7 +2692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2718,7 +2718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2798,7 +2798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2812,7 +2812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2832,7 +2832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2912,7 +2912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2940,7 +2940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2961,7 +2961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_VERSION</name>
+               <name>VERSION</name>
                <description>AFEC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -3005,7 +3005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3335,7 +3335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3369,7 +3369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3384,7 +3384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3480,7 +3480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3702,7 +3702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3723,7 +3723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3744,7 +3744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3779,7 +3779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3800,7 +3800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3833,7 +3833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3866,7 +3866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3899,7 +3899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3932,7 +3932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3952,7 +3952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3980,7 +3980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4001,7 +4001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -4364,7 +4364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4468,7 +4468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4647,7 +4647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4784,7 +4784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4834,7 +4834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4848,7 +4848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4862,7 +4862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4894,7 +4894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -5041,7 +5041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5206,7 +5206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5371,7 +5371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5585,7 +5585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5600,7 +5600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5614,7 +5614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5634,7 +5634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5654,7 +5654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5668,7 +5668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5703,7 +5703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5717,7 +5717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5732,7 +5732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5752,7 +5752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5772,7 +5772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5812,7 +5812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5850,7 +5850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5864,7 +5864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5884,7 +5884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5904,7 +5904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5918,7 +5918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5932,7 +5932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5946,7 +5946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5974,7 +5974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5989,7 +5989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -6004,7 +6004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -6019,7 +6019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -6034,7 +6034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MID</name>
+               <name>MID</name>
                <description>Module ID Register</description>
                <addressOffset>0x0FC</addressOffset>
                <size>32</size>
@@ -6055,7 +6055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -6070,7 +6070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -6085,7 +6085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -6100,7 +6100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -6115,7 +6115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -6130,7 +6130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -6145,7 +6145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -6160,7 +6160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -6175,7 +6175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6190,7 +6190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6205,7 +6205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6250,7 +6250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6265,7 +6265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6280,7 +6280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6295,7 +6295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6310,7 +6310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6325,7 +6325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6340,7 +6340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6355,7 +6355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6370,7 +6370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6385,7 +6385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6400,7 +6400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6415,7 +6415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6430,7 +6430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6445,7 +6445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6460,7 +6460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6475,7 +6475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6490,7 +6490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6520,7 +6520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6535,7 +6535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6550,7 +6550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6565,7 +6565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6580,7 +6580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6595,7 +6595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6610,7 +6610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6625,7 +6625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6640,7 +6640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6655,7 +6655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6670,7 +6670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6685,7 +6685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6700,7 +6700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6715,7 +6715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6730,7 +6730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6744,7 +6744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6758,7 +6758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6772,7 +6772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6786,7 +6786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6833,7 +6833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6863,7 +6863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6878,7 +6878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6893,7 +6893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6938,7 +6938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6955,7 +6955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -7008,7 +7008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -7024,7 +7024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -7040,7 +7040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -7054,7 +7054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -7074,7 +7074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -7088,7 +7088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -7104,7 +7104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7220,7 +7220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7273,7 +7273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7326,7 +7326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7378,7 +7378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7392,7 +7392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7412,7 +7412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7455,7 +7455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7475,7 +7475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7518,7 +7518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7538,7 +7538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7601,7 +7601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7644,7 +7644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7664,7 +7664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7707,7 +7707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7727,7 +7727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7770,7 +7770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7833,7 +7833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7853,7 +7853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7916,7 +7916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7959,7 +7959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7979,7 +7979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -8022,7 +8022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -8042,7 +8042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -8085,7 +8085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -8105,7 +8105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -8148,7 +8148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -8168,7 +8168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -8211,7 +8211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -8231,7 +8231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8274,7 +8274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8294,7 +8294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8337,7 +8337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8357,7 +8357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8400,7 +8400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8420,7 +8420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8463,7 +8463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8483,7 +8483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8526,7 +8526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8546,7 +8546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8589,7 +8589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8609,7 +8609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8672,7 +8672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8715,7 +8715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8735,7 +8735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8778,7 +8778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8798,7 +8798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8841,7 +8841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8861,7 +8861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8954,7 +8954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8993,7 +8993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9043,7 +9043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9106,7 +9106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9152,7 +9152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9166,7 +9166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9423,7 +9423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9508,7 +9508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9523,7 +9523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9538,7 +9538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9553,7 +9553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9706,7 +9706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9859,7 +9859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10012,7 +10012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10165,7 +10165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10213,7 +10213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10245,7 +10245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10273,7 +10273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10294,7 +10294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -10317,7 +10317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10350,7 +10350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10436,7 +10436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10508,7 +10508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10559,7 +10559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10610,7 +10610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10661,7 +10661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10712,7 +10712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10769,7 +10769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10785,7 +10785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10819,7 +10819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10917,7 +10917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11025,7 +11025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11045,7 +11045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11059,7 +11059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11091,7 +11091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11123,7 +11123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11155,7 +11155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11187,7 +11187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11219,7 +11219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11252,7 +11252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11333,7 +11333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11396,7 +11396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11459,7 +11459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11522,7 +11522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11585,7 +11585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11599,7 +11599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11631,7 +11631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11645,7 +11645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11659,7 +11659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11691,7 +11691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11705,7 +11705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11733,7 +11733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11754,7 +11754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -11792,7 +11792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11851,7 +11851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11901,7 +11901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11957,7 +11957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11990,7 +11990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -12166,7 +12166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -12194,7 +12194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -12215,7 +12215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x01FC</addressOffset>
                <size>32</size>
@@ -12259,7 +12259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -12304,7 +12304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -12319,7 +12319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -12333,7 +12333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -12390,7 +12390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12458,7 +12458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12478,7 +12478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12691,7 +12691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12723,7 +12723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12761,7 +12761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12775,7 +12775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12837,7 +12837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12851,7 +12851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12884,7 +12884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -13013,7 +13013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -13213,7 +13213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -13413,7 +13413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13613,7 +13613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13633,7 +13633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13717,7 +13717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13737,7 +13737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13757,7 +13757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13771,7 +13771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13827,7 +13827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -14027,7 +14027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -14227,7 +14227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -14259,7 +14259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -14298,7 +14298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -14312,7 +14312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -14326,7 +14326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -14358,7 +14358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -14426,7 +14426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -14440,7 +14440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14595,7 +14595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14627,7 +14627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14660,7 +14660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14717,7 +14717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14918,7 +14918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15118,7 +15118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -15318,7 +15318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15519,7 +15519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15720,7 +15720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15920,7 +15920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -16120,7 +16120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -16146,7 +16146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -16185,7 +16185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -16230,7 +16230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -16336,7 +16336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -16350,7 +16350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -16364,7 +16364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -16408,7 +16408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -16441,7 +16441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -16539,7 +16539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -16565,7 +16565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -16593,7 +16593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -16609,7 +16609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -16626,7 +16626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -16643,7 +16643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -16659,7 +16659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -16673,7 +16673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -16687,7 +16687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -16726,7 +16726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -16773,7 +16773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -16789,7 +16789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -16822,7 +16822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17023,7 +17023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17224,7 +17224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17425,7 +17425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17626,7 +17626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17827,7 +17827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18028,7 +18028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -18229,7 +18229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -18430,7 +18430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -18631,7 +18631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18832,7 +18832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -19033,7 +19033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -19233,7 +19233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -19434,7 +19434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -19635,7 +19635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -19836,7 +19836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -20037,7 +20037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -20238,7 +20238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -20439,7 +20439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -20640,7 +20640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -20841,7 +20841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -21042,7 +21042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -21243,7 +21243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -21446,7 +21446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -21646,7 +21646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -21847,7 +21847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -22048,7 +22048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -22249,7 +22249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -22263,7 +22263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -22464,7 +22464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -22665,7 +22665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -22866,7 +22866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -23268,7 +23268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -23469,7 +23469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -23670,7 +23670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -23871,7 +23871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -24072,7 +24072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -24273,7 +24273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -24474,7 +24474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -24675,7 +24675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -24876,7 +24876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -25077,7 +25077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -25278,7 +25278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -25479,7 +25479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25507,7 +25507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25528,7 +25528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -25549,7 +25549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25749,7 +25749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -26421,7 +26421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -26454,7 +26454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -26487,7 +26487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -26520,7 +26520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -26541,7 +26541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -26607,7 +26607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -26664,7 +26664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -26721,7 +26721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -26784,7 +26784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -26943,7 +26943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -27102,7 +27102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -27452,7 +27452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -27573,7 +27573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -27595,7 +27595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27643,7 +27643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -27742,7 +27742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -27841,7 +27841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -27958,7 +27958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -28057,7 +28057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -28215,7 +28215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -28319,7 +28319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -28334,7 +28334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -28362,7 +28362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -28383,7 +28383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -28404,7 +28404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -28563,7 +28563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -28722,7 +28722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -28881,7 +28881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -28953,7 +28953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -28997,7 +28997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -29156,7 +29156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -29315,7 +29315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -29474,7 +29474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -29633,7 +29633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -29647,7 +29647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -29806,7 +29806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -29965,7 +29965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -30124,7 +30124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -30283,7 +30283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -30298,7 +30298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -30324,7 +30324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -30371,7 +30371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30545,7 +30545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30578,7 +30578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30611,7 +30611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30644,7 +30644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30701,7 +30701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30758,7 +30758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30815,7 +30815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30872,7 +30872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30940,7 +30940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30955,7 +30955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30969,7 +30969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30989,7 +30989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31004,7 +31004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31121,7 +31121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31238,7 +31238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31355,7 +31355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31472,7 +31472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31528,7 +31528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31584,7 +31584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31641,7 +31641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31698,7 +31698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -31755,7 +31755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -31812,7 +31812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -31838,7 +31838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -31859,7 +31859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -31874,7 +31874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -31930,7 +31930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -31964,7 +31964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -32020,7 +32020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -32040,7 +32040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -32055,7 +32055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -32087,7 +32087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -32143,7 +32143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32226,7 +32226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32319,7 +32319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -32346,7 +32346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32366,7 +32366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32387,7 +32387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32431,7 +32431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32471,7 +32471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32613,7 +32613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32627,7 +32627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32642,7 +32642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32656,7 +32656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -32671,7 +32671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -32686,7 +32686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32706,7 +32706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32728,7 +32728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -32749,7 +32749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -32770,7 +32770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -32850,7 +32850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -32888,7 +32888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -32909,7 +32909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -32989,7 +32989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -33027,7 +33027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -33075,7 +33075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33108,7 +33108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33228,7 +33228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33243,7 +33243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33258,7 +33258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33315,7 +33315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33366,7 +33366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33417,7 +33417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33468,7 +33468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33500,7 +33500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33514,7 +33514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33534,7 +33534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33712,7 +33712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33745,7 +33745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33760,7 +33760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33788,7 +33788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33809,7 +33809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -33849,7 +33849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33884,7 +33884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33945,7 +33945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34004,7 +34004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34033,7 +34033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34083,7 +34083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34117,7 +34117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34190,7 +34190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34404,7 +34404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34436,7 +34436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34474,7 +34474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34524,7 +34524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34556,7 +34556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34679,7 +34679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34724,7 +34724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34769,7 +34769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34814,7 +34814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34859,7 +34859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34892,7 +34892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34932,7 +34932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34976,7 +34976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34990,7 +34990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35005,7 +35005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35045,7 +35045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35097,7 +35097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35111,7 +35111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35257,7 +35257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35336,7 +35336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35351,7 +35351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35366,7 +35366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35381,7 +35381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35396,7 +35396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35423,7 +35423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35456,7 +35456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35470,7 +35470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35485,7 +35485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35500,7 +35500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_VERSION</name>
+               <name>VERSION</name>
                <description>SDRAMC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35542,7 +35542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -35574,7 +35574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -35606,7 +35606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35626,7 +35626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35756,7 +35756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -35794,7 +35794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -35809,7 +35809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -35824,7 +35824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35852,7 +35852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35873,7 +35873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_VERSION</name>
+               <name>VERSION</name>
                <description>SMC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35913,7 +35913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35976,7 +35976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36032,7 +36032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36053,7 +36053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36080,7 +36080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36137,7 +36137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36188,7 +36188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36239,7 +36239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -36292,7 +36292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36396,7 +36396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36424,7 +36424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36445,7 +36445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -36493,7 +36493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -36532,7 +36532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -36546,7 +36546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36704,7 +36704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36806,7 +36806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36953,7 +36953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37061,7 +37061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -37076,7 +37076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -37091,7 +37091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -37106,7 +37106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -37120,7 +37120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -37134,7 +37134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -37148,7 +37148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -37217,7 +37217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -37274,7 +37274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -37331,7 +37331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -37388,7 +37388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37416,7 +37416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -37437,7 +37437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -37477,7 +37477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37538,7 +37538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37624,7 +37624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -37728,7 +37728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37938,7 +37938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38478,7 +38478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38978,7 +38978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39005,7 +39005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39248,7 +39248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39268,7 +39268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39283,7 +39283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -39298,7 +39298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -39312,7 +39312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -39326,7 +39326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -39340,7 +39340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -39415,7 +39415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -39472,7 +39472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -39529,7 +39529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -39586,7 +39586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -39639,7 +39639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -39654,7 +39654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -39800,7 +39800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -39827,7 +39827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -39854,7 +39854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39881,7 +39881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -39914,7 +39914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -39934,7 +39934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39962,7 +39962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -40050,7 +40050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40079,7 +40079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40094,7 +40094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -40109,7 +40109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -40124,7 +40124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -40139,7 +40139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -40154,7 +40154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -40194,7 +40194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40335,7 +40335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40384,7 +40384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40452,7 +40452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -40466,7 +40466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40498,7 +40498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -40621,7 +40621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -40726,7 +40726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -40831,7 +40831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -40936,7 +40936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40951,7 +40951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -40966,7 +40966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -40998,7 +40998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -41030,7 +41030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -41062,7 +41062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_DR</name>
+               <name>DR</name>
                <description>Debug Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -41095,7 +41095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -41123,7 +41123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -41144,7 +41144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -41200,7 +41200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41263,7 +41263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41372,7 +41372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -41423,7 +41423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -41474,7 +41474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -41525,7 +41525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41594,7 +41594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41609,7 +41609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -41624,7 +41624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -41638,7 +41638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -41683,7 +41683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41711,7 +41711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -43308,7 +43308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -43399,7 +43399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -43552,7 +43552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -43603,7 +43603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -43696,7 +43696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -43849,7 +43849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -44002,7 +44002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -44155,7 +44155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -44283,7 +44283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -44312,7 +44312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -44484,7 +44484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -44649,7 +44649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -44708,7 +44708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -44773,7 +44773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -44874,7 +44874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -44975,7 +44975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -45068,7 +45068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45082,7 +45082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45096,7 +45096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45158,7 +45158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45203,7 +45203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -45258,7 +45258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -45411,7 +45411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -45462,7 +45462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -45555,7 +45555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -45708,7 +45708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -45861,7 +45861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -46014,7 +46014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -46130,7 +46130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -46156,7 +46156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -46188,7 +46188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -46220,7 +46220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -46242,7 +46242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -46402,7 +46402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -46551,7 +46551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -46604,7 +46604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -46669,7 +46669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -46758,7 +46758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46841,7 +46841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -46924,7 +46924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -46946,7 +46946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -46996,7 +46996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47010,7 +47010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47024,7 +47024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47086,7 +47086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47131,7 +47131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47188,7 +47188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47233,7 +47233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47248,7 +47248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47269,7 +47269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA1</name>
+               <name>TSTA1</name>
                <description>General Test A1 Register</description>
                <addressOffset>0x0810</addressOffset>
                <size>32</size>
@@ -47313,7 +47313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA2</name>
+               <name>TSTA2</name>
                <description>General Test A2 Register</description>
                <addressOffset>0x0814</addressOffset>
                <size>32</size>
@@ -47375,7 +47375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_VERSION</name>
+               <name>VERSION</name>
                <description>General Version Register</description>
                <addressOffset>0x0818</addressOffset>
                <size>32</size>
@@ -47396,7 +47396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_FSM</name>
+               <name>FSM</name>
                <description>General Finite State Machine Register</description>
                <addressOffset>0x082C</addressOffset>
                <size>32</size>
@@ -47509,7 +47509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47540,7 +47540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47586,7 +47586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47615,7 +47615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47665,7 +47665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47705,7 +47705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47732,7 +47732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47770,7 +47770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47802,7 +47802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -47955,7 +47955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48108,7 +48108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -48261,7 +48261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48414,7 +48414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48567,7 +48567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -48720,7 +48720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -48873,7 +48873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -49025,7 +49025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -49177,7 +49177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49330,7 +49330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49483,7 +49483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49636,7 +49636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -49789,7 +49789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -49948,7 +49948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49999,7 +49999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50050,7 +50050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50101,7 +50101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50152,7 +50152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -50166,7 +50166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -50180,7 +50180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -50200,7 +50200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -50294,7 +50294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50308,7 +50308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50322,7 +50322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -50652,7 +50652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -50672,7 +50672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -50686,7 +50686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -50701,7 +50701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>XDMAC_VERSION</name>
+               <name>VERSION</name>
                <description>XDMAC Version Register</description>
                <addressOffset>0xFFC</addressOffset>
                <size>32</size>
@@ -50734,7 +50734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -50934,7 +50934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV71Q20B.svd
+++ b/data/Atmel/ATSAMV71Q20B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9287,7 +9287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9361,7 +9361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9406,7 +9406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9433,7 +9433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9484,7 +9484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9535,7 +9535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9586,7 +9586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9637,7 +9637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9694,7 +9694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9710,7 +9710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9744,7 +9744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9842,7 +9842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9950,7 +9950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9970,7 +9970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9984,7 +9984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10016,7 +10016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10048,7 +10048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10080,7 +10080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10112,7 +10112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10144,7 +10144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10177,7 +10177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10258,7 +10258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10321,7 +10321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10384,7 +10384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10447,7 +10447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10468,7 +10468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10489,7 +10489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10510,7 +10510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10524,7 +10524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10556,7 +10556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10570,7 +10570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10584,7 +10584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10616,7 +10616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10630,7 +10630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10658,7 +10658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10696,7 +10696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10861,7 +10861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10900,7 +10900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11134,7 +11134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11162,7 +11162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11206,7 +11206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11251,7 +11251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11266,7 +11266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11280,7 +11280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11331,7 +11331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11393,7 +11393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11413,7 +11413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11622,7 +11622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11654,7 +11654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11692,7 +11692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11706,7 +11706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11768,7 +11768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11782,7 +11782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11815,7 +11815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11956,7 +11956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11976,7 +11976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12152,7 +12152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12328,7 +12328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12504,7 +12504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12524,7 +12524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12608,7 +12608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12628,7 +12628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12648,7 +12648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12662,7 +12662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12718,7 +12718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12918,7 +12918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13118,7 +13118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13150,7 +13150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13189,7 +13189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13203,7 +13203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13217,7 +13217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13249,7 +13249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13317,7 +13317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13331,7 +13331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13486,7 +13486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13518,7 +13518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13551,7 +13551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13608,7 +13608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13809,7 +13809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14009,7 +14009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14209,7 +14209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14410,7 +14410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14611,7 +14611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14811,7 +14811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15011,7 +15011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15037,7 +15037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15076,7 +15076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15121,7 +15121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -15227,7 +15227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -15241,7 +15241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -15255,7 +15255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -15299,7 +15299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -15332,7 +15332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -15430,7 +15430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -15456,7 +15456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -15484,7 +15484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -15500,7 +15500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -15517,7 +15517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -15534,7 +15534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -15550,7 +15550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15564,7 +15564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -15578,7 +15578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -15617,7 +15617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -15664,7 +15664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -15680,7 +15680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -15713,7 +15713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15914,7 +15914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16115,7 +16115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16316,7 +16316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16517,7 +16517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16718,7 +16718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16919,7 +16919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17120,7 +17120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17321,7 +17321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17522,7 +17522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17723,7 +17723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17924,7 +17924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18124,7 +18124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18325,7 +18325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18526,7 +18526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18727,7 +18727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18928,7 +18928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19129,7 +19129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19330,7 +19330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19531,7 +19531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19732,7 +19732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19933,7 +19933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20134,7 +20134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20337,7 +20337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20537,7 +20537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20738,7 +20738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20939,7 +20939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21140,7 +21140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21154,7 +21154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21355,7 +21355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21556,7 +21556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21757,7 +21757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21958,7 +21958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22159,7 +22159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22360,7 +22360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22561,7 +22561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22762,7 +22762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22963,7 +22963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23164,7 +23164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23365,7 +23365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23566,7 +23566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23767,7 +23767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24169,7 +24169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24370,7 +24370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24398,7 +24398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24419,7 +24419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24619,7 +24619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25235,7 +25235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25291,7 +25291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25324,7 +25324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25357,7 +25357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25390,7 +25390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25411,7 +25411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25477,7 +25477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25540,7 +25540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25603,7 +25603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25672,7 +25672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25831,7 +25831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25990,7 +25990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26340,7 +26340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26461,7 +26461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26483,7 +26483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26531,7 +26531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26636,7 +26636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26741,7 +26741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26864,7 +26864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26969,7 +26969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27127,7 +27127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27231,7 +27231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27246,7 +27246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27274,7 +27274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27295,7 +27295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27454,7 +27454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27613,7 +27613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27772,7 +27772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27844,7 +27844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27888,7 +27888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28047,7 +28047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28206,7 +28206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28365,7 +28365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28524,7 +28524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28538,7 +28538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28697,7 +28697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28856,7 +28856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29015,7 +29015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29174,7 +29174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29208,7 +29208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29382,7 +29382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29415,7 +29415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29448,7 +29448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29481,7 +29481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29538,7 +29538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29595,7 +29595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29652,7 +29652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29709,7 +29709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29777,7 +29777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29792,7 +29792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29806,7 +29806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29826,7 +29826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29841,7 +29841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29958,7 +29958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30075,7 +30075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30192,7 +30192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30309,7 +30309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30365,7 +30365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30421,7 +30421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30478,7 +30478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30535,7 +30535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30592,7 +30592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30649,7 +30649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30675,7 +30675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30696,7 +30696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30711,7 +30711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30767,7 +30767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30801,7 +30801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30857,7 +30857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30877,7 +30877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30892,7 +30892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30924,7 +30924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30980,7 +30980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31063,7 +31063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31162,7 +31162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31195,7 +31195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31216,7 +31216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31260,7 +31260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31300,7 +31300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31494,7 +31494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31508,7 +31508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31523,7 +31523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31537,7 +31537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31552,7 +31552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31567,7 +31567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31587,7 +31587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31609,7 +31609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31630,7 +31630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31651,7 +31651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31731,7 +31731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31769,7 +31769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31790,7 +31790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31870,7 +31870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31908,7 +31908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31956,7 +31956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31989,7 +31989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32109,7 +32109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32124,7 +32124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32139,7 +32139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32196,7 +32196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32247,7 +32247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32298,7 +32298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32349,7 +32349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32381,7 +32381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32395,7 +32395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32415,7 +32415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32593,7 +32593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32626,7 +32626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32641,7 +32641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32669,7 +32669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32709,7 +32709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32744,7 +32744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32805,7 +32805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32864,7 +32864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32893,7 +32893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32943,7 +32943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32977,7 +32977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33050,7 +33050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33264,7 +33264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33296,7 +33296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33334,7 +33334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33384,7 +33384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33416,7 +33416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33539,7 +33539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33584,7 +33584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33629,7 +33629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33674,7 +33674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33719,7 +33719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33771,7 +33771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33815,7 +33815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33829,7 +33829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33844,7 +33844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33884,7 +33884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33936,7 +33936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33950,7 +33950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34096,7 +34096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34175,7 +34175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34190,7 +34190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34205,7 +34205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34220,7 +34220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34235,7 +34235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34262,7 +34262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34295,7 +34295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34309,7 +34309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34324,7 +34324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34360,7 +34360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34392,7 +34392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34424,7 +34424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34444,7 +34444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34574,7 +34574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -34612,7 +34612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -34627,7 +34627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -34642,7 +34642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34670,7 +34670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34710,7 +34710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34749,7 +34749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34841,7 +34841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34862,7 +34862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34912,7 +34912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34969,7 +34969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35020,7 +35020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35071,7 +35071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35124,7 +35124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35157,12 +35157,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -35254,7 +35254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35282,7 +35282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35330,7 +35330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -35369,7 +35369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -35383,7 +35383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35541,7 +35541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35643,7 +35643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35790,7 +35790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35898,7 +35898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35913,7 +35913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35928,7 +35928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35943,7 +35943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35957,7 +35957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35971,7 +35971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35985,7 +35985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -36054,7 +36054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36111,7 +36111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -36168,7 +36168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36225,7 +36225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36253,7 +36253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36284,7 +36284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -36293,7 +36293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36354,7 +36354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36440,7 +36440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36544,7 +36544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36754,7 +36754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37294,7 +37294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37739,6 +37739,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -37773,7 +37801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37800,7 +37828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38043,9 +38071,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -38479,7 +38507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -38499,7 +38527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -38514,7 +38542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -38529,7 +38557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -38543,7 +38571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -38557,7 +38585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -38571,7 +38599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38646,7 +38674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38703,7 +38731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38760,7 +38788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38817,7 +38845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38870,7 +38898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38885,7 +38913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -39043,7 +39071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -39076,7 +39104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -39109,7 +39137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39142,7 +39170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -39181,7 +39209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -39201,7 +39229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39296,7 +39324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -39325,7 +39353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39340,7 +39368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -39355,7 +39383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -39370,7 +39398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -39385,7 +39413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -39419,7 +39447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -39560,7 +39588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -39609,7 +39637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39677,7 +39705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39691,7 +39719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39723,7 +39751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39846,7 +39874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39951,7 +39979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -40056,7 +40084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -40161,7 +40189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40176,7 +40204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -40191,7 +40219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -40223,7 +40251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -40255,7 +40283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -40287,7 +40315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -40315,7 +40343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -40371,7 +40399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -40428,7 +40456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -40537,7 +40565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40588,7 +40616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40639,7 +40667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40690,7 +40718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40741,7 +40769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40756,7 +40784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40771,7 +40799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40785,7 +40813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40830,7 +40858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41656,6 +41684,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -41706,7 +41752,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -41747,80 +41839,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41918,12 +41936,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -41933,6 +41945,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41968,46 +41992,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -42036,6 +42020,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42089,7 +42091,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -42136,134 +42184,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42355,30 +42275,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -42388,6 +42284,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42423,64 +42331,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -42509,6 +42359,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42562,7 +42430,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -42609,134 +42523,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42828,30 +42614,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -42861,6 +42623,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42896,64 +42670,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -42982,6 +42698,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -43059,7 +42793,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -43106,140 +42892,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -43337,30 +42989,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -43370,6 +42998,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -43400,64 +43040,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -44148,7 +43730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -44239,7 +43821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -44392,7 +43974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -44443,7 +44025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -44536,7 +44118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -44689,7 +44271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -44842,7 +44424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -44995,7 +44577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -45123,7 +44705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -45152,7 +44734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -45324,7 +44906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -45489,9 +45071,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45655,9 +45237,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45821,9 +45403,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45987,7 +45569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -46046,9 +45628,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46106,9 +45688,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46166,9 +45748,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46226,7 +45808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -46291,9 +45873,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46357,9 +45939,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46423,9 +46005,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46489,7 +46071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -46590,9 +46172,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46698,9 +46280,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46800,9 +46382,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46902,7 +46484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -47003,9 +46585,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47111,9 +46693,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47213,9 +46795,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47315,7 +46897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -47404,9 +46986,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47494,9 +47076,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47584,9 +47166,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47678,7 +47260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47692,7 +47274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47706,7 +47288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47768,7 +47350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47813,7 +47395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -47868,7 +47450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -47977,43 +47559,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48021,7 +47603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -48072,7 +47654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -48121,43 +47703,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48165,7 +47747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -48274,43 +47856,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48318,7 +47900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -48427,43 +48009,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48471,7 +48053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -48580,43 +48162,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48624,7 +48206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -48740,7 +48322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -48766,7 +48348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -48798,7 +48380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -48830,7 +48412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -48852,7 +48434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -49012,9 +48594,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -49179,7 +48761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -49328,9 +48910,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49478,9 +49060,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49628,9 +49210,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49778,7 +49360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -49831,9 +49413,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49885,9 +49467,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49939,9 +49521,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49993,7 +49575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -50058,9 +49640,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50124,9 +49706,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50190,9 +49772,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50256,7 +49838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -50345,9 +49927,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -50435,9 +50017,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -50525,9 +50107,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -50615,7 +50197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -50698,9 +50280,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50782,9 +50364,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50866,9 +50448,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50950,7 +50532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -51033,9 +50615,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -51117,9 +50699,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -51201,9 +50783,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -51285,7 +50867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -51307,7 +50889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -51357,7 +50939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -51371,7 +50953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -51385,7 +50967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -51447,7 +51029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -51492,7 +51074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -51549,7 +51131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -51594,7 +51176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -51609,7 +51191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -51645,7 +51227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51676,7 +51258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -51722,7 +51304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51751,7 +51333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51801,7 +51383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51841,7 +51423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51868,7 +51450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51906,7 +51488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51938,7 +51520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -52091,7 +51673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -52244,7 +51826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -52397,7 +51979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -52550,7 +52132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -52703,7 +52285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -52856,7 +52438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -53009,7 +52591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -53161,7 +52743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -53313,7 +52895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -53466,7 +53048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -53619,7 +53201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -53772,7 +53354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -53925,7 +53507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -54084,7 +53666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -54135,7 +53717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -54186,7 +53768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -54237,7 +53819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -54288,7 +53870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -54302,7 +53884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -54316,7 +53898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -54336,7 +53918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -54430,7 +54012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -54444,7 +54026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -54458,7 +54040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -55051,7 +54633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -55071,7 +54653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -55085,7 +54667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -55113,7 +54695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -55313,7 +54895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -57202,6 +56784,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/ATSAMV71Q21.svd
+++ b/data/Atmel/ATSAMV71Q21.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -428,7 +428,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -468,7 +468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -495,7 +495,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -795,7 +795,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -822,7 +822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -849,7 +849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -876,7 +876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -944,7 +944,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -961,7 +961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -978,7 +978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register 0</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -995,7 +995,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register 0</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -1010,7 +1010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -1024,7 +1024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -1040,7 +1040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register 0</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -1056,7 +1056,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -1071,7 +1071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -1088,7 +1088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register 0</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -1102,7 +1102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -1142,7 +1142,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1163,7 +1163,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1423,7 +1423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1553,7 +1553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1609,7 +1609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1641,7 +1641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1722,7 +1722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1803,7 +1803,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1884,7 +1884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1905,7 +1905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -2010,7 +2010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -2115,7 +2115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2220,7 +2220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2325,7 +2325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2406,7 +2406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2426,7 +2426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2506,7 +2506,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2586,7 +2586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2600,7 +2600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2615,7 +2615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2629,7 +2629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2672,7 +2672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2692,7 +2692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2718,7 +2718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2798,7 +2798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2812,7 +2812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2832,7 +2832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2912,7 +2912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2940,7 +2940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2961,7 +2961,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_VERSION</name>
+               <name>VERSION</name>
                <description>AFEC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -3005,7 +3005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3335,7 +3335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3369,7 +3369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3384,7 +3384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3480,7 +3480,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3702,7 +3702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3723,7 +3723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3744,7 +3744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3779,7 +3779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3800,7 +3800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3833,7 +3833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3866,7 +3866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3899,7 +3899,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3932,7 +3932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3952,7 +3952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3980,7 +3980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4001,7 +4001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -4364,7 +4364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4468,7 +4468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4647,7 +4647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4784,7 +4784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4834,7 +4834,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4848,7 +4848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4862,7 +4862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4894,7 +4894,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -5041,7 +5041,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5206,7 +5206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5371,7 +5371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5585,7 +5585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5600,7 +5600,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5614,7 +5614,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5634,7 +5634,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5654,7 +5654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5668,7 +5668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5703,7 +5703,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5717,7 +5717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5732,7 +5732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5752,7 +5752,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5772,7 +5772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5812,7 +5812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5850,7 +5850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5864,7 +5864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5884,7 +5884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5904,7 +5904,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5918,7 +5918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5932,7 +5932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5946,7 +5946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5960,7 +5960,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5974,7 +5974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5989,7 +5989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -6004,7 +6004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -6019,7 +6019,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -6034,7 +6034,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MID</name>
+               <name>MID</name>
                <description>Module ID Register</description>
                <addressOffset>0x0FC</addressOffset>
                <size>32</size>
@@ -6055,7 +6055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -6070,7 +6070,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -6085,7 +6085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -6100,7 +6100,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -6115,7 +6115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -6130,7 +6130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -6145,7 +6145,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -6160,7 +6160,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -6175,7 +6175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6190,7 +6190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6205,7 +6205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6220,7 +6220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6235,7 +6235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6250,7 +6250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6265,7 +6265,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6280,7 +6280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6295,7 +6295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6310,7 +6310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6325,7 +6325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6340,7 +6340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6355,7 +6355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6370,7 +6370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6385,7 +6385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6400,7 +6400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6415,7 +6415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6430,7 +6430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6445,7 +6445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6460,7 +6460,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6475,7 +6475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6490,7 +6490,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6505,7 +6505,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6520,7 +6520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6535,7 +6535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6550,7 +6550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6565,7 +6565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6580,7 +6580,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6595,7 +6595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6610,7 +6610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6625,7 +6625,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6640,7 +6640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6655,7 +6655,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6670,7 +6670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6685,7 +6685,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6700,7 +6700,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6715,7 +6715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6730,7 +6730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6744,7 +6744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6758,7 +6758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6772,7 +6772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6786,7 +6786,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6807,7 +6807,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6833,7 +6833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6848,7 +6848,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6863,7 +6863,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6878,7 +6878,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6893,7 +6893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6908,7 +6908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6923,7 +6923,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6938,7 +6938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6955,7 +6955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x3FC</addressOffset>
                <size>32</size>
@@ -7008,7 +7008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x43C</addressOffset>
                <size>32</size>
@@ -7024,7 +7024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x47C</addressOffset>
                <size>32</size>
@@ -7040,7 +7040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x49C</addressOffset>
                <size>32</size>
@@ -7054,7 +7054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -7074,7 +7074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -7088,7 +7088,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -7104,7 +7104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue (index = 0) 0</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7220,7 +7220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x5FC</addressOffset>
                <size>32</size>
@@ -7273,7 +7273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x61C</addressOffset>
                <size>32</size>
@@ -7326,7 +7326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (index = 1) 0</description>
                <addressOffset>0x63C</addressOffset>
                <size>32</size>
@@ -7378,7 +7378,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register (index = 0) 0</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7392,7 +7392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW00</name>
+               <name>ST2CW00</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 0)</description>
                <addressOffset>0x700</addressOffset>
                <size>32</size>
@@ -7412,7 +7412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW10</name>
+               <name>ST2CW10</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 0)</description>
                <addressOffset>0x704</addressOffset>
                <size>32</size>
@@ -7455,7 +7455,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW01</name>
+               <name>ST2CW01</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 1)</description>
                <addressOffset>0x708</addressOffset>
                <size>32</size>
@@ -7475,7 +7475,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW11</name>
+               <name>ST2CW11</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 1)</description>
                <addressOffset>0x70C</addressOffset>
                <size>32</size>
@@ -7518,7 +7518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW02</name>
+               <name>ST2CW02</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 2)</description>
                <addressOffset>0x710</addressOffset>
                <size>32</size>
@@ -7538,7 +7538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW12</name>
+               <name>ST2CW12</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 2)</description>
                <addressOffset>0x714</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW03</name>
+               <name>ST2CW03</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 3)</description>
                <addressOffset>0x718</addressOffset>
                <size>32</size>
@@ -7601,7 +7601,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW13</name>
+               <name>ST2CW13</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 3)</description>
                <addressOffset>0x71C</addressOffset>
                <size>32</size>
@@ -7644,7 +7644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW04</name>
+               <name>ST2CW04</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 4)</description>
                <addressOffset>0x720</addressOffset>
                <size>32</size>
@@ -7664,7 +7664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW14</name>
+               <name>ST2CW14</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 4)</description>
                <addressOffset>0x724</addressOffset>
                <size>32</size>
@@ -7707,7 +7707,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW05</name>
+               <name>ST2CW05</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 5)</description>
                <addressOffset>0x728</addressOffset>
                <size>32</size>
@@ -7727,7 +7727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW15</name>
+               <name>ST2CW15</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 5)</description>
                <addressOffset>0x72C</addressOffset>
                <size>32</size>
@@ -7770,7 +7770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW06</name>
+               <name>ST2CW06</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 6)</description>
                <addressOffset>0x730</addressOffset>
                <size>32</size>
@@ -7790,7 +7790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW16</name>
+               <name>ST2CW16</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 6)</description>
                <addressOffset>0x734</addressOffset>
                <size>32</size>
@@ -7833,7 +7833,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW07</name>
+               <name>ST2CW07</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 7)</description>
                <addressOffset>0x738</addressOffset>
                <size>32</size>
@@ -7853,7 +7853,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW17</name>
+               <name>ST2CW17</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 7)</description>
                <addressOffset>0x73C</addressOffset>
                <size>32</size>
@@ -7896,7 +7896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW08</name>
+               <name>ST2CW08</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 8)</description>
                <addressOffset>0x740</addressOffset>
                <size>32</size>
@@ -7916,7 +7916,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW18</name>
+               <name>ST2CW18</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 8)</description>
                <addressOffset>0x744</addressOffset>
                <size>32</size>
@@ -7959,7 +7959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW09</name>
+               <name>ST2CW09</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 9)</description>
                <addressOffset>0x748</addressOffset>
                <size>32</size>
@@ -7979,7 +7979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW19</name>
+               <name>ST2CW19</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 9)</description>
                <addressOffset>0x74C</addressOffset>
                <size>32</size>
@@ -8022,7 +8022,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW010</name>
+               <name>ST2CW010</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 10)</description>
                <addressOffset>0x750</addressOffset>
                <size>32</size>
@@ -8042,7 +8042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW110</name>
+               <name>ST2CW110</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 10)</description>
                <addressOffset>0x754</addressOffset>
                <size>32</size>
@@ -8085,7 +8085,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW011</name>
+               <name>ST2CW011</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 11)</description>
                <addressOffset>0x758</addressOffset>
                <size>32</size>
@@ -8105,7 +8105,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW111</name>
+               <name>ST2CW111</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 11)</description>
                <addressOffset>0x75C</addressOffset>
                <size>32</size>
@@ -8148,7 +8148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW012</name>
+               <name>ST2CW012</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 12)</description>
                <addressOffset>0x760</addressOffset>
                <size>32</size>
@@ -8168,7 +8168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW112</name>
+               <name>ST2CW112</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 12)</description>
                <addressOffset>0x764</addressOffset>
                <size>32</size>
@@ -8211,7 +8211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW013</name>
+               <name>ST2CW013</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 13)</description>
                <addressOffset>0x768</addressOffset>
                <size>32</size>
@@ -8231,7 +8231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW113</name>
+               <name>ST2CW113</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 13)</description>
                <addressOffset>0x76C</addressOffset>
                <size>32</size>
@@ -8274,7 +8274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW014</name>
+               <name>ST2CW014</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 14)</description>
                <addressOffset>0x770</addressOffset>
                <size>32</size>
@@ -8294,7 +8294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW114</name>
+               <name>ST2CW114</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 14)</description>
                <addressOffset>0x774</addressOffset>
                <size>32</size>
@@ -8337,7 +8337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW015</name>
+               <name>ST2CW015</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 15)</description>
                <addressOffset>0x778</addressOffset>
                <size>32</size>
@@ -8357,7 +8357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW115</name>
+               <name>ST2CW115</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 15)</description>
                <addressOffset>0x77C</addressOffset>
                <size>32</size>
@@ -8400,7 +8400,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW016</name>
+               <name>ST2CW016</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 16)</description>
                <addressOffset>0x780</addressOffset>
                <size>32</size>
@@ -8420,7 +8420,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW116</name>
+               <name>ST2CW116</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 16)</description>
                <addressOffset>0x784</addressOffset>
                <size>32</size>
@@ -8463,7 +8463,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW017</name>
+               <name>ST2CW017</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 17)</description>
                <addressOffset>0x788</addressOffset>
                <size>32</size>
@@ -8483,7 +8483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW117</name>
+               <name>ST2CW117</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 17)</description>
                <addressOffset>0x78C</addressOffset>
                <size>32</size>
@@ -8526,7 +8526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW018</name>
+               <name>ST2CW018</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 18)</description>
                <addressOffset>0x790</addressOffset>
                <size>32</size>
@@ -8546,7 +8546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW118</name>
+               <name>ST2CW118</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 18)</description>
                <addressOffset>0x794</addressOffset>
                <size>32</size>
@@ -8589,7 +8589,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW019</name>
+               <name>ST2CW019</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 19)</description>
                <addressOffset>0x798</addressOffset>
                <size>32</size>
@@ -8609,7 +8609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW119</name>
+               <name>ST2CW119</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 19)</description>
                <addressOffset>0x79C</addressOffset>
                <size>32</size>
@@ -8652,7 +8652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW020</name>
+               <name>ST2CW020</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 20)</description>
                <addressOffset>0x7A0</addressOffset>
                <size>32</size>
@@ -8672,7 +8672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW120</name>
+               <name>ST2CW120</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 20)</description>
                <addressOffset>0x7A4</addressOffset>
                <size>32</size>
@@ -8715,7 +8715,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW021</name>
+               <name>ST2CW021</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 21)</description>
                <addressOffset>0x7A8</addressOffset>
                <size>32</size>
@@ -8735,7 +8735,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW121</name>
+               <name>ST2CW121</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 21)</description>
                <addressOffset>0x7AC</addressOffset>
                <size>32</size>
@@ -8778,7 +8778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW022</name>
+               <name>ST2CW022</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 22)</description>
                <addressOffset>0x7B0</addressOffset>
                <size>32</size>
@@ -8798,7 +8798,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW122</name>
+               <name>ST2CW122</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 22)</description>
                <addressOffset>0x7B4</addressOffset>
                <size>32</size>
@@ -8841,7 +8841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW023</name>
+               <name>ST2CW023</name>
                <description>Screening Type 2 Compare Word 0 Register (index = 23)</description>
                <addressOffset>0x7B8</addressOffset>
                <size>32</size>
@@ -8861,7 +8861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ST2CW123</name>
+               <name>ST2CW123</name>
                <description>Screening Type 2 Compare Word 1 Register (index = 23)</description>
                <addressOffset>0x7BC</addressOffset>
                <size>32</size>
@@ -8954,7 +8954,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8993,7 +8993,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9043,7 +9043,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9106,7 +9106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9152,7 +9152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9166,7 +9166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9423,7 +9423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9443,7 +9443,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9508,7 +9508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9523,7 +9523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9538,7 +9538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9553,7 +9553,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -9706,7 +9706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -9859,7 +9859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10012,7 +10012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10165,7 +10165,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10213,7 +10213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10245,7 +10245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10273,7 +10273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10294,7 +10294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -10317,7 +10317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -10350,7 +10350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10436,7 +10436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -10481,7 +10481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -10508,7 +10508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10559,7 +10559,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10610,7 +10610,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10661,7 +10661,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10712,7 +10712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10769,7 +10769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10785,7 +10785,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10819,7 +10819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -10917,7 +10917,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11025,7 +11025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11045,7 +11045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11059,7 +11059,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11091,7 +11091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11123,7 +11123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11155,7 +11155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11187,7 +11187,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11219,7 +11219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11252,7 +11252,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11333,7 +11333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11396,7 +11396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -11459,7 +11459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -11522,7 +11522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -11543,7 +11543,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -11564,7 +11564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11585,7 +11585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11599,7 +11599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11631,7 +11631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -11645,7 +11645,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -11659,7 +11659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -11691,7 +11691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -11705,7 +11705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -11733,7 +11733,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -11754,7 +11754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -11792,7 +11792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>12</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -11851,7 +11851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11901,7 +11901,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -11957,7 +11957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -11990,7 +11990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -12166,7 +12166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -12194,7 +12194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -12215,7 +12215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x01FC</addressOffset>
                <size>32</size>
@@ -12259,7 +12259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -12304,7 +12304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -12319,7 +12319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -12333,7 +12333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_FBTP</name>
+               <name>FBTP</name>
                <description>Fast Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -12390,7 +12390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -12458,7 +12458,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -12478,7 +12478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -12691,7 +12691,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_BTP</name>
+               <name>BTP</name>
                <description>Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -12723,7 +12723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -12761,7 +12761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -12775,7 +12775,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -12837,7 +12837,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -12851,7 +12851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -12884,7 +12884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -13013,7 +13013,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -13213,7 +13213,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -13413,7 +13413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -13613,7 +13613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -13633,7 +13633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -13717,7 +13717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -13737,7 +13737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -13757,7 +13757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -13771,7 +13771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -13827,7 +13827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -14027,7 +14027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -14227,7 +14227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -14259,7 +14259,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -14298,7 +14298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -14312,7 +14312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -14326,7 +14326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -14358,7 +14358,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -14426,7 +14426,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -14440,7 +14440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -14595,7 +14595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -14627,7 +14627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -14660,7 +14660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -14717,7 +14717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -14918,7 +14918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15118,7 +15118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -15318,7 +15318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -15519,7 +15519,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -15720,7 +15720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -15920,7 +15920,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -16120,7 +16120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -16146,7 +16146,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -16185,7 +16185,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -16230,7 +16230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -16336,7 +16336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -16350,7 +16350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -16364,7 +16364,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -16408,7 +16408,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -16441,7 +16441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -16539,7 +16539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -16565,7 +16565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -16593,7 +16593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -16609,7 +16609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -16626,7 +16626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -16643,7 +16643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -16659,7 +16659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -16673,7 +16673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -16687,7 +16687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -16726,7 +16726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -16773,7 +16773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -16789,7 +16789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -16822,7 +16822,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -17023,7 +17023,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -17224,7 +17224,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -17425,7 +17425,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -17626,7 +17626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -17827,7 +17827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -18028,7 +18028,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -18229,7 +18229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -18430,7 +18430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -18631,7 +18631,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -18832,7 +18832,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -19033,7 +19033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -19233,7 +19233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -19434,7 +19434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -19635,7 +19635,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -19836,7 +19836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -20037,7 +20037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -20238,7 +20238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -20439,7 +20439,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -20640,7 +20640,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -20841,7 +20841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -21042,7 +21042,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -21243,7 +21243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -21446,7 +21446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -21646,7 +21646,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -21847,7 +21847,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -22048,7 +22048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -22249,7 +22249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -22263,7 +22263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -22464,7 +22464,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -22665,7 +22665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -22866,7 +22866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -23067,7 +23067,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -23268,7 +23268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -23469,7 +23469,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -23670,7 +23670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -23871,7 +23871,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -24072,7 +24072,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -24273,7 +24273,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -24474,7 +24474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -24675,7 +24675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -24876,7 +24876,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -25077,7 +25077,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -25278,7 +25278,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -25479,7 +25479,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -25507,7 +25507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -25528,7 +25528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -25549,7 +25549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -25749,7 +25749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -26365,7 +26365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -26421,7 +26421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -26454,7 +26454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -26487,7 +26487,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -26520,7 +26520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -26541,7 +26541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -26607,7 +26607,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -26664,7 +26664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -26721,7 +26721,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -26784,7 +26784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -26943,7 +26943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -27102,7 +27102,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -27452,7 +27452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -27573,7 +27573,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -27595,7 +27595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register (chid = 0) 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -27643,7 +27643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -27742,7 +27742,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -27841,7 +27841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -27958,7 +27958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -28057,7 +28057,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -28215,7 +28215,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -28319,7 +28319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -28334,7 +28334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -28362,7 +28362,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -28383,7 +28383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -28404,7 +28404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -28563,7 +28563,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -28722,7 +28722,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -28881,7 +28881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -28953,7 +28953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -28997,7 +28997,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -29156,7 +29156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -29315,7 +29315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -29474,7 +29474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -29633,7 +29633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -29647,7 +29647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -29806,7 +29806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -29965,7 +29965,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -30124,7 +30124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -30283,7 +30283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -30298,7 +30298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_APLLACR</name>
+               <name>APLLACR</name>
                <description>Audio PLL Analog Configuration Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -30324,7 +30324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WMST</name>
+               <name>WMST</name>
                <description>Wait Mode Startup Time Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -30371,7 +30371,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -30545,7 +30545,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -30578,7 +30578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -30611,7 +30611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -30644,7 +30644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -30701,7 +30701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -30758,7 +30758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -30815,7 +30815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -30872,7 +30872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -30940,7 +30940,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -30955,7 +30955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -30969,7 +30969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -30989,7 +30989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -31004,7 +31004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -31121,7 +31121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -31238,7 +31238,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -31355,7 +31355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -31472,7 +31472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -31528,7 +31528,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -31584,7 +31584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -31641,7 +31641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -31698,7 +31698,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -31755,7 +31755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -31812,7 +31812,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -31838,7 +31838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -31859,7 +31859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -31874,7 +31874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -31930,7 +31930,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -31964,7 +31964,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -32020,7 +32020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -32040,7 +32040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -32055,7 +32055,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -32087,7 +32087,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -32143,7 +32143,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32226,7 +32226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32319,7 +32319,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -32346,7 +32346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32366,7 +32366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32387,7 +32387,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32431,7 +32431,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32471,7 +32471,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register (ch_num = 0)</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register (ch_num = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -32613,7 +32613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register (ch_num = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -32627,7 +32627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register (ch_num = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -32642,7 +32642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register (ch_num = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -32656,7 +32656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register (ch_num = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -32671,7 +32671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register (ch_num = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -32686,7 +32686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register (ch_num = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -32706,7 +32706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register (ch_num = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -32728,7 +32728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -32749,7 +32749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -32770,7 +32770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -32850,7 +32850,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -32888,7 +32888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -32909,7 +32909,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -32989,7 +32989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -33027,7 +33027,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -33075,7 +33075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33108,7 +33108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33228,7 +33228,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33243,7 +33243,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33258,7 +33258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33315,7 +33315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33366,7 +33366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33417,7 +33417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33468,7 +33468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33500,7 +33500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -33514,7 +33514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -33534,7 +33534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -33712,7 +33712,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -33745,7 +33745,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -33760,7 +33760,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -33788,7 +33788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -33809,7 +33809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -33849,7 +33849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33884,7 +33884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33945,7 +33945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34004,7 +34004,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34033,7 +34033,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34083,7 +34083,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34117,7 +34117,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34190,7 +34190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34404,7 +34404,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34436,7 +34436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34474,7 +34474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34524,7 +34524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34556,7 +34556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34679,7 +34679,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34724,7 +34724,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34769,7 +34769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34814,7 +34814,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34859,7 +34859,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34892,7 +34892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -34932,7 +34932,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34976,7 +34976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34990,7 +34990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35005,7 +35005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -35045,7 +35045,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35097,7 +35097,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -35111,7 +35111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -35257,7 +35257,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35336,7 +35336,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35351,7 +35351,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35366,7 +35366,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35381,7 +35381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35396,7 +35396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35423,7 +35423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -35456,7 +35456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -35470,7 +35470,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35485,7 +35485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35500,7 +35500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_VERSION</name>
+               <name>VERSION</name>
                <description>SDRAMC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35542,7 +35542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register (CS_number = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register (CS_number = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -35574,7 +35574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register (CS_number = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -35606,7 +35606,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register (CS_number = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -35626,7 +35626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register (CS_number = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -35756,7 +35756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -35794,7 +35794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -35809,7 +35809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -35824,7 +35824,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35852,7 +35852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35873,7 +35873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_VERSION</name>
+               <name>VERSION</name>
                <description>SMC Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -35913,7 +35913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -35976,7 +35976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36032,7 +36032,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36053,7 +36053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36080,7 +36080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36137,7 +36137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36188,7 +36188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36239,7 +36239,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -36292,7 +36292,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register (CS_number = 0) 0</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -36396,7 +36396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36424,7 +36424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36445,7 +36445,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -36493,7 +36493,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -36532,7 +36532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -36546,7 +36546,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -36704,7 +36704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -36806,7 +36806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -36953,7 +36953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -37061,7 +37061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -37076,7 +37076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -37091,7 +37091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -37106,7 +37106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -37120,7 +37120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -37134,7 +37134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -37148,7 +37148,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -37217,7 +37217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -37274,7 +37274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -37331,7 +37331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -37388,7 +37388,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -37416,7 +37416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -37437,7 +37437,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -37477,7 +37477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -37538,7 +37538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -37624,7 +37624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -37728,7 +37728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wakeup Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -37938,7 +37938,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wakeup Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -38478,7 +38478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -38978,7 +38978,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -39005,7 +39005,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR</name>
+                  <name>CMR</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -39248,7 +39248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -39268,7 +39268,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -39283,7 +39283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -39298,7 +39298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -39312,7 +39312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -39326,7 +39326,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -39340,7 +39340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -39415,7 +39415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -39472,7 +39472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -39529,7 +39529,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -39586,7 +39586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -39639,7 +39639,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -39654,7 +39654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -39800,7 +39800,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -39827,7 +39827,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -39854,7 +39854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39881,7 +39881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -39914,7 +39914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -39934,7 +39934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39962,7 +39962,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -40050,7 +40050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40079,7 +40079,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40094,7 +40094,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -40109,7 +40109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -40124,7 +40124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -40139,7 +40139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -40154,7 +40154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -40194,7 +40194,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -40335,7 +40335,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -40384,7 +40384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -40452,7 +40452,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -40466,7 +40466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -40498,7 +40498,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -40621,7 +40621,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -40726,7 +40726,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -40831,7 +40831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -40936,7 +40936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40951,7 +40951,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -40966,7 +40966,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -40998,7 +40998,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -41030,7 +41030,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -41062,7 +41062,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_DR</name>
+               <name>DR</name>
                <description>Debug Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -41095,7 +41095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -41123,7 +41123,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -41144,7 +41144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_VER</name>
+               <name>VER</name>
                <description>Version Register</description>
                <addressOffset>0xFC</addressOffset>
                <size>32</size>
@@ -41200,7 +41200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -41263,7 +41263,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -41372,7 +41372,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -41423,7 +41423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -41474,7 +41474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -41525,7 +41525,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -41594,7 +41594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -41609,7 +41609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -41624,7 +41624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -41638,7 +41638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -41683,7 +41683,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41711,7 +41711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_VERSION</name>
+               <name>VERSION</name>
                <description>Version Register</description>
                <addressOffset>0x00FC</addressOffset>
                <size>32</size>
@@ -43308,7 +43308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -43399,7 +43399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -43552,7 +43552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -43603,7 +43603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -43696,7 +43696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -43849,7 +43849,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -44002,7 +44002,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -44155,7 +44155,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -44283,7 +44283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -44312,7 +44312,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register (n = 0) 0</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -44484,7 +44484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR[%s]</name>
+               <name>DEVEPTISR[%s]</name>
                <description>Device Endpoint Status Register (n = 0) 0</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -44649,7 +44649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR[%s]</name>
+               <name>DEVEPTICR[%s]</name>
                <description>Device Endpoint Clear Register (n = 0) 0</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -44708,7 +44708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR[%s]</name>
+               <name>DEVEPTIFR[%s]</name>
                <description>Device Endpoint Set Register (n = 0) 0</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -44773,7 +44773,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR[%s]</name>
+               <name>DEVEPTIMR[%s]</name>
                <description>Device Endpoint Mask Register (n = 0) 0</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -44874,7 +44874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER[%s]</name>
+               <name>DEVEPTIER[%s]</name>
                <description>Device Endpoint Enable Register (n = 0) 0</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -44975,7 +44975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR[%s]</name>
+               <name>DEVEPTIDR[%s]</name>
                <description>Device Endpoint Disable Register (n = 0) 0</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -45068,7 +45068,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -45082,7 +45082,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -45096,7 +45096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -45158,7 +45158,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -45203,7 +45203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -45258,7 +45258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -45411,7 +45411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -45462,7 +45462,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -45555,7 +45555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -45708,7 +45708,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -45861,7 +45861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -46014,7 +46014,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -46130,7 +46130,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -46156,7 +46156,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -46188,7 +46188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -46220,7 +46220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -46242,7 +46242,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register (n = 0) 0</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -46402,7 +46402,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR[%s]</name>
+               <name>HSTPIPISR[%s]</name>
                <description>Host Pipe Status Register (n = 0) 0</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -46551,7 +46551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR[%s]</name>
+               <name>HSTPIPICR[%s]</name>
                <description>Host Pipe Clear Register (n = 0) 0</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -46604,7 +46604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR[%s]</name>
+               <name>HSTPIPIFR[%s]</name>
                <description>Host Pipe Set Register (n = 0) 0</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -46669,7 +46669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR[%s]</name>
+               <name>HSTPIPIMR[%s]</name>
                <description>Host Pipe Mask Register (n = 0) 0</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -46758,7 +46758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER[%s]</name>
+               <name>HSTPIPIER[%s]</name>
                <description>Host Pipe Enable Register (n = 0) 0</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -46841,7 +46841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR[%s]</name>
+               <name>HSTPIPIDR[%s]</name>
                <description>Host Pipe Disable Register (n = 0) 0</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -46924,7 +46924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register (n = 0) 0</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -46946,7 +46946,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register (n = 0) 0</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -46996,7 +46996,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register (n = 1)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47010,7 +47010,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register (n = 1)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47024,7 +47024,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register (n = 1)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47086,7 +47086,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register (n = 1)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47131,7 +47131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -47188,7 +47188,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -47233,7 +47233,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -47248,7 +47248,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -47269,7 +47269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA1</name>
+               <name>TSTA1</name>
                <description>General Test A1 Register</description>
                <addressOffset>0x0810</addressOffset>
                <size>32</size>
@@ -47313,7 +47313,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_TSTA2</name>
+               <name>TSTA2</name>
                <description>General Test A2 Register</description>
                <addressOffset>0x0814</addressOffset>
                <size>32</size>
@@ -47375,7 +47375,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_VERSION</name>
+               <name>VERSION</name>
                <description>General Version Register</description>
                <addressOffset>0x0818</addressOffset>
                <size>32</size>
@@ -47396,7 +47396,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_FSM</name>
+               <name>FSM</name>
                <description>General Finite State Machine Register</description>
                <addressOffset>0x082C</addressOffset>
                <size>32</size>
@@ -47509,7 +47509,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -47540,7 +47540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -47586,7 +47586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47615,7 +47615,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47665,7 +47665,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47705,7 +47705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -47732,7 +47732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -47770,7 +47770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -47802,7 +47802,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -47955,7 +47955,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -48108,7 +48108,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -48261,7 +48261,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -48414,7 +48414,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -48567,7 +48567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -48720,7 +48720,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -48873,7 +48873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -49025,7 +49025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -49177,7 +49177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -49330,7 +49330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -49483,7 +49483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -49636,7 +49636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -49789,7 +49789,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -49948,7 +49948,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register (chid = 0)</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register (chid = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -49999,7 +49999,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register (chid = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -50050,7 +50050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register (chid = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -50101,7 +50101,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register (chid = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -50152,7 +50152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register (chid = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -50166,7 +50166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register (chid = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -50180,7 +50180,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register (chid = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -50200,7 +50200,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register (chid = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -50294,7 +50294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register (chid = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -50308,7 +50308,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register (chid = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -50322,7 +50322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register (chid = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -50652,7 +50652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern (chid = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -50672,7 +50672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride (chid = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -50686,7 +50686,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride (chid = 0)</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -50701,7 +50701,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>XDMAC_VERSION</name>
+               <name>VERSION</name>
                <description>XDMAC Version Register</description>
                <addressOffset>0xFFC</addressOffset>
                <size>32</size>
@@ -50734,7 +50734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -50934,7 +50934,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -51134,7 +51134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -51334,7 +51334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>

--- a/data/Atmel/ATSAMV71Q21B.svd
+++ b/data/Atmel/ATSAMV71Q21B.svd
@@ -59,7 +59,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -74,7 +74,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -280,7 +280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -295,7 +295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -310,7 +310,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -325,7 +325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -352,7 +352,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -385,7 +385,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -413,7 +413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -447,7 +447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AES_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -474,7 +474,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -660,7 +660,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -687,7 +687,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -714,7 +714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -741,7 +741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -809,7 +809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_KEYWR[%s]</name>
+               <name>KEYWR[%s]</name>
                <description>Key Word Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -826,7 +826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IDATAR[%s]</name>
+               <name>IDATAR[%s]</name>
                <description>Input Data Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -843,7 +843,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_ODATAR[%s]</name>
+               <name>ODATAR[%s]</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -860,7 +860,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_IVR[%s]</name>
+               <name>IVR[%s]</name>
                <description>Initialization Vector Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -875,7 +875,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_AADLENR</name>
+               <name>AADLENR</name>
                <description>Additional Authenticated Data Length Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -889,7 +889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CLENR</name>
+               <name>CLENR</name>
                <description>Plaintext/Ciphertext Length Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -905,7 +905,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GHASHR[%s]</name>
+               <name>GHASHR[%s]</name>
                <description>GCM Intermediate Hash Word Register</description>
                <addressOffset>0x78</addressOffset>
                <size>32</size>
@@ -921,7 +921,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_TAGR[%s]</name>
+               <name>TAGR[%s]</name>
                <description>GCM Authentication Tag Word Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -936,7 +936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AES_CTRR</name>
+               <name>CTRR</name>
                <description>GCM Encryption Counter Value Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -953,7 +953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>AES_GCMHR[%s]</name>
+               <name>GCMHR[%s]</name>
                <description>GCM H Word Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -986,7 +986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>AFEC_CR</name>
+               <name>CR</name>
                <description>AFEC Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -1007,7 +1007,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_MR</name>
+               <name>MR</name>
                <description>AFEC Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -1267,7 +1267,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_EMR</name>
+               <name>EMR</name>
                <description>AFEC Extended Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -1397,7 +1397,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ1R</name>
+               <name>SEQ1R</name>
                <description>AFEC Channel Sequence 1 Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -1453,7 +1453,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SEQ2R</name>
+               <name>SEQ2R</name>
                <description>AFEC Channel Sequence 2 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -1485,7 +1485,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHER</name>
+               <name>CHER</name>
                <description>AFEC Channel Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -1566,7 +1566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHDR</name>
+               <name>CHDR</name>
                <description>AFEC Channel Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -1647,7 +1647,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CHSR</name>
+               <name>CHSR</name>
                <description>AFEC Channel Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -1728,7 +1728,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_LCDR</name>
+               <name>LCDR</name>
                <description>AFEC Last Converted Data Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -1749,7 +1749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IER</name>
+               <name>IER</name>
                <description>AFEC Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -1854,7 +1854,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IDR</name>
+               <name>IDR</name>
                <description>AFEC Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -1959,7 +1959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_IMR</name>
+               <name>IMR</name>
                <description>AFEC Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -2064,7 +2064,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ISR</name>
+               <name>ISR</name>
                <description>AFEC Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -2169,7 +2169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_OVER</name>
+               <name>OVER</name>
                <description>AFEC Overrun Status Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -2250,7 +2250,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CWR</name>
+               <name>CWR</name>
                <description>AFEC Compare Window Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -2270,7 +2270,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CGR</name>
+               <name>CGR</name>
                <description>AFEC Channel Gain Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -2350,7 +2350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_DIFFR</name>
+               <name>DIFFR</name>
                <description>AFEC Channel Differential Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -2430,7 +2430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CSELR</name>
+               <name>CSELR</name>
                <description>AFEC Channel Selection Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -2444,7 +2444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CDR</name>
+               <name>CDR</name>
                <description>AFEC Channel Data Register</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -2459,7 +2459,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COCR</name>
+               <name>COCR</name>
                <description>AFEC Channel Offset Compensation Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -2473,7 +2473,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPMR</name>
+               <name>TEMPMR</name>
                <description>AFEC Temperature Sensor Mode Register</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -2516,7 +2516,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_TEMPCWR</name>
+               <name>TEMPCWR</name>
                <description>AFEC Temperature Compare Window Register</description>
                <addressOffset>0x74</addressOffset>
                <size>32</size>
@@ -2536,7 +2536,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_ACR</name>
+               <name>ACR</name>
                <description>AFEC Analog Control Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -2562,7 +2562,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_SHMR</name>
+               <name>SHMR</name>
                <description>AFEC Sample &amp; Hold Mode Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -2642,7 +2642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_COSR</name>
+               <name>COSR</name>
                <description>AFEC Correction Select Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -2656,7 +2656,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CVR</name>
+               <name>CVR</name>
                <description>AFEC Correction Values Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -2676,7 +2676,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_CECR</name>
+               <name>CECR</name>
                <description>AFEC Channel Error Correction Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -2756,7 +2756,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPMR</name>
+               <name>WPMR</name>
                <description>AFEC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -2784,7 +2784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>AFEC_WPSR</name>
+               <name>WPSR</name>
                <description>AFEC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -2828,7 +2828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>CHIPID_CIDR</name>
+               <name>CIDR</name>
                <description>Chip ID Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -3173,7 +3173,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>CHIPID_EXID</name>
+               <name>EXID</name>
                <description>Chip ID Extension Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -3207,7 +3207,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>DACC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -3222,7 +3222,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -3318,7 +3318,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_TRIGR</name>
+               <name>TRIGR</name>
                <description>Trigger Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -3540,7 +3540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHER</name>
+               <name>CHER</name>
                <description>Channel Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -3561,7 +3561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHDR</name>
+               <name>CHDR</name>
                <description>Channel Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -3582,7 +3582,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_CHSR</name>
+               <name>CHSR</name>
                <description>Channel Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -3617,7 +3617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>DACC_CDR[%s]</name>
+               <name>CDR[%s]</name>
                <description>Conversion Data Register 0</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -3638,7 +3638,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -3671,7 +3671,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -3704,7 +3704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -3737,7 +3737,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -3770,7 +3770,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_ACR</name>
+               <name>ACR</name>
                <description>Analog Current Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -3790,7 +3790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -3818,7 +3818,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>DACC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -4172,7 +4172,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>GMAC_NCR</name>
+               <name>NCR</name>
                <description>Network Control Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -4282,7 +4282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NCFGR</name>
+               <name>NCFGR</name>
                <description>Network Configuration Register</description>
                <addressOffset>0x004</addressOffset>
                <size>32</size>
@@ -4461,7 +4461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSR</name>
+               <name>NSR</name>
                <description>Network Status Register</description>
                <addressOffset>0x008</addressOffset>
                <size>32</size>
@@ -4488,7 +4488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UR</name>
+               <name>UR</name>
                <description>User Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -4502,7 +4502,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DCFGR</name>
+               <name>DCFGR</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x010</addressOffset>
                <size>32</size>
@@ -4604,7 +4604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSR</name>
+               <name>TSR</name>
                <description>Transmit Status Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -4654,7 +4654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RBQB</name>
+               <name>RBQB</name>
                <description>Receive Buffer Queue Base Address Register</description>
                <addressOffset>0x018</addressOffset>
                <size>32</size>
@@ -4668,7 +4668,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBQB</name>
+               <name>TBQB</name>
                <description>Transmit Buffer Queue Base Address Register</description>
                <addressOffset>0x01C</addressOffset>
                <size>32</size>
@@ -4682,7 +4682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSR</name>
+               <name>RSR</name>
                <description>Receive Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -4714,7 +4714,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -4873,7 +4873,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x028</addressOffset>
                <size>32</size>
@@ -5038,7 +5038,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -5203,7 +5203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x030</addressOffset>
                <size>32</size>
@@ -5367,7 +5367,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MAN</name>
+               <name>MAN</name>
                <description>PHY Maintenance Register</description>
                <addressOffset>0x034</addressOffset>
                <size>32</size>
@@ -5417,7 +5417,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPQ</name>
+               <name>RPQ</name>
                <description>Received Pause Quantum Register</description>
                <addressOffset>0x038</addressOffset>
                <size>32</size>
@@ -5432,7 +5432,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPQ</name>
+               <name>TPQ</name>
                <description>Transmit Pause Quantum Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -5446,7 +5446,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPSF</name>
+               <name>TPSF</name>
                <description>TX Partial Store and Forward Register</description>
                <addressOffset>0x040</addressOffset>
                <size>32</size>
@@ -5466,7 +5466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RPSF</name>
+               <name>RPSF</name>
                <description>RX Partial Store and Forward Register</description>
                <addressOffset>0x044</addressOffset>
                <size>32</size>
@@ -5486,7 +5486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RJFML</name>
+               <name>RJFML</name>
                <description>RX Jumbo Frame Max Length Register</description>
                <addressOffset>0x048</addressOffset>
                <size>32</size>
@@ -5500,7 +5500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRB</name>
+               <name>HRB</name>
                <description>Hash Register Bottom</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -5514,7 +5514,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_HRT</name>
+               <name>HRT</name>
                <description>Hash Register Top</description>
                <addressOffset>0x084</addressOffset>
                <size>32</size>
@@ -5535,7 +5535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Specific Address 1 Bottom Register</description>
                <addressOffset>0x088</addressOffset>
                <register>
-                  <name>GMAC_SAB</name>
+                  <name>SAB</name>
                   <description>Specific Address 1 Bottom Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -5549,7 +5549,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_SAT</name>
+                  <name>SAT</name>
                   <description>Specific Address 1 Top Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -5564,7 +5564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>GMAC_TIDM1</name>
+               <name>TIDM1</name>
                <description>Type ID Match 1 Register</description>
                <addressOffset>0x0A8</addressOffset>
                <size>32</size>
@@ -5584,7 +5584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM2</name>
+               <name>TIDM2</name>
                <description>Type ID Match 2 Register</description>
                <addressOffset>0x0AC</addressOffset>
                <size>32</size>
@@ -5604,7 +5604,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM3</name>
+               <name>TIDM3</name>
                <description>Type ID Match 3 Register</description>
                <addressOffset>0x0B0</addressOffset>
                <size>32</size>
@@ -5624,7 +5624,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TIDM4</name>
+               <name>TIDM4</name>
                <description>Type ID Match 4 Register</description>
                <addressOffset>0x0B4</addressOffset>
                <size>32</size>
@@ -5644,7 +5644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_WOL</name>
+               <name>WOL</name>
                <description>Wake on LAN Register</description>
                <addressOffset>0x0B8</addressOffset>
                <size>32</size>
@@ -5682,7 +5682,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IPGS</name>
+               <name>IPGS</name>
                <description>IPG Stretch Register</description>
                <addressOffset>0x0BC</addressOffset>
                <size>32</size>
@@ -5696,7 +5696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SVLAN</name>
+               <name>SVLAN</name>
                <description>Stacked VLAN Register</description>
                <addressOffset>0x0C0</addressOffset>
                <size>32</size>
@@ -5716,7 +5716,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TPFCP</name>
+               <name>TPFCP</name>
                <description>Transmit PFC Pause Register</description>
                <addressOffset>0x0C4</addressOffset>
                <size>32</size>
@@ -5736,7 +5736,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMB1</name>
+               <name>SAMB1</name>
                <description>Specific Address 1 Mask Bottom Register</description>
                <addressOffset>0x0C8</addressOffset>
                <size>32</size>
@@ -5750,7 +5750,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SAMT1</name>
+               <name>SAMT1</name>
                <description>Specific Address 1 Mask Top Register</description>
                <addressOffset>0x0CC</addressOffset>
                <size>32</size>
@@ -5764,7 +5764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_NSC</name>
+               <name>NSC</name>
                <description>1588 Timer Nanosecond Comparison Register</description>
                <addressOffset>0x0DC</addressOffset>
                <size>32</size>
@@ -5778,7 +5778,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCL</name>
+               <name>SCL</name>
                <description>1588 Timer Second Comparison Low Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -5792,7 +5792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCH</name>
+               <name>SCH</name>
                <description>1588 Timer Second Comparison High Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -5806,7 +5806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSH</name>
+               <name>EFTSH</name>
                <description>PTP Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0E8</addressOffset>
                <size>32</size>
@@ -5821,7 +5821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSH</name>
+               <name>EFRSH</name>
                <description>PTP Event Frame Received Seconds High Register</description>
                <addressOffset>0x0EC</addressOffset>
                <size>32</size>
@@ -5836,7 +5836,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSH</name>
+               <name>PEFTSH</name>
                <description>PTP Peer Event Frame Transmitted Seconds High Register</description>
                <addressOffset>0x0F0</addressOffset>
                <size>32</size>
@@ -5851,7 +5851,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSH</name>
+               <name>PEFRSH</name>
                <description>PTP Peer Event Frame Received Seconds High Register</description>
                <addressOffset>0x0F4</addressOffset>
                <size>32</size>
@@ -5866,7 +5866,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTLO</name>
+               <name>OTLO</name>
                <description>Octets Transmitted Low Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -5881,7 +5881,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OTHI</name>
+               <name>OTHI</name>
                <description>Octets Transmitted High Register</description>
                <addressOffset>0x104</addressOffset>
                <size>32</size>
@@ -5896,7 +5896,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FT</name>
+               <name>FT</name>
                <description>Frames Transmitted Register</description>
                <addressOffset>0x108</addressOffset>
                <size>32</size>
@@ -5911,7 +5911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFT</name>
+               <name>BCFT</name>
                <description>Broadcast Frames Transmitted Register</description>
                <addressOffset>0x10C</addressOffset>
                <size>32</size>
@@ -5926,7 +5926,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFT</name>
+               <name>MFT</name>
                <description>Multicast Frames Transmitted Register</description>
                <addressOffset>0x110</addressOffset>
                <size>32</size>
@@ -5941,7 +5941,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFT</name>
+               <name>PFT</name>
                <description>Pause Frames Transmitted Register</description>
                <addressOffset>0x114</addressOffset>
                <size>32</size>
@@ -5956,7 +5956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFT64</name>
+               <name>BFT64</name>
                <description>64 Byte Frames Transmitted Register</description>
                <addressOffset>0x118</addressOffset>
                <size>32</size>
@@ -5971,7 +5971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT127</name>
+               <name>TBFT127</name>
                <description>65 to 127 Byte Frames Transmitted Register</description>
                <addressOffset>0x11C</addressOffset>
                <size>32</size>
@@ -5986,7 +5986,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT255</name>
+               <name>TBFT255</name>
                <description>128 to 255 Byte Frames Transmitted Register</description>
                <addressOffset>0x120</addressOffset>
                <size>32</size>
@@ -6001,7 +6001,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT511</name>
+               <name>TBFT511</name>
                <description>256 to 511 Byte Frames Transmitted Register</description>
                <addressOffset>0x124</addressOffset>
                <size>32</size>
@@ -6016,7 +6016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1023</name>
+               <name>TBFT1023</name>
                <description>512 to 1023 Byte Frames Transmitted Register</description>
                <addressOffset>0x128</addressOffset>
                <size>32</size>
@@ -6031,7 +6031,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFT1518</name>
+               <name>TBFT1518</name>
                <description>1024 to 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x12C</addressOffset>
                <size>32</size>
@@ -6046,7 +6046,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_GTBFT1518</name>
+               <name>GTBFT1518</name>
                <description>Greater Than 1518 Byte Frames Transmitted Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -6061,7 +6061,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TUR</name>
+               <name>TUR</name>
                <description>Transmit Underruns Register</description>
                <addressOffset>0x134</addressOffset>
                <size>32</size>
@@ -6076,7 +6076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_SCF</name>
+               <name>SCF</name>
                <description>Single Collision Frames Register</description>
                <addressOffset>0x138</addressOffset>
                <size>32</size>
@@ -6091,7 +6091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MCF</name>
+               <name>MCF</name>
                <description>Multiple Collision Frames Register</description>
                <addressOffset>0x13C</addressOffset>
                <size>32</size>
@@ -6106,7 +6106,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EC</name>
+               <name>EC</name>
                <description>Excessive Collisions Register</description>
                <addressOffset>0x140</addressOffset>
                <size>32</size>
@@ -6121,7 +6121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LC</name>
+               <name>LC</name>
                <description>Late Collisions Register</description>
                <addressOffset>0x144</addressOffset>
                <size>32</size>
@@ -6136,7 +6136,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_DTF</name>
+               <name>DTF</name>
                <description>Deferred Transmission Frames Register</description>
                <addressOffset>0x148</addressOffset>
                <size>32</size>
@@ -6151,7 +6151,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CSE</name>
+               <name>CSE</name>
                <description>Carrier Sense Errors Register</description>
                <addressOffset>0x14C</addressOffset>
                <size>32</size>
@@ -6166,7 +6166,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORLO</name>
+               <name>ORLO</name>
                <description>Octets Received Low Received Register</description>
                <addressOffset>0x150</addressOffset>
                <size>32</size>
@@ -6181,7 +6181,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ORHI</name>
+               <name>ORHI</name>
                <description>Octets Received High Received Register</description>
                <addressOffset>0x154</addressOffset>
                <size>32</size>
@@ -6196,7 +6196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FR</name>
+               <name>FR</name>
                <description>Frames Received Register</description>
                <addressOffset>0x158</addressOffset>
                <size>32</size>
@@ -6211,7 +6211,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BCFR</name>
+               <name>BCFR</name>
                <description>Broadcast Frames Received Register</description>
                <addressOffset>0x15C</addressOffset>
                <size>32</size>
@@ -6226,7 +6226,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_MFR</name>
+               <name>MFR</name>
                <description>Multicast Frames Received Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -6241,7 +6241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PFR</name>
+               <name>PFR</name>
                <description>Pause Frames Received Register</description>
                <addressOffset>0x164</addressOffset>
                <size>32</size>
@@ -6256,7 +6256,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_BFR64</name>
+               <name>BFR64</name>
                <description>64 Byte Frames Received Register</description>
                <addressOffset>0x168</addressOffset>
                <size>32</size>
@@ -6271,7 +6271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR127</name>
+               <name>TBFR127</name>
                <description>65 to 127 Byte Frames Received Register</description>
                <addressOffset>0x16C</addressOffset>
                <size>32</size>
@@ -6286,7 +6286,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR255</name>
+               <name>TBFR255</name>
                <description>128 to 255 Byte Frames Received Register</description>
                <addressOffset>0x170</addressOffset>
                <size>32</size>
@@ -6301,7 +6301,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR511</name>
+               <name>TBFR511</name>
                <description>256 to 511 Byte Frames Received Register</description>
                <addressOffset>0x174</addressOffset>
                <size>32</size>
@@ -6316,7 +6316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1023</name>
+               <name>TBFR1023</name>
                <description>512 to 1023 Byte Frames Received Register</description>
                <addressOffset>0x178</addressOffset>
                <size>32</size>
@@ -6331,7 +6331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TBFR1518</name>
+               <name>TBFR1518</name>
                <description>1024 to 1518 Byte Frames Received Register</description>
                <addressOffset>0x17C</addressOffset>
                <size>32</size>
@@ -6346,7 +6346,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TMXBFR</name>
+               <name>TMXBFR</name>
                <description>1519 to Maximum Byte Frames Received Register</description>
                <addressOffset>0x180</addressOffset>
                <size>32</size>
@@ -6361,7 +6361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UFR</name>
+               <name>UFR</name>
                <description>Undersize Frames Received Register</description>
                <addressOffset>0x184</addressOffset>
                <size>32</size>
@@ -6376,7 +6376,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_OFR</name>
+               <name>OFR</name>
                <description>Oversize Frames Received Register</description>
                <addressOffset>0x188</addressOffset>
                <size>32</size>
@@ -6391,7 +6391,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_JR</name>
+               <name>JR</name>
                <description>Jabbers Received Register</description>
                <addressOffset>0x18C</addressOffset>
                <size>32</size>
@@ -6406,7 +6406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_FCSE</name>
+               <name>FCSE</name>
                <description>Frame Check Sequence Errors Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -6421,7 +6421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_LFFE</name>
+               <name>LFFE</name>
                <description>Length Field Frame Errors Register</description>
                <addressOffset>0x194</addressOffset>
                <size>32</size>
@@ -6436,7 +6436,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RSE</name>
+               <name>RSE</name>
                <description>Receive Symbol Errors Register</description>
                <addressOffset>0x198</addressOffset>
                <size>32</size>
@@ -6451,7 +6451,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_AE</name>
+               <name>AE</name>
                <description>Alignment Errors Register</description>
                <addressOffset>0x19C</addressOffset>
                <size>32</size>
@@ -6466,7 +6466,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RRE</name>
+               <name>RRE</name>
                <description>Receive Resource Errors Register</description>
                <addressOffset>0x1A0</addressOffset>
                <size>32</size>
@@ -6481,7 +6481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_ROE</name>
+               <name>ROE</name>
                <description>Receive Overrun Register</description>
                <addressOffset>0x1A4</addressOffset>
                <size>32</size>
@@ -6496,7 +6496,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_IHCE</name>
+               <name>IHCE</name>
                <description>IP Header Checksum Errors Register</description>
                <addressOffset>0x1A8</addressOffset>
                <size>32</size>
@@ -6511,7 +6511,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TCE</name>
+               <name>TCE</name>
                <description>TCP Checksum Errors Register</description>
                <addressOffset>0x1AC</addressOffset>
                <size>32</size>
@@ -6526,7 +6526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_UCE</name>
+               <name>UCE</name>
                <description>UDP Checksum Errors Register</description>
                <addressOffset>0x1B0</addressOffset>
                <size>32</size>
@@ -6541,7 +6541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TISUBN</name>
+               <name>TISUBN</name>
                <description>1588 Timer Increment Sub-nanoseconds Register</description>
                <addressOffset>0x1BC</addressOffset>
                <size>32</size>
@@ -6555,7 +6555,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSH</name>
+               <name>TSH</name>
                <description>1588 Timer Seconds High Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -6569,7 +6569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TSL</name>
+               <name>TSL</name>
                <description>1588 Timer Seconds Low Register</description>
                <addressOffset>0x1D0</addressOffset>
                <size>32</size>
@@ -6583,7 +6583,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TN</name>
+               <name>TN</name>
                <description>1588 Timer Nanoseconds Register</description>
                <addressOffset>0x1D4</addressOffset>
                <size>32</size>
@@ -6597,7 +6597,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TA</name>
+               <name>TA</name>
                <description>1588 Timer Adjust Register</description>
                <addressOffset>0x1D8</addressOffset>
                <size>32</size>
@@ -6618,7 +6618,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TI</name>
+               <name>TI</name>
                <description>1588 Timer Increment Register</description>
                <addressOffset>0x1DC</addressOffset>
                <size>32</size>
@@ -6644,7 +6644,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTSL</name>
+               <name>EFTSL</name>
                <description>PTP Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1E0</addressOffset>
                <size>32</size>
@@ -6659,7 +6659,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFTN</name>
+               <name>EFTN</name>
                <description>PTP Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1E4</addressOffset>
                <size>32</size>
@@ -6674,7 +6674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRSL</name>
+               <name>EFRSL</name>
                <description>PTP Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1E8</addressOffset>
                <size>32</size>
@@ -6689,7 +6689,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_EFRN</name>
+               <name>EFRN</name>
                <description>PTP Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1EC</addressOffset>
                <size>32</size>
@@ -6704,7 +6704,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTSL</name>
+               <name>PEFTSL</name>
                <description>PTP Peer Event Frame Transmitted Seconds Low Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -6719,7 +6719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFTN</name>
+               <name>PEFTN</name>
                <description>PTP Peer Event Frame Transmitted Nanoseconds Register</description>
                <addressOffset>0x1F4</addressOffset>
                <size>32</size>
@@ -6734,7 +6734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRSL</name>
+               <name>PEFRSL</name>
                <description>PTP Peer Event Frame Received Seconds Low Register</description>
                <addressOffset>0x1F8</addressOffset>
                <size>32</size>
@@ -6749,7 +6749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_PEFRN</name>
+               <name>PEFRN</name>
                <description>PTP Peer Event Frame Received Nanoseconds Register</description>
                <addressOffset>0x1FC</addressOffset>
                <size>32</size>
@@ -6764,7 +6764,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPI</name>
+               <name>RXLPI</name>
                <description>Received LPI Transitions</description>
                <addressOffset>0x270</addressOffset>
                <size>32</size>
@@ -6779,7 +6779,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_RXLPITIME</name>
+               <name>RXLPITIME</name>
                <description>Received LPI Time</description>
                <addressOffset>0x274</addressOffset>
                <size>32</size>
@@ -6794,7 +6794,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPI</name>
+               <name>TXLPI</name>
                <description>Transmit LPI Transitions</description>
                <addressOffset>0x278</addressOffset>
                <size>32</size>
@@ -6809,7 +6809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_TXLPITIME</name>
+               <name>TXLPITIME</name>
                <description>Transmit LPI Time</description>
                <addressOffset>0x27C</addressOffset>
                <size>32</size>
@@ -6826,7 +6826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ISRPQ[%s]</name>
+               <name>ISRPQ[%s]</name>
                <description>Interrupt Status Register Priority Queue (1..5)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -6879,7 +6879,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_TBQBAPQ[%s]</name>
+               <name>TBQBAPQ[%s]</name>
                <description>Transmit Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -6895,7 +6895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBQBAPQ[%s]</name>
+               <name>RBQBAPQ[%s]</name>
                <description>Receive Buffer Queue Base Address Register Priority Queue (1..5)</description>
                <addressOffset>0x480</addressOffset>
                <size>32</size>
@@ -6911,7 +6911,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_RBSRPQ[%s]</name>
+               <name>RBSRPQ[%s]</name>
                <description>Receive Buffer Size Register Priority Queue (1..5)</description>
                <addressOffset>0x4A0</addressOffset>
                <size>32</size>
@@ -6925,7 +6925,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSCR</name>
+               <name>CBSCR</name>
                <description>Credit-Based Shaping Control Register</description>
                <addressOffset>0x4BC</addressOffset>
                <size>32</size>
@@ -6945,7 +6945,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQA</name>
+               <name>CBSISQA</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue A</description>
                <addressOffset>0x4C0</addressOffset>
                <size>32</size>
@@ -6959,7 +6959,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>GMAC_CBSISQB</name>
+               <name>CBSISQB</name>
                <description>Credit-Based Shaping IdleSlope Register for Queue B</description>
                <addressOffset>0x4C4</addressOffset>
                <size>32</size>
@@ -6975,7 +6975,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST1RPQ[%s]</name>
+               <name>ST1RPQ[%s]</name>
                <description>Screening Type 1 Register Priority Queue</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -7015,7 +7015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2RPQ[%s]</name>
+               <name>ST2RPQ[%s]</name>
                <description>Screening Type 2 Register Priority Queue</description>
                <addressOffset>0x540</addressOffset>
                <size>32</size>
@@ -7091,7 +7091,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IERPQ[%s]</name>
+               <name>IERPQ[%s]</name>
                <description>Interrupt Enable Register Priority Queue (1..5)</description>
                <addressOffset>0x600</addressOffset>
                <size>32</size>
@@ -7144,7 +7144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IDRPQ[%s]</name>
+               <name>IDRPQ[%s]</name>
                <description>Interrupt Disable Register Priority Queue (1..5)</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -7197,7 +7197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>5</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_IMRPQ[%s]</name>
+               <name>IMRPQ[%s]</name>
                <description>Interrupt Mask Register Priority Queue (1..5)</description>
                <addressOffset>0x640</addressOffset>
                <size>32</size>
@@ -7249,7 +7249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>GMAC_ST2ER[%s]</name>
+               <name>ST2ER[%s]</name>
                <description>Screening Type 2 Ethertype Register</description>
                <addressOffset>0x6E0</addressOffset>
                <size>32</size>
@@ -7269,7 +7269,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Screening Type 2 Compare Word 0 Register</description>
                <addressOffset>0x700</addressOffset>
                <register>
-                  <name>GMAC_ST2CW0</name>
+                  <name>ST2CW0</name>
                   <description>Screening Type 2 Compare Word 0 Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -7289,7 +7289,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>GMAC_ST2CW1</name>
+                  <name>ST2CW1</name>
                   <description>Screening Type 2 Compare Word 1 Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -7383,7 +7383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>HSMCI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -7422,7 +7422,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -7472,7 +7472,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DTOR</name>
+               <name>DTOR</name>
                <description>Data Timeout Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -7535,7 +7535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SDCR</name>
+               <name>SDCR</name>
                <description>SD/SDIO Card Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -7581,7 +7581,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_ARGR</name>
+               <name>ARGR</name>
                <description>Argument Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -7595,7 +7595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CMDR</name>
+               <name>CMDR</name>
                <description>Command Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -7852,7 +7852,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_BLKR</name>
+               <name>BLKR</name>
                <description>Block Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -7872,7 +7872,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CSTOR</name>
+               <name>CSTOR</name>
                <description>Completion Signal Timeout Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -7937,7 +7937,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_RSPR[%s]</name>
+               <name>RSPR[%s]</name>
                <description>Response Register 0</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -7952,7 +7952,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -7967,7 +7967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -7982,7 +7982,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -8135,7 +8135,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -8288,7 +8288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -8441,7 +8441,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -8594,7 +8594,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_DMA</name>
+               <name>DMA</name>
                <description>DMA Configuration Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -8642,7 +8642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -8674,7 +8674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -8702,7 +8702,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>HSMCI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -8725,7 +8725,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>256</dim>
                <dimIncrement>4</dimIncrement>
-               <name>HSMCI_FIFO[%s]</name>
+               <name>FIFO[%s]</name>
                <description>FIFO Memory Aperture0 0</description>
                <addressOffset>0x200</addressOffset>
                <size>32</size>
@@ -8758,7 +8758,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>I2SC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -8809,7 +8809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9008,7 +9008,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9065,7 +9065,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SCR</name>
+               <name>SCR</name>
                <description>Status Clear Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9098,7 +9098,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_SSR</name>
+               <name>SSR</name>
                <description>Status Set Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9131,7 +9131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9164,7 +9164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9197,7 +9197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9230,7 +9230,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_RHR</name>
+               <name>RHR</name>
                <description>Receiver Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9245,7 +9245,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>I2SC_THR</name>
+               <name>THR</name>
                <description>Transmitter Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -9287,7 +9287,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ICM_CFG</name>
+               <name>CFG</name>
                <description>Configuration Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9361,7 +9361,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_CTRL</name>
+               <name>CTRL</name>
                <description>Control Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9406,7 +9406,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9433,7 +9433,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -9484,7 +9484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -9535,7 +9535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -9586,7 +9586,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -9637,7 +9637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_UASR</name>
+               <name>UASR</name>
                <description>Undefined Access Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -9680,7 +9680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_DSCR</name>
+               <name>DSCR</name>
                <description>Region Descriptor Area Start Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -9694,7 +9694,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ICM_HASH</name>
+               <name>HASH</name>
                <description>Region Hash Area Start Address Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -9710,7 +9710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>ICM_UIHVAL[%s]</name>
+               <name>UIHVAL[%s]</name>
                <description>User Initial Hash Value 0 Register 0</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -9744,7 +9744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>ISI_CFG1</name>
+               <name>CFG1</name>
                <description>ISI Configuration 1 Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -9842,7 +9842,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CFG2</name>
+               <name>CFG2</name>
                <description>ISI Configuration 2 Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -9950,7 +9950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PSIZE</name>
+               <name>PSIZE</name>
                <description>ISI Preview Size Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -9970,7 +9970,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_PDECF</name>
+               <name>PDECF</name>
                <description>ISI Preview Decimation Factor Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -9984,7 +9984,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET0</name>
+               <name>Y2R_SET0</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 0 Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -10016,7 +10016,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_Y2R_SET1</name>
+               <name>Y2R_SET1</name>
                <description>ISI Color Space Conversion YCrCb To RGB Set 1 Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -10048,7 +10048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET0</name>
+               <name>R2Y_SET0</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 0 Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -10080,7 +10080,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET1</name>
+               <name>R2Y_SET1</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 1 Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -10112,7 +10112,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_R2Y_SET2</name>
+               <name>R2Y_SET2</name>
                <description>ISI Color Space Conversion RGB To YCrCb Set 2 Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -10144,7 +10144,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_CR</name>
+               <name>CR</name>
                <description>ISI Control Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -10177,7 +10177,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_SR</name>
+               <name>SR</name>
                <description>ISI Status Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -10258,7 +10258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IER</name>
+               <name>IER</name>
                <description>ISI Interrupt Enable Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -10321,7 +10321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IDR</name>
+               <name>IDR</name>
                <description>ISI Interrupt Disable Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -10384,7 +10384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_IMR</name>
+               <name>IMR</name>
                <description>ISI Interrupt Mask Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -10447,7 +10447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHER</name>
+               <name>DMA_CHER</name>
                <description>DMA Channel Enable Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -10468,7 +10468,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHDR</name>
+               <name>DMA_CHDR</name>
                <description>DMA Channel Disable Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -10489,7 +10489,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_CHSR</name>
+               <name>DMA_CHSR</name>
                <description>DMA Channel Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10510,7 +10510,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_ADDR</name>
+               <name>DMA_P_ADDR</name>
                <description>DMA Preview Base Address Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -10524,7 +10524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_CTRL</name>
+               <name>DMA_P_CTRL</name>
                <description>DMA Preview Control Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -10556,7 +10556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_P_DSCR</name>
+               <name>DMA_P_DSCR</name>
                <description>DMA Preview Descriptor Address Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -10570,7 +10570,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_ADDR</name>
+               <name>DMA_C_ADDR</name>
                <description>DMA Codec Base Address Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -10584,7 +10584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_CTRL</name>
+               <name>DMA_C_CTRL</name>
                <description>DMA Codec Control Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -10616,7 +10616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_DMA_C_DSCR</name>
+               <name>DMA_C_DSCR</name>
                <description>DMA Codec Descriptor Address Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -10630,7 +10630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -10658,7 +10658,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>ISI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -10696,7 +10696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>13</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_MCFG[%s]</name>
+               <name>MCFG[%s]</name>
                <description>Master Configuration Register 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -10755,7 +10755,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>9</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MATRIX_SCFG[%s]</name>
+               <name>SCFG[%s]</name>
                <description>Slave Configuration Register 0</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -10805,7 +10805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Priority Register A for Slave 0</description>
                <addressOffset>0x0080</addressOffset>
                <register>
-                  <name>MATRIX_PRAS</name>
+                  <name>PRAS</name>
                   <description>Priority Register A for Slave 0</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -10861,7 +10861,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>MATRIX_PRBS</name>
+                  <name>PRBS</name>
                   <description>Priority Register B for Slave 0</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -10900,7 +10900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>MATRIX_MRCR</name>
+               <name>MRCR</name>
                <description>Master Remap Control Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -11134,7 +11134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x01E4</addressOffset>
                <size>32</size>
@@ -11162,7 +11162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MATRIX_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x01E8</addressOffset>
                <size>32</size>
@@ -11206,7 +11206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MCAN_CREL</name>
+               <name>CREL</name>
                <description>Core Release Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -11251,7 +11251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ENDN</name>
+               <name>ENDN</name>
                <description>Endian Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -11266,7 +11266,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CUST</name>
+               <name>CUST</name>
                <description>Customer Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -11280,7 +11280,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_DBTP</name>
+               <name>DBTP</name>
                <description>Data Bit Timing and Prescaler Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -11331,7 +11331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TEST</name>
+               <name>TEST</name>
                <description>Test Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -11393,7 +11393,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RWD</name>
+               <name>RWD</name>
                <description>RAM Watchdog Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -11413,7 +11413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_CCCR</name>
+               <name>CCCR</name>
                <description>CC Control Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -11622,7 +11622,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NBTP</name>
+               <name>NBTP</name>
                <description>Nominal Bit Timing and Prescaler Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -11654,7 +11654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCC</name>
+               <name>TSCC</name>
                <description>Timestamp Counter Configuration Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -11692,7 +11692,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TSCV</name>
+               <name>TSCV</name>
                <description>Timestamp Counter Value Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -11706,7 +11706,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCC</name>
+               <name>TOCC</name>
                <description>Timeout Counter Configuration Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -11768,7 +11768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TOCV</name>
+               <name>TOCV</name>
                <description>Timeout Counter Value Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -11782,7 +11782,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ECR</name>
+               <name>ECR</name>
                <description>Error Counter Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -11815,7 +11815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_PSR</name>
+               <name>PSR</name>
                <description>Protocol Status Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -11956,7 +11956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TDCR</name>
+               <name>TDCR</name>
                <description>Transmit Delay Compensation Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -11976,7 +11976,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IR</name>
+               <name>IR</name>
                <description>Interrupt Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -12152,7 +12152,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_IE</name>
+               <name>IE</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -12328,7 +12328,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILS</name>
+               <name>ILS</name>
                <description>Interrupt Line Select Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -12504,7 +12504,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_ILE</name>
+               <name>ILE</name>
                <description>Interrupt Line Enable Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -12524,7 +12524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_GFC</name>
+               <name>GFC</name>
                <description>Global Filter Configuration Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -12608,7 +12608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_SIDFC</name>
+               <name>SIDFC</name>
                <description>Standard ID Filter Configuration Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -12628,7 +12628,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDFC</name>
+               <name>XIDFC</name>
                <description>Extended ID Filter Configuration Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -12648,7 +12648,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_XIDAM</name>
+               <name>XIDAM</name>
                <description>Extended ID AND Mask Register</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -12662,7 +12662,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_HPMS</name>
+               <name>HPMS</name>
                <description>High Priority Message Status Register</description>
                <addressOffset>0x94</addressOffset>
                <size>32</size>
@@ -12718,7 +12718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT1</name>
+               <name>NDAT1</name>
                <description>New Data 1 Register</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -12918,7 +12918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_NDAT2</name>
+               <name>NDAT2</name>
                <description>New Data 2 Register</description>
                <addressOffset>0x9C</addressOffset>
                <size>32</size>
@@ -13118,7 +13118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0C</name>
+               <name>RXF0C</name>
                <description>Receive FIFO 0 Configuration Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -13150,7 +13150,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0S</name>
+               <name>RXF0S</name>
                <description>Receive FIFO 0 Status Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -13189,7 +13189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF0A</name>
+               <name>RXF0A</name>
                <description>Receive FIFO 0 Acknowledge Register</description>
                <addressOffset>0xA8</addressOffset>
                <size>32</size>
@@ -13203,7 +13203,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXBC</name>
+               <name>RXBC</name>
                <description>Receive Rx Buffer Configuration Register</description>
                <addressOffset>0xAC</addressOffset>
                <size>32</size>
@@ -13217,7 +13217,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1C</name>
+               <name>RXF1C</name>
                <description>Receive FIFO 1 Configuration Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -13249,7 +13249,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1S</name>
+               <name>RXF1S</name>
                <description>Receive FIFO 1 Status Register</description>
                <addressOffset>0xB4</addressOffset>
                <size>32</size>
@@ -13317,7 +13317,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXF1A</name>
+               <name>RXF1A</name>
                <description>Receive FIFO 1 Acknowledge Register</description>
                <addressOffset>0xB8</addressOffset>
                <size>32</size>
@@ -13331,7 +13331,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_RXESC</name>
+               <name>RXESC</name>
                <description>Receive Buffer / FIFO Element Size Configuration Register</description>
                <addressOffset>0xBC</addressOffset>
                <size>32</size>
@@ -13486,7 +13486,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBC</name>
+               <name>TXBC</name>
                <description>Transmit Buffer Configuration Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -13518,7 +13518,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXFQS</name>
+               <name>TXFQS</name>
                <description>Transmit FIFO/Queue Status Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -13551,7 +13551,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXESC</name>
+               <name>TXESC</name>
                <description>Transmit Buffer Element Size Configuration Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -13608,7 +13608,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBRP</name>
+               <name>TXBRP</name>
                <description>Transmit Buffer Request Pending Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -13809,7 +13809,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBAR</name>
+               <name>TXBAR</name>
                <description>Transmit Buffer Add Request Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -14009,7 +14009,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCR</name>
+               <name>TXBCR</name>
                <description>Transmit Buffer Cancellation Request Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -14209,7 +14209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTO</name>
+               <name>TXBTO</name>
                <description>Transmit Buffer Transmission Occurred Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -14410,7 +14410,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCF</name>
+               <name>TXBCF</name>
                <description>Transmit Buffer Cancellation Finished Register</description>
                <addressOffset>0xDC</addressOffset>
                <size>32</size>
@@ -14611,7 +14611,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBTIE</name>
+               <name>TXBTIE</name>
                <description>Transmit Buffer Transmission Interrupt Enable Register</description>
                <addressOffset>0xE0</addressOffset>
                <size>32</size>
@@ -14811,7 +14811,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXBCIE</name>
+               <name>TXBCIE</name>
                <description>Transmit Buffer Cancellation Finished Interrupt Enable Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -15011,7 +15011,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFC</name>
+               <name>TXEFC</name>
                <description>Transmit Event FIFO Configuration Register</description>
                <addressOffset>0xF0</addressOffset>
                <size>32</size>
@@ -15037,7 +15037,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFS</name>
+               <name>TXEFS</name>
                <description>Transmit Event FIFO Status Register</description>
                <addressOffset>0xF4</addressOffset>
                <size>32</size>
@@ -15076,7 +15076,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MCAN_TXEFA</name>
+               <name>TXEFA</name>
                <description>Transmit Event FIFO Acknowledge Register</description>
                <addressOffset>0xF8</addressOffset>
                <size>32</size>
@@ -15121,7 +15121,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>MLB_MLBC0</name>
+               <name>MLBC0</name>
                <description>MediaLB Control 0 Register</description>
                <addressOffset>0x000</addressOffset>
                <size>32</size>
@@ -15227,7 +15227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS0</name>
+               <name>MS0</name>
                <description>MediaLB Channel Status 0 Register</description>
                <addressOffset>0x00C</addressOffset>
                <size>32</size>
@@ -15241,7 +15241,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MS1</name>
+               <name>MS1</name>
                <description>MediaLB Channel Status1 Register</description>
                <addressOffset>0x014</addressOffset>
                <size>32</size>
@@ -15255,7 +15255,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSS</name>
+               <name>MSS</name>
                <description>MediaLB System Status Register</description>
                <addressOffset>0x020</addressOffset>
                <size>32</size>
@@ -15299,7 +15299,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MSD</name>
+               <name>MSD</name>
                <description>MediaLB System Data Register</description>
                <addressOffset>0x024</addressOffset>
                <size>32</size>
@@ -15332,7 +15332,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MIEN</name>
+               <name>MIEN</name>
                <description>MediaLB Interrupt Enable Register</description>
                <addressOffset>0x02C</addressOffset>
                <size>32</size>
@@ -15430,7 +15430,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MLBC1</name>
+               <name>MLBC1</name>
                <description>MediaLB Control 1 Register</description>
                <addressOffset>0x03C</addressOffset>
                <size>32</size>
@@ -15456,7 +15456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_HCTL</name>
+               <name>HCTL</name>
                <description>HBI Control Register</description>
                <addressOffset>0x080</addressOffset>
                <size>32</size>
@@ -15484,7 +15484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCMR[%s]</name>
+               <name>HCMR[%s]</name>
                <description>HBI Channel Mask 0 Register 0</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -15500,7 +15500,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCER[%s]</name>
+               <name>HCER[%s]</name>
                <description>HBI Channel Error 0 Register 0</description>
                <addressOffset>0x90</addressOffset>
                <size>32</size>
@@ -15517,7 +15517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_HCBR[%s]</name>
+               <name>HCBR[%s]</name>
                <description>HBI Channel Busy 0 Register 0</description>
                <addressOffset>0x98</addressOffset>
                <size>32</size>
@@ -15534,7 +15534,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDAT[%s]</name>
+               <name>MDAT[%s]</name>
                <description>MIF Data 0 Register 0</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -15550,7 +15550,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_MDWE[%s]</name>
+               <name>MDWE[%s]</name>
                <description>MIF Data Write Enable 0 Register 0</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -15564,7 +15564,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MCTL</name>
+               <name>MCTL</name>
                <description>MIF Control Register</description>
                <addressOffset>0x0E0</addressOffset>
                <size>32</size>
@@ -15578,7 +15578,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_MADR</name>
+               <name>MADR</name>
                <description>MIF Address Register</description>
                <addressOffset>0x0E4</addressOffset>
                <size>32</size>
@@ -15617,7 +15617,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>MLB_ACTL</name>
+               <name>ACTL</name>
                <description>AHB Control Register</description>
                <addressOffset>0x3C0</addressOffset>
                <size>32</size>
@@ -15664,7 +15664,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACSR[%s]</name>
+               <name>ACSR[%s]</name>
                <description>AHB Channel Status 0 Register 0</description>
                <addressOffset>0x3D0</addressOffset>
                <size>32</size>
@@ -15680,7 +15680,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>MLB_ACMR[%s]</name>
+               <name>ACMR[%s]</name>
                <description>AHB Channel Mask 0 Register 0</description>
                <addressOffset>0x3D8</addressOffset>
                <size>32</size>
@@ -15713,7 +15713,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PIO_PER</name>
+               <name>PER</name>
                <description>PIO Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -15914,7 +15914,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDR</name>
+               <name>PDR</name>
                <description>PIO Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -16115,7 +16115,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PSR</name>
+               <name>PSR</name>
                <description>PIO Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -16316,7 +16316,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OER</name>
+               <name>OER</name>
                <description>Output Enable Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -16517,7 +16517,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODR</name>
+               <name>ODR</name>
                <description>Output Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -16718,7 +16718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OSR</name>
+               <name>OSR</name>
                <description>Output Status Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -16919,7 +16919,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFER</name>
+               <name>IFER</name>
                <description>Glitch Input Filter Enable Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -17120,7 +17120,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFDR</name>
+               <name>IFDR</name>
                <description>Glitch Input Filter Disable Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -17321,7 +17321,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSR</name>
+               <name>IFSR</name>
                <description>Glitch Input Filter Status Register</description>
                <addressOffset>0x0028</addressOffset>
                <size>32</size>
@@ -17522,7 +17522,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SODR</name>
+               <name>SODR</name>
                <description>Set Output Data Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -17723,7 +17723,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_CODR</name>
+               <name>CODR</name>
                <description>Clear Output Data Register</description>
                <addressOffset>0x0034</addressOffset>
                <size>32</size>
@@ -17924,7 +17924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ODSR</name>
+               <name>ODSR</name>
                <description>Output Data Status Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -18124,7 +18124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PDSR</name>
+               <name>PDSR</name>
                <description>Pin Data Status Register</description>
                <addressOffset>0x003C</addressOffset>
                <size>32</size>
@@ -18325,7 +18325,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0040</addressOffset>
                <size>32</size>
@@ -18526,7 +18526,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0044</addressOffset>
                <size>32</size>
@@ -18727,7 +18727,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0048</addressOffset>
                <size>32</size>
@@ -18928,7 +18928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x004C</addressOffset>
                <size>32</size>
@@ -19129,7 +19129,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDER</name>
+               <name>MDER</name>
                <description>Multi-driver Enable Register</description>
                <addressOffset>0x0050</addressOffset>
                <size>32</size>
@@ -19330,7 +19330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDDR</name>
+               <name>MDDR</name>
                <description>Multi-driver Disable Register</description>
                <addressOffset>0x0054</addressOffset>
                <size>32</size>
@@ -19531,7 +19531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_MDSR</name>
+               <name>MDSR</name>
                <description>Multi-driver Status Register</description>
                <addressOffset>0x0058</addressOffset>
                <size>32</size>
@@ -19732,7 +19732,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUDR</name>
+               <name>PUDR</name>
                <description>Pull-up Disable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -19933,7 +19933,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUER</name>
+               <name>PUER</name>
                <description>Pull-up Enable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -20134,7 +20134,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PUSR</name>
+               <name>PUSR</name>
                <description>Pad Pull-up Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -20337,7 +20337,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PIO_ABCDSR[%s]</name>
+               <name>ABCDSR[%s]</name>
                <description>Peripheral ABCD Select Register 0</description>
                <addressOffset>0x70</addressOffset>
                <size>32</size>
@@ -20537,7 +20537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCDR</name>
+               <name>IFSCDR</name>
                <description>Input Filter Slow Clock Disable Register</description>
                <addressOffset>0x0080</addressOffset>
                <size>32</size>
@@ -20738,7 +20738,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCER</name>
+               <name>IFSCER</name>
                <description>Input Filter Slow Clock Enable Register</description>
                <addressOffset>0x0084</addressOffset>
                <size>32</size>
@@ -20939,7 +20939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_IFSCSR</name>
+               <name>IFSCSR</name>
                <description>Input Filter Slow Clock Status Register</description>
                <addressOffset>0x0088</addressOffset>
                <size>32</size>
@@ -21140,7 +21140,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCDR</name>
+               <name>SCDR</name>
                <description>Slow Clock Divider Debouncing Register</description>
                <addressOffset>0x008C</addressOffset>
                <size>32</size>
@@ -21154,7 +21154,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDDR</name>
+               <name>PPDDR</name>
                <description>Pad Pull-down Disable Register</description>
                <addressOffset>0x0090</addressOffset>
                <size>32</size>
@@ -21355,7 +21355,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDER</name>
+               <name>PPDER</name>
                <description>Pad Pull-down Enable Register</description>
                <addressOffset>0x0094</addressOffset>
                <size>32</size>
@@ -21556,7 +21556,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PPDSR</name>
+               <name>PPDSR</name>
                <description>Pad Pull-down Status Register</description>
                <addressOffset>0x0098</addressOffset>
                <size>32</size>
@@ -21757,7 +21757,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWER</name>
+               <name>OWER</name>
                <description>Output Write Enable</description>
                <addressOffset>0x00A0</addressOffset>
                <size>32</size>
@@ -21958,7 +21958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWDR</name>
+               <name>OWDR</name>
                <description>Output Write Disable</description>
                <addressOffset>0x00A4</addressOffset>
                <size>32</size>
@@ -22159,7 +22159,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_OWSR</name>
+               <name>OWSR</name>
                <description>Output Write Status Register</description>
                <addressOffset>0x00A8</addressOffset>
                <size>32</size>
@@ -22360,7 +22360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMER</name>
+               <name>AIMER</name>
                <description>Additional Interrupt Modes Enable Register</description>
                <addressOffset>0x00B0</addressOffset>
                <size>32</size>
@@ -22561,7 +22561,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMDR</name>
+               <name>AIMDR</name>
                <description>Additional Interrupt Modes Disable Register</description>
                <addressOffset>0x00B4</addressOffset>
                <size>32</size>
@@ -22762,7 +22762,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_AIMMR</name>
+               <name>AIMMR</name>
                <description>Additional Interrupt Modes Mask Register</description>
                <addressOffset>0x00B8</addressOffset>
                <size>32</size>
@@ -22963,7 +22963,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ESR</name>
+               <name>ESR</name>
                <description>Edge Select Register</description>
                <addressOffset>0x00C0</addressOffset>
                <size>32</size>
@@ -23164,7 +23164,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LSR</name>
+               <name>LSR</name>
                <description>Level Select Register</description>
                <addressOffset>0x00C4</addressOffset>
                <size>32</size>
@@ -23365,7 +23365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_ELSR</name>
+               <name>ELSR</name>
                <description>Edge/Level Status Register</description>
                <addressOffset>0x00C8</addressOffset>
                <size>32</size>
@@ -23566,7 +23566,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FELLSR</name>
+               <name>FELLSR</name>
                <description>Falling Edge/Low-Level Select Register</description>
                <addressOffset>0x00D0</addressOffset>
                <size>32</size>
@@ -23767,7 +23767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_REHLSR</name>
+               <name>REHLSR</name>
                <description>Rising Edge/High-Level Select Register</description>
                <addressOffset>0x00D4</addressOffset>
                <size>32</size>
@@ -23968,7 +23968,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_FRLHSR</name>
+               <name>FRLHSR</name>
                <description>Fall/Rise - Low/High Status Register</description>
                <addressOffset>0x00D8</addressOffset>
                <size>32</size>
@@ -24169,7 +24169,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_LOCKSR</name>
+               <name>LOCKSR</name>
                <description>Lock Status</description>
                <addressOffset>0x00E0</addressOffset>
                <size>32</size>
@@ -24370,7 +24370,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -24398,7 +24398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -24419,7 +24419,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_SCHMITT</name>
+               <name>SCHMITT</name>
                <description>Schmitt Trigger Register</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -24619,7 +24619,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_DRIVER</name>
+               <name>DRIVER</name>
                <description>I/O Drive Register</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -25235,7 +25235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCMR</name>
+               <name>PCMR</name>
                <description>Parallel Capture Mode Register</description>
                <addressOffset>0x0150</addressOffset>
                <size>32</size>
@@ -25291,7 +25291,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIER</name>
+               <name>PCIER</name>
                <description>Parallel Capture Interrupt Enable Register</description>
                <addressOffset>0x0154</addressOffset>
                <size>32</size>
@@ -25324,7 +25324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIDR</name>
+               <name>PCIDR</name>
                <description>Parallel Capture Interrupt Disable Register</description>
                <addressOffset>0x0158</addressOffset>
                <size>32</size>
@@ -25357,7 +25357,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCIMR</name>
+               <name>PCIMR</name>
                <description>Parallel Capture Interrupt Mask Register</description>
                <addressOffset>0x015C</addressOffset>
                <size>32</size>
@@ -25390,7 +25390,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCISR</name>
+               <name>PCISR</name>
                <description>Parallel Capture Interrupt Status Register</description>
                <addressOffset>0x0160</addressOffset>
                <size>32</size>
@@ -25411,7 +25411,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PIO_PCRHR</name>
+               <name>PCRHR</name>
                <description>Parallel Capture Reception Holding Register</description>
                <addressOffset>0x0164</addressOffset>
                <size>32</size>
@@ -25477,7 +25477,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PMC_SCER</name>
+               <name>SCER</name>
                <description>System Clock Enable Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -25540,7 +25540,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCDR</name>
+               <name>SCDR</name>
                <description>System Clock Disable Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -25603,7 +25603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SCSR</name>
+               <name>SCSR</name>
                <description>System Clock Status Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -25672,7 +25672,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER0</name>
+               <name>PCER0</name>
                <description>Peripheral Clock Enable Register 0</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -25831,7 +25831,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR0</name>
+               <name>PCDR0</name>
                <description>Peripheral Clock Disable Register 0</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -25990,7 +25990,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR0</name>
+               <name>PCSR0</name>
                <description>Peripheral Clock Status Register 0</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -26340,7 +26340,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_MCKR</name>
+               <name>MCKR</name>
                <description>Master Clock Register</description>
                <addressOffset>0x0030</addressOffset>
                <size>32</size>
@@ -26461,7 +26461,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_USB</name>
+               <name>USB</name>
                <description>USB Clock Register</description>
                <addressOffset>0x0038</addressOffset>
                <size>32</size>
@@ -26483,7 +26483,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>8</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PMC_PCK[%s]</name>
+               <name>PCK[%s]</name>
                <description>Programmable Clock Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -26531,7 +26531,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0060</addressOffset>
                <size>32</size>
@@ -26636,7 +26636,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x0064</addressOffset>
                <size>32</size>
@@ -26741,7 +26741,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0068</addressOffset>
                <size>32</size>
@@ -26864,7 +26864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x006C</addressOffset>
                <size>32</size>
@@ -26969,7 +26969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSMR</name>
+               <name>FSMR</name>
                <description>Fast Startup Mode Register</description>
                <addressOffset>0x0070</addressOffset>
                <size>32</size>
@@ -27127,7 +27127,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FSPR</name>
+               <name>FSPR</name>
                <description>Fast Startup Polarity Register</description>
                <addressOffset>0x0074</addressOffset>
                <size>32</size>
@@ -27231,7 +27231,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_FOCR</name>
+               <name>FOCR</name>
                <description>Fault Output Clear Register</description>
                <addressOffset>0x0078</addressOffset>
                <size>32</size>
@@ -27246,7 +27246,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -27274,7 +27274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0x00E8</addressOffset>
                <size>32</size>
@@ -27295,7 +27295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCER1</name>
+               <name>PCER1</name>
                <description>Peripheral Clock Enable Register 1</description>
                <addressOffset>0x0100</addressOffset>
                <size>32</size>
@@ -27454,7 +27454,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCDR1</name>
+               <name>PCDR1</name>
                <description>Peripheral Clock Disable Register 1</description>
                <addressOffset>0x0104</addressOffset>
                <size>32</size>
@@ -27613,7 +27613,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCSR1</name>
+               <name>PCSR1</name>
                <description>Peripheral Clock Status Register 1</description>
                <addressOffset>0x0108</addressOffset>
                <size>32</size>
@@ -27772,7 +27772,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PCR</name>
+               <name>PCR</name>
                <description>Peripheral Control Register</description>
                <addressOffset>0x010C</addressOffset>
                <size>32</size>
@@ -27844,7 +27844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_OCR</name>
+               <name>OCR</name>
                <description>Oscillator Calibration Register</description>
                <addressOffset>0x0110</addressOffset>
                <size>32</size>
@@ -27888,7 +27888,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER0</name>
+               <name>SLPWK_ER0</name>
                <description>SleepWalking Enable Register 0</description>
                <addressOffset>0x0114</addressOffset>
                <size>32</size>
@@ -28047,7 +28047,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR0</name>
+               <name>SLPWK_DR0</name>
                <description>SleepWalking Disable Register 0</description>
                <addressOffset>0x0118</addressOffset>
                <size>32</size>
@@ -28206,7 +28206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR0</name>
+               <name>SLPWK_SR0</name>
                <description>SleepWalking Status Register 0</description>
                <addressOffset>0x011C</addressOffset>
                <size>32</size>
@@ -28365,7 +28365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR0</name>
+               <name>SLPWK_ASR0</name>
                <description>SleepWalking Activity Status Register 0</description>
                <addressOffset>0x0120</addressOffset>
                <size>32</size>
@@ -28524,7 +28524,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_PMMR</name>
+               <name>PMMR</name>
                <description>PLL Maximum Multiplier Value Register</description>
                <addressOffset>0x0130</addressOffset>
                <size>32</size>
@@ -28538,7 +28538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ER1</name>
+               <name>SLPWK_ER1</name>
                <description>SleepWalking Enable Register 1</description>
                <addressOffset>0x0134</addressOffset>
                <size>32</size>
@@ -28697,7 +28697,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_DR1</name>
+               <name>SLPWK_DR1</name>
                <description>SleepWalking Disable Register 1</description>
                <addressOffset>0x0138</addressOffset>
                <size>32</size>
@@ -28856,7 +28856,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_SR1</name>
+               <name>SLPWK_SR1</name>
                <description>SleepWalking Status Register 1</description>
                <addressOffset>0x013C</addressOffset>
                <size>32</size>
@@ -29015,7 +29015,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_ASR1</name>
+               <name>SLPWK_ASR1</name>
                <description>SleepWalking Activity Status Register 1</description>
                <addressOffset>0x0140</addressOffset>
                <size>32</size>
@@ -29174,7 +29174,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PMC_SLPWK_AIPR</name>
+               <name>SLPWK_AIPR</name>
                <description>SleepWalking Activity In Progress Register</description>
                <addressOffset>0x0144</addressOffset>
                <size>32</size>
@@ -29208,7 +29208,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>PWM_CLK</name>
+               <name>CLK</name>
                <description>PWM Clock Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -29382,7 +29382,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ENA</name>
+               <name>ENA</name>
                <description>PWM Enable Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -29415,7 +29415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DIS</name>
+               <name>DIS</name>
                <description>PWM Disable Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -29448,7 +29448,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SR</name>
+               <name>SR</name>
                <description>PWM Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -29481,7 +29481,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER1</name>
+               <name>IER1</name>
                <description>PWM Interrupt Enable Register 1</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -29538,7 +29538,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR1</name>
+               <name>IDR1</name>
                <description>PWM Interrupt Disable Register 1</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -29595,7 +29595,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR1</name>
+               <name>IMR1</name>
                <description>PWM Interrupt Mask Register 1</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -29652,7 +29652,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR1</name>
+               <name>ISR1</name>
                <description>PWM Interrupt Status Register 1</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -29709,7 +29709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCM</name>
+               <name>SCM</name>
                <description>PWM Sync Channels Mode Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -29777,7 +29777,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_DMAR</name>
+               <name>DMAR</name>
                <description>PWM DMA Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -29792,7 +29792,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUC</name>
+               <name>SCUC</name>
                <description>PWM Sync Channels Update Control Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -29806,7 +29806,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUP</name>
+               <name>SCUP</name>
                <description>PWM Sync Channels Update Period Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -29826,7 +29826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SCUPUPD</name>
+               <name>SCUPUPD</name>
                <description>PWM Sync Channels Update Period Update Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -29841,7 +29841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IER2</name>
+               <name>IER2</name>
                <description>PWM Interrupt Enable Register 2</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -29958,7 +29958,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IDR2</name>
+               <name>IDR2</name>
                <description>PWM Interrupt Disable Register 2</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -30075,7 +30075,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_IMR2</name>
+               <name>IMR2</name>
                <description>PWM Interrupt Mask Register 2</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -30192,7 +30192,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ISR2</name>
+               <name>ISR2</name>
                <description>PWM Interrupt Status Register 2</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -30309,7 +30309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OOV</name>
+               <name>OOV</name>
                <description>PWM Output Override Value Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -30365,7 +30365,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OS</name>
+               <name>OS</name>
                <description>PWM Output Selection Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -30421,7 +30421,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSS</name>
+               <name>OSS</name>
                <description>PWM Output Selection Set Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -30478,7 +30478,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSC</name>
+               <name>OSC</name>
                <description>PWM Output Selection Clear Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -30535,7 +30535,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSSUPD</name>
+               <name>OSSUPD</name>
                <description>PWM Output Selection Set Update Register</description>
                <addressOffset>0x54</addressOffset>
                <size>32</size>
@@ -30592,7 +30592,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_OSCUPD</name>
+               <name>OSCUPD</name>
                <description>PWM Output Selection Clear Update Register</description>
                <addressOffset>0x58</addressOffset>
                <size>32</size>
@@ -30649,7 +30649,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FMR</name>
+               <name>FMR</name>
                <description>PWM Fault Mode Register</description>
                <addressOffset>0x5C</addressOffset>
                <size>32</size>
@@ -30675,7 +30675,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FSR</name>
+               <name>FSR</name>
                <description>PWM Fault Status Register</description>
                <addressOffset>0x60</addressOffset>
                <size>32</size>
@@ -30696,7 +30696,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FCR</name>
+               <name>FCR</name>
                <description>PWM Fault Clear Register</description>
                <addressOffset>0x64</addressOffset>
                <size>32</size>
@@ -30711,7 +30711,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV1</name>
+               <name>FPV1</name>
                <description>PWM Fault Protection Value Register 1</description>
                <addressOffset>0x68</addressOffset>
                <size>32</size>
@@ -30767,7 +30767,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPE</name>
+               <name>FPE</name>
                <description>PWM Fault Protection Enable Register</description>
                <addressOffset>0x6C</addressOffset>
                <size>32</size>
@@ -30801,7 +30801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>2</dim>
                <dimIncrement>4</dimIncrement>
-               <name>PWM_ELMR[%s]</name>
+               <name>ELMR[%s]</name>
                <description>PWM Event Line 0 Mode Register 0</description>
                <addressOffset>0x7C</addressOffset>
                <size>32</size>
@@ -30857,7 +30857,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPR</name>
+               <name>SSPR</name>
                <description>PWM Spread Spectrum Register</description>
                <addressOffset>0xA0</addressOffset>
                <size>32</size>
@@ -30877,7 +30877,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SSPUP</name>
+               <name>SSPUP</name>
                <description>PWM Spread Spectrum Update Register</description>
                <addressOffset>0xA4</addressOffset>
                <size>32</size>
@@ -30892,7 +30892,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_SMMR</name>
+               <name>SMMR</name>
                <description>PWM Stepper Motor Mode Register</description>
                <addressOffset>0xB0</addressOffset>
                <size>32</size>
@@ -30924,7 +30924,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_FPV2</name>
+               <name>FPV2</name>
                <description>PWM Fault Protection Value 2 Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -30980,7 +30980,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPCR</name>
+               <name>WPCR</name>
                <description>PWM Write Protection Control Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -31063,7 +31063,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_WPSR</name>
+               <name>WPSR</name>
                <description>PWM Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -31162,7 +31162,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Comparison 0 Value Register</description>
                <addressOffset>0x130</addressOffset>
                <register>
-                  <name>PWM_CMPV</name>
+                  <name>CMPV</name>
                   <description>PWM Comparison 0 Value Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31195,7 +31195,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPVUPD</name>
+                  <name>CMPVUPD</name>
                   <description>PWM Comparison 0 Value Update Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31216,7 +31216,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPM</name>
+                  <name>CMPM</name>
                   <description>PWM Comparison 0 Mode Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31260,7 +31260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CMPMUPD</name>
+                  <name>CMPMUPD</name>
                   <description>PWM Comparison 0 Mode Update Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31300,7 +31300,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>PWM Channel Mode Register</description>
                <addressOffset>0x200</addressOffset>
                <register>
-                  <name>PWM_CMR</name>
+                  <name>CMR</name>
                   <description>PWM Channel Mode Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -31494,7 +31494,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTY</name>
+                  <name>CDTY</name>
                   <description>PWM Channel Duty Cycle Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -31508,7 +31508,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CDTYUPD</name>
+                  <name>CDTYUPD</name>
                   <description>PWM Channel Duty Cycle Update Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -31523,7 +31523,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRD</name>
+                  <name>CPRD</name>
                   <description>PWM Channel Period Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -31537,7 +31537,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CPRDUPD</name>
+                  <name>CPRDUPD</name>
                   <description>PWM Channel Period Update Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -31552,7 +31552,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_CCNT</name>
+                  <name>CCNT</name>
                   <description>PWM Channel Counter Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -31567,7 +31567,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DT</name>
+                  <name>DT</name>
                   <description>PWM Channel Dead Time Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -31587,7 +31587,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>PWM_DTUPD</name>
+                  <name>DTUPD</name>
                   <description>PWM Channel Dead Time Update Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -31609,7 +31609,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>PWM_CMUPD0</name>
+               <name>CMUPD0</name>
                <description>PWM Channel Mode Update Register (ch_num = 0)</description>
                <addressOffset>0x400</addressOffset>
                <size>32</size>
@@ -31630,7 +31630,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD1</name>
+               <name>CMUPD1</name>
                <description>PWM Channel Mode Update Register (ch_num = 1)</description>
                <addressOffset>0x420</addressOffset>
                <size>32</size>
@@ -31651,7 +31651,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG1</name>
+               <name>ETRG1</name>
                <description>PWM External Trigger Register (trg_num = 1)</description>
                <addressOffset>0x42C</addressOffset>
                <size>32</size>
@@ -31731,7 +31731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR1</name>
+               <name>LEBR1</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 1)</description>
                <addressOffset>0x430</addressOffset>
                <size>32</size>
@@ -31769,7 +31769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD2</name>
+               <name>CMUPD2</name>
                <description>PWM Channel Mode Update Register (ch_num = 2)</description>
                <addressOffset>0x440</addressOffset>
                <size>32</size>
@@ -31790,7 +31790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_ETRG2</name>
+               <name>ETRG2</name>
                <description>PWM External Trigger Register (trg_num = 2)</description>
                <addressOffset>0x44C</addressOffset>
                <size>32</size>
@@ -31870,7 +31870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_LEBR2</name>
+               <name>LEBR2</name>
                <description>PWM Leading-Edge Blanking Register (trg_num = 2)</description>
                <addressOffset>0x450</addressOffset>
                <size>32</size>
@@ -31908,7 +31908,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>PWM_CMUPD3</name>
+               <name>CMUPD3</name>
                <description>PWM Channel Mode Update Register (ch_num = 3)</description>
                <addressOffset>0x460</addressOffset>
                <size>32</size>
@@ -31956,7 +31956,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>QSPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -31989,7 +31989,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32109,7 +32109,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32124,7 +32124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -32139,7 +32139,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -32196,7 +32196,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -32247,7 +32247,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -32298,7 +32298,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -32349,7 +32349,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SCR</name>
+               <name>SCR</name>
                <description>Serial Clock Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -32381,7 +32381,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IAR</name>
+               <name>IAR</name>
                <description>Instruction Address Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -32395,7 +32395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_ICR</name>
+               <name>ICR</name>
                <description>Instruction Code Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -32415,7 +32415,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_IFR</name>
+               <name>IFR</name>
                <description>Instruction Frame Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -32593,7 +32593,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SMR</name>
+               <name>SMR</name>
                <description>Scrambling Mode Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -32626,7 +32626,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_SKR</name>
+               <name>SKR</name>
                <description>Scrambling Key Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -32641,7 +32641,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -32669,7 +32669,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>QSPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -32709,7 +32709,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32744,7 +32744,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32805,7 +32805,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32864,7 +32864,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RSWDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -32893,7 +32893,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -32943,7 +32943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RSWDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -32977,7 +32977,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33050,7 +33050,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33264,7 +33264,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMR</name>
+               <name>TIMR</name>
                <description>Time Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33296,7 +33296,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALR</name>
+               <name>CALR</name>
                <description>Calendar Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33334,7 +33334,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_TIMALR</name>
+               <name>TIMALR</name>
                <description>Time Alarm Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -33384,7 +33384,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_CALALR</name>
+               <name>CALALR</name>
                <description>Calendar Alarm Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -33416,7 +33416,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -33539,7 +33539,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_SCCR</name>
+               <name>SCCR</name>
                <description>Status Clear Command Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -33584,7 +33584,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -33629,7 +33629,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -33674,7 +33674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -33719,7 +33719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTC_VER</name>
+               <name>VER</name>
                <description>Valid Entry Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -33771,7 +33771,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>RTT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33815,7 +33815,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_AR</name>
+               <name>AR</name>
                <description>Alarm Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33829,7 +33829,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_VR</name>
+               <name>VR</name>
                <description>Value Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -33844,7 +33844,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>RTT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -33884,7 +33884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SDRAMC_MR</name>
+               <name>MR</name>
                <description>SDRAMC Mode Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -33936,7 +33936,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_TR</name>
+               <name>TR</name>
                <description>SDRAMC Refresh Timer Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -33950,7 +33950,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CR</name>
+               <name>CR</name>
                <description>SDRAMC Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34096,7 +34096,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_LPR</name>
+               <name>LPR</name>
                <description>SDRAMC Low Power Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34175,7 +34175,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IER</name>
+               <name>IER</name>
                <description>SDRAMC Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -34190,7 +34190,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IDR</name>
+               <name>IDR</name>
                <description>SDRAMC Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -34205,7 +34205,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_IMR</name>
+               <name>IMR</name>
                <description>SDRAMC Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -34220,7 +34220,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_ISR</name>
+               <name>ISR</name>
                <description>SDRAMC Interrupt Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -34235,7 +34235,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_MDR</name>
+               <name>MDR</name>
                <description>SDRAMC Memory Device Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -34262,7 +34262,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_CFR1</name>
+               <name>CFR1</name>
                <description>SDRAMC Configuration Register 1</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -34295,7 +34295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS</name>
+               <name>OCMS</name>
                <description>SDRAMC OCMS Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -34309,7 +34309,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY1</name>
+               <name>OCMS_KEY1</name>
                <description>SDRAMC OCMS KEY1 Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -34324,7 +34324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SDRAMC_OCMS_KEY2</name>
+               <name>OCMS_KEY2</name>
                <description>SDRAMC OCMS KEY2 Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -34360,7 +34360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>SMC Setup Register</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>SMC_SETUP</name>
+                  <name>SETUP</name>
                   <description>SMC Setup Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -34392,7 +34392,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_PULSE</name>
+                  <name>PULSE</name>
                   <description>SMC Pulse Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -34424,7 +34424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_CYCLE</name>
+                  <name>CYCLE</name>
                   <description>SMC Cycle Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -34444,7 +34444,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>SMC_MODE</name>
+                  <name>MODE</name>
                   <description>SMC Mode Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -34574,7 +34574,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>SMC_OCMS</name>
+               <name>OCMS</name>
                <description>SMC Off-Chip Memory Scrambling Register</description>
                <addressOffset>0x80</addressOffset>
                <size>32</size>
@@ -34612,7 +34612,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY1</name>
+               <name>KEY1</name>
                <description>SMC Off-Chip Memory Scrambling KEY1 Register</description>
                <addressOffset>0x84</addressOffset>
                <size>32</size>
@@ -34627,7 +34627,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_KEY2</name>
+               <name>KEY2</name>
                <description>SMC Off-Chip Memory Scrambling KEY2 Register</description>
                <addressOffset>0x88</addressOffset>
                <size>32</size>
@@ -34642,7 +34642,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPMR</name>
+               <name>WPMR</name>
                <description>SMC Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -34670,7 +34670,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SMC_WPSR</name>
+               <name>WPSR</name>
                <description>SMC Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -34710,7 +34710,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SPI_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -34749,7 +34749,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -34841,7 +34841,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_RDR</name>
+               <name>RDR</name>
                <description>Receive Data Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -34862,7 +34862,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_TDR</name>
+               <name>TDR</name>
                <description>Transmit Data Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -34912,7 +34912,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -34969,7 +34969,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35020,7 +35020,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35071,7 +35071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35124,7 +35124,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>4</dim>
                <dimIncrement>4</dimIncrement>
-               <name>SPI_CSR[%s]</name>
+               <name>CSR[%s]</name>
                <description>Chip Select Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35157,12 +35157,12 @@ Copyright (c) 2017 Microchip Technology Inc.
                         <name>NCPHASelect</name>
                         <enumeratedValue>
                            <name>VALID_LEADING_EDGE</name>
-                           <description>Data is valid on clock leading edge (CPHA=0)</description>
+                           <description>Data is valid on clock leading edge (NCPHA=1)</description>
                            <value>0x1</value>
                         </enumeratedValue>
                         <enumeratedValue>
                            <name>VALID_TRAILING_EDGE</name>
-                           <description>Data is valid on clock trailing edge (CPHA=1)</description>
+                           <description>Data is valid on clock trailing edge (NCPHA=0)</description>
                            <value>0x0</value>
                         </enumeratedValue>
                      </enumeratedValues>
@@ -35254,7 +35254,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -35282,7 +35282,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SPI_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -35330,7 +35330,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SSC_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -35369,7 +35369,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_CMR</name>
+               <name>CMR</name>
                <description>Clock Mode Register</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -35383,7 +35383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RCMR</name>
+               <name>RCMR</name>
                <description>Receive Clock Mode Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -35541,7 +35541,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RFMR</name>
+               <name>RFMR</name>
                <description>Receive Frame Mode Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -35643,7 +35643,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TCMR</name>
+               <name>TCMR</name>
                <description>Transmit Clock Mode Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -35790,7 +35790,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TFMR</name>
+               <name>TFMR</name>
                <description>Transmit Frame Mode Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -35898,7 +35898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -35913,7 +35913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -35928,7 +35928,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RSHR</name>
+               <name>RSHR</name>
                <description>Receive Sync. Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -35943,7 +35943,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_TSHR</name>
+               <name>TSHR</name>
                <description>Transmit Sync. Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -35957,7 +35957,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC0R</name>
+               <name>RC0R</name>
                <description>Receive Compare 0 Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -35971,7 +35971,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_RC1R</name>
+               <name>RC1R</name>
                <description>Receive Compare 1 Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -35985,7 +35985,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -36054,7 +36054,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -36111,7 +36111,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x48</addressOffset>
                <size>32</size>
@@ -36168,7 +36168,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -36225,7 +36225,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -36253,7 +36253,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SSC_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -36284,7 +36284,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          <baseAddress>0x400E1810</baseAddress>
          <addressBlock>
             <offset>0</offset>
-            <size>0x18</size>
+            <size>0xD8</size>
             <usage>registers</usage>
          </addressBlock>
          <interrupt>
@@ -36293,7 +36293,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>SUPC_CR</name>
+               <name>CR</name>
                <description>Supply Controller Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -36354,7 +36354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SMMR</name>
+               <name>SMMR</name>
                <description>Supply Controller Supply Monitor Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -36440,7 +36440,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_MR</name>
+               <name>MR</name>
                <description>Supply Controller Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -36544,7 +36544,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUMR</name>
+               <name>WUMR</name>
                <description>Supply Controller Wake-up Mode Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -36754,7 +36754,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_WUIR</name>
+               <name>WUIR</name>
                <description>Supply Controller Wake-up Inputs Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -37294,7 +37294,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>SUPC_SR</name>
+               <name>SR</name>
                <description>Supply Controller Status Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -37739,6 +37739,34 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </field>
                </fields>
             </register>
+            <register>
+               <name>SYSC_WPMR</name>
+               <description>Write Protection Mode Register</description>
+               <addressOffset>0xD4</addressOffset>
+               <size>32</size>
+               <fields>
+                  <field>
+                     <name>WPEN</name>
+                     <description>Write Protection Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>WPKEY</name>
+                     <description>Write Protection Key</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>24</bitWidth>
+                     <enumeratedValues>
+                        <name>WPKEYSelect</name>
+                        <enumeratedValue>
+                           <name>PASSWD</name>
+                           <description>Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.</description>
+                           <value>0x525443</value>
+                        </enumeratedValue>
+                     </enumeratedValues>
+                  </field>
+               </fields>
+            </register>
          </registers>
       </peripheral>
       <peripheral>
@@ -37773,7 +37801,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Control Register (channel = 0)</description>
                <addressOffset>0x0</addressOffset>
                <register>
-                  <name>TC_CCR</name>
+                  <name>CCR</name>
                   <description>Channel Control Register (channel = 0)</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -37800,7 +37828,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_CAPTURE_MODE</name>
+                  <name>CMR_CAPTURE_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -38043,9 +38071,9 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CMR_WAVEFORM_MODE</name>
+                  <name>CMR_WAVEFORM_MODE</name>
                   <description>Channel Mode Register (channel = 0)</description>
-                  <alternateRegister>TC_CMR_CAPTURE_MODE</alternateRegister>
+                  <alternateRegister>CMR_CAPTURE_MODE</alternateRegister>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
                   <fields>
@@ -38479,7 +38507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SMMR</name>
+                  <name>SMMR</name>
                   <description>Stepper Motor Mode Register (channel = 0)</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -38499,7 +38527,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RAB</name>
+                  <name>RAB</name>
                   <description>Register AB (channel = 0)</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -38514,7 +38542,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_CV</name>
+                  <name>CV</name>
                   <description>Counter Value (channel = 0)</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -38529,7 +38557,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RA</name>
+                  <name>RA</name>
                   <description>Register A (channel = 0)</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -38543,7 +38571,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RB</name>
+                  <name>RB</name>
                   <description>Register B (channel = 0)</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -38557,7 +38585,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_RC</name>
+                  <name>RC</name>
                   <description>Register C (channel = 0)</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -38571,7 +38599,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_SR</name>
+                  <name>SR</name>
                   <description>Status Register (channel = 0)</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -38646,7 +38674,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IER</name>
+                  <name>IER</name>
                   <description>Interrupt Enable Register (channel = 0)</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -38703,7 +38731,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IDR</name>
+                  <name>IDR</name>
                   <description>Interrupt Disable Register (channel = 0)</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -38760,7 +38788,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_IMR</name>
+                  <name>IMR</name>
                   <description>Interrupt Mask Register (channel = 0)</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -38817,7 +38845,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>TC_EMR</name>
+                  <name>EMR</name>
                   <description>Extended Mode Register (channel = 0)</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -38870,7 +38898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>TC_BCR</name>
+               <name>BCR</name>
                <description>Block Control Register</description>
                <addressOffset>0xC0</addressOffset>
                <size>32</size>
@@ -38885,7 +38913,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_BMR</name>
+               <name>BMR</name>
                <description>Block Mode Register</description>
                <addressOffset>0xC4</addressOffset>
                <size>32</size>
@@ -39043,7 +39071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIER</name>
+               <name>QIER</name>
                <description>QDEC Interrupt Enable Register</description>
                <addressOffset>0xC8</addressOffset>
                <size>32</size>
@@ -39076,7 +39104,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIDR</name>
+               <name>QIDR</name>
                <description>QDEC Interrupt Disable Register</description>
                <addressOffset>0xCC</addressOffset>
                <size>32</size>
@@ -39109,7 +39137,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QIMR</name>
+               <name>QIMR</name>
                <description>QDEC Interrupt Mask Register</description>
                <addressOffset>0xD0</addressOffset>
                <size>32</size>
@@ -39142,7 +39170,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_QISR</name>
+               <name>QISR</name>
                <description>QDEC Interrupt Status Register</description>
                <addressOffset>0xD4</addressOffset>
                <size>32</size>
@@ -39181,7 +39209,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_FMR</name>
+               <name>FMR</name>
                <description>Fault Mode Register</description>
                <addressOffset>0xD8</addressOffset>
                <size>32</size>
@@ -39201,7 +39229,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TC_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -39296,7 +39324,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TRNG_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -39325,7 +39353,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39340,7 +39368,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -39355,7 +39383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -39370,7 +39398,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ISR</name>
+               <name>ISR</name>
                <description>Interrupt Status Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -39385,7 +39413,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TRNG_ODATA</name>
+               <name>ODATA</name>
                <description>Output Data Register</description>
                <addressOffset>0x50</addressOffset>
                <size>32</size>
@@ -39419,7 +39447,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>TWIHS_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -39560,7 +39588,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_MMR</name>
+               <name>MMR</name>
                <description>Master Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -39609,7 +39637,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMR</name>
+               <name>SMR</name>
                <description>Slave Mode Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -39677,7 +39705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IADR</name>
+               <name>IADR</name>
                <description>Internal Address Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -39691,7 +39719,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_CWGR</name>
+               <name>CWGR</name>
                <description>Clock Waveform Generator Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -39723,7 +39751,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -39846,7 +39874,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -39951,7 +39979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -40056,7 +40084,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -40161,7 +40189,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -40176,7 +40204,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -40191,7 +40219,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SMBTR</name>
+               <name>SMBTR</name>
                <description>SMBus Timing Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -40223,7 +40251,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_FILTR</name>
+               <name>FILTR</name>
                <description>Filter Register</description>
                <addressOffset>0x44</addressOffset>
                <size>32</size>
@@ -40255,7 +40283,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_SWMR</name>
+               <name>SWMR</name>
                <description>SleepWalking Matching Register</description>
                <addressOffset>0x4C</addressOffset>
                <size>32</size>
@@ -40287,7 +40315,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0xE4</addressOffset>
                <size>32</size>
@@ -40315,7 +40343,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>TWIHS_WPSR</name>
+               <name>WPSR</name>
                <description>Write Protection Status Register</description>
                <addressOffset>0xE8</addressOffset>
                <size>32</size>
@@ -40371,7 +40399,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>UART_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -40428,7 +40456,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -40537,7 +40565,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IER</name>
+               <name>IER</name>
                <description>Interrupt Enable Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -40588,7 +40616,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IDR</name>
+               <name>IDR</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -40639,7 +40667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_IMR</name>
+               <name>IMR</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -40690,7 +40718,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -40741,7 +40769,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_RHR</name>
+               <name>RHR</name>
                <description>Receive Holding Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -40756,7 +40784,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_THR</name>
+               <name>THR</name>
                <description>Transmit Holding Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -40771,7 +40799,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_BRGR</name>
+               <name>BRGR</name>
                <description>Baud Rate Generator Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -40785,7 +40813,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_CMPR</name>
+               <name>CMPR</name>
                <description>Comparison Register</description>
                <addressOffset>0x0024</addressOffset>
                <size>32</size>
@@ -40830,7 +40858,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UART_WPMR</name>
+               <name>WPMR</name>
                <description>Write Protection Mode Register</description>
                <addressOffset>0x00E4</addressOffset>
                <size>32</size>
@@ -41656,6 +41684,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Enable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Enable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Enable</description>
+                     <bitOffset>8</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Enable</description>
                      <bitOffset>9</bitOffset>
@@ -41706,7 +41752,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_USART_LIN_MODE</name>
+               <name>US_IER_SPI_MODE</name>
+               <description>Interrupt Enable Register</description>
+               <alternateRegister>US_IER_USART_MODE</alternateRegister>
+               <addressOffset>0x0008</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Enable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Enable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IER_LIN_MODE</name>
                <description>Interrupt Enable Register</description>
                <alternateRegister>US_IER_USART_MODE</alternateRegister>
                <addressOffset>0x0008</addressOffset>
@@ -41747,80 +41839,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TIMEOUT</name>
                      <description>Timeout Interrupt Enable</description>
                      <bitOffset>8</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IER_LIN_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41918,12 +41936,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Enable</description>
                      <bitOffset>6</bitOffset>
@@ -41933,6 +41945,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Enable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Enable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error Interrupt Enable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -41968,46 +41992,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IER_LON_SPI_MODE</name>
-               <description>Interrupt Enable Register</description>
-               <alternateRegister>US_IER_USART_MODE</alternateRegister>
-               <addressOffset>0x0008</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Enable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Enable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Enable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>Underrun Error Interrupt Enable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IDR_USART_MODE</name>
                <description>Interrupt Disable Register</description>
                <addressOffset>0x000C</addressOffset>
@@ -42036,6 +42020,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Enable</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Disable</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Disable</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Disable</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42089,7 +42091,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_USART_LIN_MODE</name>
+               <name>US_IDR_SPI_MODE</name>
+               <description>Interrupt Disable Register</description>
+               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
+               <addressOffset>0x000C</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Disable</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Disable</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Enable</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IDR_LIN_MODE</name>
                <description>Interrupt Disable Register</description>
                <alternateRegister>US_IDR_USART_MODE</alternateRegister>
                <addressOffset>0x000C</addressOffset>
@@ -42136,134 +42184,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Disable</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IDR_LIN_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42355,30 +42275,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Disable</description>
                      <bitOffset>6</bitOffset>
@@ -42388,6 +42284,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Disable</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Disable</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Disable</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42423,64 +42331,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IDR_LON_SPI_MODE</name>
-               <description>Interrupt Disable Register</description>
-               <alternateRegister>US_IDR_USART_MODE</alternateRegister>
-               <addressOffset>0x000C</addressOffset>
-               <size>32</size>
-               <access>write-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Disable</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Disable</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Enable</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Disable</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Disable</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Disable</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Disable</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Disable</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_IMR_USART_MODE</name>
                <description>Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
@@ -42509,6 +42359,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error Interrupt Mask</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error Interrupt Mask</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error Interrupt Mask</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Timeout Interrupt Mask</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42562,7 +42430,53 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_USART_LIN_MODE</name>
+               <name>US_IMR_SPI_MODE</name>
+               <description>Interrupt Mask Register</description>
+               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
+               <addressOffset>0x0010</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>RXRDY Interrupt Mask</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>TXRDY Interrupt Mask</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error Interrupt Mask</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_IMR_LIN_MODE</name>
                <description>Interrupt Mask Register</description>
                <alternateRegister>US_IMR_USART_MODE</alternateRegister>
                <addressOffset>0x0010</addressOffset>
@@ -42609,134 +42523,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>TXEMPTY Interrupt Mask</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_IMR_LIN_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42828,30 +42614,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error Interrupt Mask</description>
                      <bitOffset>6</bitOffset>
@@ -42861,6 +42623,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error Interrupt Mask</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>TXEMPTY Interrupt Mask</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error Interrupt Mask</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -42896,64 +42670,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_IMR_LON_SPI_MODE</name>
-               <description>Interrupt Mask Register</description>
-               <alternateRegister>US_IMR_USART_MODE</alternateRegister>
-               <addressOffset>0x0010</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>RXRDY Interrupt Mask</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>TXRDY Interrupt Mask</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error Interrupt Mask</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>TXEMPTY Interrupt Mask</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Mask</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Mask</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Interrupt Mask</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error Interrupt Mask</description>
-                     <bitOffset>10</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
                <name>US_CSR_USART_MODE</name>
                <description>Channel Status Register</description>
                <addressOffset>0x0014</addressOffset>
@@ -42982,6 +42698,24 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>OVRE</name>
                      <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
                      <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>FRAME</name>
+                     <description>Framing Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>6</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>PARE</name>
+                     <description>Parity Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TIMEOUT</name>
+                     <description>Receiver Timeout (cleared by writing a one to bit US_CR.STTTO)</description>
+                     <bitOffset>8</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -43059,7 +42793,59 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>US_CSR_USART_LIN_MODE</name>
+               <name>US_CSR_SPI_MODE</name>
+               <description>Channel Status Register</description>
+               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
+               <addressOffset>0x0014</addressOffset>
+               <size>32</size>
+               <access>read-only</access>
+               <fields>
+                  <field>
+                     <name>RXRDY</name>
+                     <description>Receiver Ready (cleared by reading US_RHR)</description>
+                     <bitOffset>0</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXRDY</name>
+                     <description>Transmitter Ready (cleared by writing US_THR)</description>
+                     <bitOffset>1</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>OVRE</name>
+                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
+                     <bitOffset>5</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>SPI Underrun Error</description>
+                     <bitOffset>10</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSSE</name>
+                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
+                     <bitOffset>19</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>NSS</name>
+                     <description>Image of NSS Line</description>
+                     <bitOffset>23</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+               </fields>
+            </register>
+            <register>
+               <name>US_CSR_LIN_MODE</name>
                <description>Channel Status Register</description>
                <alternateRegister>US_CSR_USART_MODE</alternateRegister>
                <addressOffset>0x0014</addressOffset>
@@ -43106,140 +42892,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>TXEMPTY</name>
                      <description>Transmitter Empty (cleared by writing US_THR)</description>
                      <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSSE</name>
-                     <description>NSS Line (Driving CTS Pin) Rising or Falling Edge Event</description>
-                     <bitOffset>19</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>NSS</name>
-                     <description>Image of NSS Line</description>
-                     <bitOffset>23</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LIN_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -43337,30 +42989,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
                      <name>LSFE</name>
                      <description>LON Short Frame Error</description>
                      <bitOffset>6</bitOffset>
@@ -43370,6 +42998,18 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LCRCE</name>
                      <description>LON CRC Error</description>
                      <bitOffset>7</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>TXEMPTY</name>
+                     <description>Transmitter Empty (cleared by writing US_THR)</description>
+                     <bitOffset>9</bitOffset>
+                     <bitWidth>1</bitWidth>
+                  </field>
+                  <field>
+                     <name>UNRE</name>
+                     <description>Underrun Error</description>
+                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
@@ -43400,64 +43040,6 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <name>LBLOVFE</name>
                      <description>LON Backlog Overflow Error</description>
                      <bitOffset>28</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-               </fields>
-            </register>
-            <register>
-               <name>US_CSR_LON_SPI_MODE</name>
-               <description>Channel Status Register</description>
-               <alternateRegister>US_CSR_USART_MODE</alternateRegister>
-               <addressOffset>0x0014</addressOffset>
-               <size>32</size>
-               <access>read-only</access>
-               <fields>
-                  <field>
-                     <name>RXRDY</name>
-                     <description>Receiver Ready (cleared by reading US_RHR)</description>
-                     <bitOffset>0</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXRDY</name>
-                     <description>Transmitter Ready (cleared by writing US_THR)</description>
-                     <bitOffset>1</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>OVRE</name>
-                     <description>Overrun Error (cleared by writing a one to bit US_CR.RSTSTA)</description>
-                     <bitOffset>5</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>TXEMPTY</name>
-                     <description>Transmitter Empty (cleared by writing US_THR)</description>
-                     <bitOffset>9</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>RIIC</name>
-                     <description>Ring Indicator Input Change Flag (cleared on read)</description>
-                     <bitOffset>16</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DSRIC</name>
-                     <description>Data Set Ready Input Change Flag (cleared on read)</description>
-                     <bitOffset>17</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>DCDIC</name>
-                     <description>Data Carrier Detect Input Change Flag (cleared on read)</description>
-                     <bitOffset>18</bitOffset>
-                     <bitWidth>1</bitWidth>
-                  </field>
-                  <field>
-                     <name>UNRE</name>
-                     <description>SPI Underrun Error</description>
-                     <bitOffset>10</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                </fields>
@@ -44148,7 +43730,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>USBHS_DEVCTRL</name>
+               <name>DEVCTRL</name>
                <description>Device General Control Register</description>
                <addressOffset>0x0000</addressOffset>
                <size>32</size>
@@ -44239,7 +43821,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVISR</name>
+               <name>DEVISR</name>
                <description>Device Global Interrupt Status Register</description>
                <addressOffset>0x0004</addressOffset>
                <size>32</size>
@@ -44392,7 +43974,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVICR</name>
+               <name>DEVICR</name>
                <description>Device Global Interrupt Clear Register</description>
                <addressOffset>0x0008</addressOffset>
                <size>32</size>
@@ -44443,7 +44025,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIFR</name>
+               <name>DEVIFR</name>
                <description>Device Global Interrupt Set Register</description>
                <addressOffset>0x000C</addressOffset>
                <size>32</size>
@@ -44536,7 +44118,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIMR</name>
+               <name>DEVIMR</name>
                <description>Device Global Interrupt Mask Register</description>
                <addressOffset>0x0010</addressOffset>
                <size>32</size>
@@ -44689,7 +44271,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIDR</name>
+               <name>DEVIDR</name>
                <description>Device Global Interrupt Disable Register</description>
                <addressOffset>0x0014</addressOffset>
                <size>32</size>
@@ -44842,7 +44424,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVIER</name>
+               <name>DEVIER</name>
                <description>Device Global Interrupt Enable Register</description>
                <addressOffset>0x0018</addressOffset>
                <size>32</size>
@@ -44995,7 +44577,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVEPT</name>
+               <name>DEVEPT</name>
                <description>Device Endpoint Register</description>
                <addressOffset>0x001C</addressOffset>
                <size>32</size>
@@ -45123,7 +44705,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_DEVFNUM</name>
+               <name>DEVFNUM</name>
                <description>Device Frame Number Register</description>
                <addressOffset>0x0020</addressOffset>
                <size>32</size>
@@ -45152,7 +44734,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTCFG[%s]</name>
+               <name>DEVEPTCFG[%s]</name>
                <description>Device Endpoint Configuration Register</description>
                <addressOffset>0x100</addressOffset>
                <size>32</size>
@@ -45324,7 +44906,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_CTRL_MODE[%s]</name>
+               <name>DEVEPTISR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
@@ -45489,9 +45071,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_ISO_MODE[%s]</name>
+               <name>DEVEPTISR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45655,9 +45237,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_BLK_MODE[%s]</name>
+               <name>DEVEPTISR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45821,9 +45403,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTISR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTISR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Status Register</description>
-               <alternateRegister>USBHS_DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x130</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -45987,7 +45569,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_CTRL_MODE[%s]</name>
+               <name>DEVEPTICR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
@@ -46046,9 +45628,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_ISO_MODE[%s]</name>
+               <name>DEVEPTICR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46106,9 +45688,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_BLK_MODE[%s]</name>
+               <name>DEVEPTICR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46166,9 +45748,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTICR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTICR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Clear Register</description>
-               <alternateRegister>USBHS_DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x160</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46226,7 +45808,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIFR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
@@ -46291,9 +45873,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_ISO_MODE[%s]</name>
+               <name>DEVEPTIFR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46357,9 +45939,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_BLK_MODE[%s]</name>
+               <name>DEVEPTIFR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46423,9 +46005,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIFR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIFR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Set Register</description>
-               <alternateRegister>USBHS_DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x190</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -46489,7 +46071,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIMR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
@@ -46590,9 +46172,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_ISO_MODE[%s]</name>
+               <name>DEVEPTIMR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46698,9 +46280,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_BLK_MODE[%s]</name>
+               <name>DEVEPTIMR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46800,9 +46382,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIMR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIMR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Mask Register</description>
-               <alternateRegister>USBHS_DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -46902,7 +46484,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_CTRL_MODE[%s]</name>
+               <name>DEVEPTIER_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
@@ -47003,9 +46585,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_ISO_MODE[%s]</name>
+               <name>DEVEPTIER_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47111,9 +46693,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_BLK_MODE[%s]</name>
+               <name>DEVEPTIER_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47213,9 +46795,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIER_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIER_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Enable Register</description>
-               <alternateRegister>USBHS_DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x1F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47315,7 +46897,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_CTRL_MODE[%s]</name>
+               <name>DEVEPTIDR_CTRL_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
@@ -47404,9 +46986,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_ISO_MODE[%s]</name>
+               <name>DEVEPTIDR_ISO_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47494,9 +47076,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_BLK_MODE[%s]</name>
+               <name>DEVEPTIDR_BLK_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47584,9 +47166,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_DEVEPTIDR_INTRPT_MODE[%s]</name>
+               <name>DEVEPTIDR_INTRPT_MODE[%s]</name>
                <description>Device Endpoint Interrupt Disable Register</description>
-               <alternateRegister>USBHS_DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>DEVEPTIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x220</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -47678,7 +47260,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Device DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x310</addressOffset>
                <register>
-                  <name>USBHS_DEVDMANXTDSC</name>
+                  <name>DEVDMANXTDSC</name>
                   <description>Device DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -47692,7 +47274,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMAADDRESS</name>
+                  <name>DEVDMAADDRESS</name>
                   <description>Device DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -47706,7 +47288,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMACONTROL</name>
+                  <name>DEVDMACONTROL</name>
                   <description>Device DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -47768,7 +47350,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_DEVDMASTATUS</name>
+                  <name>DEVDMASTATUS</name>
                   <description>Device DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -47813,7 +47395,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_HSTCTRL</name>
+               <name>HSTCTRL</name>
                <description>Host General Control Register</description>
                <addressOffset>0x0400</addressOffset>
                <size>32</size>
@@ -47868,7 +47450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTISR</name>
+               <name>HSTISR</name>
                <description>Host Global Interrupt Status Register</description>
                <addressOffset>0x0404</addressOffset>
                <size>32</size>
@@ -47977,43 +47559,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48021,7 +47603,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTICR</name>
+               <name>HSTICR</name>
                <description>Host Global Interrupt Clear Register</description>
                <addressOffset>0x0408</addressOffset>
                <size>32</size>
@@ -48072,7 +47654,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIFR</name>
+               <name>HSTIFR</name>
                <description>Host Global Interrupt Set Register</description>
                <addressOffset>0x040C</addressOffset>
                <size>32</size>
@@ -48121,43 +47703,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Set</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Set</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Set</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Set</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Set</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Set</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Set</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48165,7 +47747,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIMR</name>
+               <name>HSTIMR</name>
                <description>Host Global Interrupt Mask Register</description>
                <addressOffset>0x0410</addressOffset>
                <size>32</size>
@@ -48274,43 +47856,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48318,7 +47900,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIDR</name>
+               <name>HSTIDR</name>
                <description>Host Global Interrupt Disable Register</description>
                <addressOffset>0x0414</addressOffset>
                <size>32</size>
@@ -48427,43 +48009,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Disable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Disable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Disable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Disable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Disable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Disable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Disable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48471,7 +48053,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTIER</name>
+               <name>HSTIER</name>
                <description>Host Global Interrupt Enable Register</description>
                <addressOffset>0x0418</addressOffset>
                <size>32</size>
@@ -48580,43 +48162,43 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_0</name>
+                     <name>DMA_1</name>
                      <description>DMA Channel 0 Interrupt Enable</description>
                      <bitOffset>25</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_1</name>
+                     <name>DMA_2</name>
                      <description>DMA Channel 1 Interrupt Enable</description>
                      <bitOffset>26</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_2</name>
+                     <name>DMA_3</name>
                      <description>DMA Channel 2 Interrupt Enable</description>
                      <bitOffset>27</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_3</name>
+                     <name>DMA_4</name>
                      <description>DMA Channel 3 Interrupt Enable</description>
                      <bitOffset>28</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_4</name>
+                     <name>DMA_5</name>
                      <description>DMA Channel 4 Interrupt Enable</description>
                      <bitOffset>29</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_5</name>
+                     <name>DMA_6</name>
                      <description>DMA Channel 5 Interrupt Enable</description>
                      <bitOffset>30</bitOffset>
                      <bitWidth>1</bitWidth>
                   </field>
                   <field>
-                     <name>DMA_6</name>
+                     <name>DMA_7</name>
                      <description>DMA Channel 6 Interrupt Enable</description>
                      <bitOffset>31</bitOffset>
                      <bitWidth>1</bitWidth>
@@ -48624,7 +48206,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTPIP</name>
+               <name>HSTPIP</name>
                <description>Host Pipe Register</description>
                <addressOffset>0x0041C</addressOffset>
                <size>32</size>
@@ -48740,7 +48322,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTFNUM</name>
+               <name>HSTFNUM</name>
                <description>Host Frame Number Register</description>
                <addressOffset>0x0420</addressOffset>
                <size>32</size>
@@ -48766,7 +48348,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR1</name>
+               <name>HSTADDR1</name>
                <description>Host Address 1 Register</description>
                <addressOffset>0x0424</addressOffset>
                <size>32</size>
@@ -48798,7 +48380,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR2</name>
+               <name>HSTADDR2</name>
                <description>Host Address 2 Register</description>
                <addressOffset>0x0428</addressOffset>
                <size>32</size>
@@ -48830,7 +48412,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_HSTADDR3</name>
+               <name>HSTADDR3</name>
                <description>Host Address 3 Register</description>
                <addressOffset>0x042C</addressOffset>
                <size>32</size>
@@ -48852,7 +48434,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG[%s]</name>
+               <name>HSTPIPCFG[%s]</name>
                <description>Host Pipe Configuration Register</description>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
@@ -49012,9 +48594,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
+               <name>HSTPIPCFG_CTRL_BULK_MODE[%s]</name>
                <description>Host Pipe Configuration Register</description>
-               <alternateRegister>USBHS_HSTPIPCFG[%s]</alternateRegister>
+               <alternateRegister>HSTPIPCFG[%s]</alternateRegister>
                <addressOffset>0x500</addressOffset>
                <size>32</size>
                <fields>
@@ -49179,7 +48761,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_CTRL_MODE[%s]</name>
+               <name>HSTPIPISR_CTRL_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
@@ -49328,9 +48910,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_ISO_MODE[%s]</name>
+               <name>HSTPIPISR_ISO_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49478,9 +49060,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_BLK_MODE[%s]</name>
+               <name>HSTPIPISR_BLK_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49628,9 +49210,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPISR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPISR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Status Register</description>
-               <alternateRegister>USBHS_HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPISR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x530</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -49778,7 +49360,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_CTRL_MODE[%s]</name>
+               <name>HSTPIPICR_CTRL_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
@@ -49831,9 +49413,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_ISO_MODE[%s]</name>
+               <name>HSTPIPICR_ISO_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49885,9 +49467,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_BLK_MODE[%s]</name>
+               <name>HSTPIPICR_BLK_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49939,9 +49521,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPICR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPICR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Clear Register</description>
-               <alternateRegister>USBHS_HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPICR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x560</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -49993,7 +49575,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIFR_CTRL_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
@@ -50058,9 +49640,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_ISO_MODE[%s]</name>
+               <name>HSTPIPIFR_ISO_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50124,9 +49706,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_BLK_MODE[%s]</name>
+               <name>HSTPIPIFR_BLK_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50190,9 +49772,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIFR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIFR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Set Register</description>
-               <alternateRegister>USBHS_HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIFR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x590</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50256,7 +49838,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIMR_CTRL_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
@@ -50345,9 +49927,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_ISO_MODE[%s]</name>
+               <name>HSTPIPIMR_ISO_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -50435,9 +50017,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_BLK_MODE[%s]</name>
+               <name>HSTPIPIMR_BLK_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -50525,9 +50107,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIMR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIMR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Mask Register</description>
-               <alternateRegister>USBHS_HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIMR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5C0</addressOffset>
                <size>32</size>
                <access>read-only</access>
@@ -50615,7 +50197,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_CTRL_MODE[%s]</name>
+               <name>HSTPIPIER_CTRL_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
@@ -50698,9 +50280,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_ISO_MODE[%s]</name>
+               <name>HSTPIPIER_ISO_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50782,9 +50364,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_BLK_MODE[%s]</name>
+               <name>HSTPIPIER_BLK_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50866,9 +50448,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIER_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIER_INTRPT_MODE[%s]</name>
                <description>Host Pipe Enable Register</description>
-               <alternateRegister>USBHS_HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIER_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x5F0</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -50950,7 +50532,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_CTRL_MODE[%s]</name>
+               <name>HSTPIPIDR_CTRL_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
@@ -51033,9 +50615,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_ISO_MODE[%s]</name>
+               <name>HSTPIPIDR_ISO_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -51117,9 +50699,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_BLK_MODE[%s]</name>
+               <name>HSTPIPIDR_BLK_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -51201,9 +50783,9 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPIDR_INTRPT_MODE[%s]</name>
+               <name>HSTPIPIDR_INTRPT_MODE[%s]</name>
                <description>Host Pipe Disable Register</description>
-               <alternateRegister>USBHS_HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
+               <alternateRegister>HSTPIPIDR_CTRL_MODE[%s]</alternateRegister>
                <addressOffset>0x620</addressOffset>
                <size>32</size>
                <access>write-only</access>
@@ -51285,7 +50867,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPINRQ[%s]</name>
+               <name>HSTPIPINRQ[%s]</name>
                <description>Host Pipe IN Request Register</description>
                <addressOffset>0x650</addressOffset>
                <size>32</size>
@@ -51307,7 +50889,7 @@ Copyright (c) 2017 Microchip Technology Inc.
             <register>
                <dim>10</dim>
                <dimIncrement>4</dimIncrement>
-               <name>USBHS_HSTPIPERR[%s]</name>
+               <name>HSTPIPERR[%s]</name>
                <description>Host Pipe Error Register</description>
                <addressOffset>0x680</addressOffset>
                <size>32</size>
@@ -51357,7 +50939,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Host DMA Channel Next Descriptor Address Register</description>
                <addressOffset>0x710</addressOffset>
                <register>
-                  <name>USBHS_HSTDMANXTDSC</name>
+                  <name>HSTDMANXTDSC</name>
                   <description>Host DMA Channel Next Descriptor Address Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -51371,7 +50953,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMAADDRESS</name>
+                  <name>HSTDMAADDRESS</name>
                   <description>Host DMA Channel Address Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -51385,7 +50967,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMACONTROL</name>
+                  <name>HSTDMACONTROL</name>
                   <description>Host DMA Channel Control Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -51447,7 +51029,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>USBHS_HSTDMASTATUS</name>
+                  <name>HSTDMASTATUS</name>
                   <description>Host DMA Channel Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -51492,7 +51074,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </register>
             </cluster>
             <register>
-               <name>USBHS_CTRL</name>
+               <name>CTRL</name>
                <description>General Control Register</description>
                <addressOffset>0x0800</addressOffset>
                <size>32</size>
@@ -51549,7 +51131,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SR</name>
+               <name>SR</name>
                <description>General Status Register</description>
                <addressOffset>0x0804</addressOffset>
                <size>32</size>
@@ -51594,7 +51176,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SCR</name>
+               <name>SCR</name>
                <description>General Status Clear Register</description>
                <addressOffset>0x0808</addressOffset>
                <size>32</size>
@@ -51609,7 +51191,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>USBHS_SFR</name>
+               <name>SFR</name>
                <description>General Status Set Register</description>
                <addressOffset>0x080C</addressOffset>
                <size>32</size>
@@ -51645,7 +51227,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>UTMI_OHCIICR</name>
+               <name>OHCIICR</name>
                <description>OHCI Interrupt Configuration Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -51676,7 +51258,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>UTMI_CKTRIM</name>
+               <name>CKTRIM</name>
                <description>UTMI Clock Trimming Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -51722,7 +51304,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>WDT_CR</name>
+               <name>CR</name>
                <description>Control Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51751,7 +51333,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_MR</name>
+               <name>MR</name>
                <description>Mode Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51801,7 +51383,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>WDT_SR</name>
+               <name>SR</name>
                <description>Status Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51841,7 +51423,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </interrupt>
          <registers>
             <register>
-               <name>XDMAC_GTYPE</name>
+               <name>GTYPE</name>
                <description>Global Type Register</description>
                <addressOffset>0x00</addressOffset>
                <size>32</size>
@@ -51868,7 +51450,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GCFG</name>
+               <name>GCFG</name>
                <description>Global Configuration Register</description>
                <addressOffset>0x04</addressOffset>
                <size>32</size>
@@ -51906,7 +51488,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWAC</name>
+               <name>GWAC</name>
                <description>Global Weighted Arbiter Configuration Register</description>
                <addressOffset>0x08</addressOffset>
                <size>32</size>
@@ -51938,7 +51520,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIE</name>
+               <name>GIE</name>
                <description>Global Interrupt Enable Register</description>
                <addressOffset>0x0C</addressOffset>
                <size>32</size>
@@ -52091,7 +51673,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GID</name>
+               <name>GID</name>
                <description>Global Interrupt Disable Register</description>
                <addressOffset>0x10</addressOffset>
                <size>32</size>
@@ -52244,7 +51826,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIM</name>
+               <name>GIM</name>
                <description>Global Interrupt Mask Register</description>
                <addressOffset>0x14</addressOffset>
                <size>32</size>
@@ -52397,7 +51979,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GIS</name>
+               <name>GIS</name>
                <description>Global Interrupt Status Register</description>
                <addressOffset>0x18</addressOffset>
                <size>32</size>
@@ -52550,7 +52132,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GE</name>
+               <name>GE</name>
                <description>Global Channel Enable Register</description>
                <addressOffset>0x1C</addressOffset>
                <size>32</size>
@@ -52703,7 +52285,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GD</name>
+               <name>GD</name>
                <description>Global Channel Disable Register</description>
                <addressOffset>0x20</addressOffset>
                <size>32</size>
@@ -52856,7 +52438,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GS</name>
+               <name>GS</name>
                <description>Global Channel Status Register</description>
                <addressOffset>0x24</addressOffset>
                <size>32</size>
@@ -53009,7 +52591,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRS</name>
+               <name>GRS</name>
                <description>Global Channel Read Suspend Register</description>
                <addressOffset>0x28</addressOffset>
                <size>32</size>
@@ -53161,7 +52743,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GWS</name>
+               <name>GWS</name>
                <description>Global Channel Write Suspend Register</description>
                <addressOffset>0x2C</addressOffset>
                <size>32</size>
@@ -53313,7 +52895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWS</name>
+               <name>GRWS</name>
                <description>Global Channel Read Write Suspend Register</description>
                <addressOffset>0x30</addressOffset>
                <size>32</size>
@@ -53466,7 +53048,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GRWR</name>
+               <name>GRWR</name>
                <description>Global Channel Read Write Resume Register</description>
                <addressOffset>0x34</addressOffset>
                <size>32</size>
@@ -53619,7 +53201,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWR</name>
+               <name>GSWR</name>
                <description>Global Channel Software Request Register</description>
                <addressOffset>0x38</addressOffset>
                <size>32</size>
@@ -53772,7 +53354,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWS</name>
+               <name>GSWS</name>
                <description>Global Channel Software Request Status Register</description>
                <addressOffset>0x3C</addressOffset>
                <size>32</size>
@@ -53925,7 +53507,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>XDMAC_GSWF</name>
+               <name>GSWF</name>
                <description>Global Channel Software Flush Request Register</description>
                <addressOffset>0x40</addressOffset>
                <size>32</size>
@@ -54084,7 +53666,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                <description>Channel Interrupt Enable Register</description>
                <addressOffset>0x50</addressOffset>
                <register>
-                  <name>XDMAC_CIE</name>
+                  <name>CIE</name>
                   <description>Channel Interrupt Enable Register</description>
                   <addressOffset>0x00</addressOffset>
                   <size>32</size>
@@ -54135,7 +53717,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CID</name>
+                  <name>CID</name>
                   <description>Channel Interrupt Disable Register</description>
                   <addressOffset>0x04</addressOffset>
                   <size>32</size>
@@ -54186,7 +53768,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIM</name>
+                  <name>CIM</name>
                   <description>Channel Interrupt Mask Register</description>
                   <addressOffset>0x08</addressOffset>
                   <size>32</size>
@@ -54237,7 +53819,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CIS</name>
+                  <name>CIS</name>
                   <description>Channel Interrupt Status Register</description>
                   <addressOffset>0x0C</addressOffset>
                   <size>32</size>
@@ -54288,7 +53870,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSA</name>
+                  <name>CSA</name>
                   <description>Channel Source Address Register</description>
                   <addressOffset>0x10</addressOffset>
                   <size>32</size>
@@ -54302,7 +53884,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDA</name>
+                  <name>CDA</name>
                   <description>Channel Destination Address Register</description>
                   <addressOffset>0x14</addressOffset>
                   <size>32</size>
@@ -54316,7 +53898,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDA</name>
+                  <name>CNDA</name>
                   <description>Channel Next Descriptor Address Register</description>
                   <addressOffset>0x18</addressOffset>
                   <size>32</size>
@@ -54336,7 +53918,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CNDC</name>
+                  <name>CNDC</name>
                   <description>Channel Next Descriptor Control Register</description>
                   <addressOffset>0x1C</addressOffset>
                   <size>32</size>
@@ -54430,7 +54012,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CUBC</name>
+                  <name>CUBC</name>
                   <description>Channel Microblock Control Register</description>
                   <addressOffset>0x20</addressOffset>
                   <size>32</size>
@@ -54444,7 +54026,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CBC</name>
+                  <name>CBC</name>
                   <description>Channel Block Control Register</description>
                   <addressOffset>0x24</addressOffset>
                   <size>32</size>
@@ -54458,7 +54040,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CC</name>
+                  <name>CC</name>
                   <description>Channel Configuration Register</description>
                   <addressOffset>0x28</addressOffset>
                   <size>32</size>
@@ -55051,7 +54633,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDS_MSP</name>
+                  <name>CDS_MSP</name>
                   <description>Channel Data Stride Memory Set Pattern</description>
                   <addressOffset>0x2C</addressOffset>
                   <size>32</size>
@@ -55071,7 +54653,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CSUS</name>
+                  <name>CSUS</name>
                   <description>Channel Source Microblock Stride</description>
                   <addressOffset>0x30</addressOffset>
                   <size>32</size>
@@ -55085,7 +54667,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                   </fields>
                </register>
                <register>
-                  <name>XDMAC_CDUS</name>
+                  <name>CDUS</name>
                   <description>Channel Destination Microblock Stride</description>
                   <addressOffset>0x34</addressOffset>
                   <size>32</size>
@@ -55113,7 +54695,7 @@ Copyright (c) 2017 Microchip Technology Inc.
          </addressBlock>
          <registers>
             <register>
-               <name>LOCKBIT_WORD0</name>
+               <name>WORD0</name>
                <description>Lock Bits Word 0</description>
                <addressOffset>0x0</addressOffset>
                <size>32</size>
@@ -55313,7 +54895,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD1</name>
+               <name>WORD1</name>
                <description>Lock Bits Word 1</description>
                <addressOffset>0x4</addressOffset>
                <size>32</size>
@@ -55513,7 +55095,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD2</name>
+               <name>WORD2</name>
                <description>Lock Bits Word 2</description>
                <addressOffset>0x8</addressOffset>
                <size>32</size>
@@ -55713,7 +55295,7 @@ Copyright (c) 2017 Microchip Technology Inc.
                </fields>
             </register>
             <register>
-               <name>LOCKBIT_WORD3</name>
+               <name>WORD3</name>
                <description>Lock Bits Word 3</description>
                <addressOffset>0xC</addressOffset>
                <size>32</size>
@@ -57602,6 +57184,76 @@ Copyright (c) 2017 Microchip Technology Inc.
                      <bitWidth>2</bitWidth>
                   </field>
                </fields>
+            </register>
+            <register>
+               <name>ICIALLU</name>
+               <description>I-cache invalidate all to PoU</description>
+               <addressOffset>0x00000150</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>ICIMVAU</name>
+               <description>I-cache invalidate by MVA to PoU</description>
+               <addressOffset>0x00000158</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCIMVAC</name>
+               <description>D-cache invalidate by MVA to PoC</description>
+               <addressOffset>0x0000015c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCISW</name>
+               <description>D-cache invalidate by set-way</description>
+               <addressOffset>0x00000160</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAU</name>
+               <description>D-cache clean by MVA to PoU</description>
+               <addressOffset>0x00000164</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCMVAC</name>
+               <description>D-cache clean by MVA to PoC</description>
+               <addressOffset>0x000000168</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCSW</name>
+               <description>D-cache clean by set-way</description>
+               <addressOffset>0x0000016c</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCIMVAC</name>
+               <description>D-cache clean and invalidate by MVA to PoC</description>
+               <addressOffset>0x00000170</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>DCCISW</name>
+               <description>D-cache clean and invalidate by set-way</description>
+               <addressOffset>0x00000174</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
+            </register>
+            <register>
+               <name>BPIALL</name>
+               <description>Branch predictor invalidate all</description>
+               <addressOffset>0x00000178</addressOffset>
+               <size>32</size>
+               <access>write-only</access>
             </register>
             <register>
                <name>STIR</name>

--- a/data/Atmel/README.md
+++ b/data/Atmel/README.md
@@ -2,7 +2,7 @@ Microchip (Atmel) Pack Repository
 =================================
 
 The following files were downloaded from the [Atmel Pack
-Repository](http://packs.download.atmel.com/) and the corresponding `svd` files
+Repository](http://packs.download.microchip.com/) and the corresponding `svd` files
 extracted to be placed in this repository. The files are all provided under the
 Apache License, version 2.0.
 
@@ -14,13 +14,23 @@ Apache License, version 2.0.
 * `Atmel.SAM4S_DFP.1.0.56.atpack`: `ATSAM4S*.svd`
 * `Atmel.SAMD21_DFP.1.3.331.atpack`: `ATSAMD21*.svd`
 * `Atmel.SAMD51_DFP.1.2.139.atpack`: `ATSAMD51*.svd`
-* `Atmel.SAME70_DFP.2.4.166.atpack`: `ATSAME70*.svd`
+* `Atmel.SAME70_DFP.4.8.125.atpack`: `ATSAME70*B.svd`
 * `Atmel.SAML11_DFP.1.0.109.atpack`: `ATSAML11*.svd`
 * `Atmel.SAML22_DFP.1.2.77.atpack` : `ATSAML22*.svd`
 * `Atmel.SAMR21_DFP.1.1.72.atpack`: `ATSAMR21*.svd`
-* `Atmel.SAMS70_DFP.2.4.134.atpack`: `ATSAMS70*.svd`
-* `Atmel.SAMV70_DFP.2.4.134.atpack`: `ATSAMV70*.svd`
-* `Atmel.SAMV71_DFP.2.4.182.atpack`: `ATSAMV71*.svd`
+* `Atmel.SAMS70_DFP.4.8.100.atpack`: `ATSAMS70*B.svd`
+* `Atmel.SAMV70_DFP.4.8.97.atpack`: `ATSAMV70*B.svd`
+* `Atmel.SAMV71_DFP.4.8.113.atpack`: `ATSAMV71*B.svd`
+
+Deprecated by Microchip
+=======================
+
+Last versions where deprecated **Rev A** chips SVDs are available:
+
+* `Atmel.SAME70_DFP.4.5.86.atpack`: `ATSAMS70*[^B].svd`
+* `Atmel.SAMS70_DFP.4.5.74.atpack`: `ATSAMS70*[^B].svd`
+* `Atmel.SAMV70_DFP.4.5.75.atpack`: `ATSAMV70*[^B].svd`
+* `Atmel.SAMV71_DFP.4.6.82.atpack`: `ATSAMV71*[^B].svd`
 
 EmbSysRegView
 =============


### PR DESCRIPTION
It has been noted in #153 that Microchip publishes newer ATPACKS on different website than previously, so we take it to update SVDs here from them.

However, Microchip deprecated **Rev A** chips from these series, so I had to address this matter somehow:
* Latest available SVDs for Rev A are brought instead.
* The note is added to `README.md` to reflect this.

This helps addressing atsams-rs/atsamx7x-rust#17.